### PR TITLE
Refactor stack monitoring templating

### DIFF
--- a/pkg/controller/beat/common/pod.go
+++ b/pkg/controller/beat/common/pod.go
@@ -164,7 +164,7 @@ func buildPodTemplate(
 	}
 
 	if monitoring.IsMetricsDefined(&params.Beat) {
-		sideCar, err := beat_stackmon.MetricBeat(params.Context, params.Client, &params.Beat, params.Beat.Spec.Version)
+		sideCar, err := beat_stackmon.MetricBeat(params.Context, params.Client, &params.Beat)
 		if err != nil {
 			return podTemplate, err
 		}

--- a/pkg/controller/beat/common/stackmon/stackmon.go
+++ b/pkg/controller/beat/common/stackmon/stackmon.go
@@ -15,10 +15,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/elastic/cloud-on-k8s/v2/pkg/apis/beat/v1beta1"
-	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/association"
-	common_name "github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/name"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/stackmon"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/stackmon/monitoring"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/bootstrap"
@@ -91,16 +89,10 @@ func MetricBeat(ctx context.Context, client k8s.Client, beat *v1beta1.Beat, vers
 	sidecar, err := stackmon.NewMetricBeatSidecar(
 		ctx,
 		client,
-		commonv1.BeatMonitoringAssociationType,
 		beat,
 		version,
+		nil,
 		byteBuffer.String(),
-		common_name.NewNamer("beat"),
-		GetStackMonitoringSocketURL(beat),
-		"",
-		"",
-		"",
-		false,
 	)
 	if err != nil {
 		return stackmon.BeatSidecar{}, err

--- a/pkg/controller/beat/common/stackmon/stackmon.go
+++ b/pkg/controller/beat/common/stackmon/stackmon.go
@@ -5,12 +5,10 @@
 package stackmon
 
 import (
-	"bytes"
 	"context"
 	_ "embed" // for the beats config files
 	"errors"
 	"fmt"
-	"text/template"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -19,6 +17,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/association"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/stackmon"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/stackmon/monitoring"
+	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/bootstrap"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/k8s"
 )
@@ -58,7 +57,7 @@ func Filebeat(ctx context.Context, client k8s.Client, resource monitoring.HasMon
 	return sidecar, nil
 }
 
-func MetricBeat(ctx context.Context, client k8s.Client, beat *v1beta1.Beat, version string) (stackmon.BeatSidecar, error) {
+func MetricBeat(ctx context.Context, client k8s.Client, beat *v1beta1.Beat) (stackmon.BeatSidecar, error) {
 	if err := beat.ElasticsearchRef().IsValid(); err != nil {
 		return stackmon.BeatSidecar{}, err
 	}
@@ -68,11 +67,6 @@ func MetricBeat(ctx context.Context, client k8s.Client, beat *v1beta1.Beat, vers
 		return stackmon.BeatSidecar{}, err
 	}
 
-	beatTemplate, err := template.New("beat_stack_monitoring").Parse(metricbeatConfigTemplate)
-	if err != nil {
-		return stackmon.BeatSidecar{}, fmt.Errorf("while parsing template for beats stack monitoring configuration: %w", err)
-	}
-	var byteBuffer bytes.Buffer
 	data := struct {
 		ClusterUUID string
 		URL         string
@@ -82,18 +76,16 @@ func MetricBeat(ctx context.Context, client k8s.Client, beat *v1beta1.Beat, vers
 		// Beat module http options require "http+" to be appended to unix sockets.
 		URL: fmt.Sprintf("http+%s", GetStackMonitoringSocketURL(beat)),
 	}
-	if err := beatTemplate.Execute(&byteBuffer, data); err != nil {
-		return stackmon.BeatSidecar{}, fmt.Errorf("while templating beats stack monitoring configuration: %w", err)
+	v, err := version.Parse(beat.Spec.Version)
+	if err != nil {
+		return stackmon.BeatSidecar{}, err
+	}
+	cfg, err := stackmon.RenderTemplate(v, metricbeatConfigTemplate, data)
+	if err != nil {
+		return stackmon.BeatSidecar{}, err
 	}
 
-	sidecar, err := stackmon.NewMetricBeatSidecar(
-		ctx,
-		client,
-		beat,
-		version,
-		nil,
-		byteBuffer.String(),
-	)
+	sidecar, err := stackmon.NewMetricBeatSidecar(ctx, client, beat, v, nil, cfg)
 	if err != nil {
 		return stackmon.BeatSidecar{}, err
 	}

--- a/pkg/controller/beat/common/stackmon/stackmon_test.go
+++ b/pkg/controller/beat/common/stackmon/stackmon_test.go
@@ -250,9 +250,8 @@ output:
 	}
 
 	type args struct {
-		client  k8s.Client
-		beat    func() *v1beta1.Beat
-		version string
+		client k8s.Client
+		beat   func() *v1beta1.Beat
 	}
 	tests := []struct {
 		name    string
@@ -270,7 +269,6 @@ output:
 				beat: func() *v1beta1.Beat {
 					return &beatFixture
 				},
-				version: "8.2.3",
 			},
 			want:    beatSidecarFixture(fmt.Sprintf(beatYml, "abcd1234", "es-metrics-monitoring-url")),
 			wantErr: false,
@@ -287,7 +285,6 @@ output:
 					beat.Spec.ElasticsearchRef = commonv1.ObjectSelector{}
 					return beat
 				},
-				version: "8.2.3",
 			},
 			want:    beatSidecarFixture(standaloneBeatYML),
 			wantErr: false,
@@ -317,7 +314,6 @@ output:
 					}
 					return beat
 				},
-				version: "8.2.3",
 			},
 			want:    beatSidecarFixture(fmt.Sprintf(beatYml, "QGq3wcU7Sd6bC31wh37eKQ", esAPIFixture.URL)),
 			wantErr: false,
@@ -331,7 +327,6 @@ output:
 					beat.Spec.Config.Data = map[string]interface{}{"http.port": "invalid"}
 					return beat
 				},
-				version: "8.2.3",
 			},
 			want:    stackmon.BeatSidecar{},
 			wantErr: true,
@@ -339,7 +334,7 @@ output:
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := MetricBeat(context.Background(), tt.args.client, tt.args.beat(), tt.args.version)
+			got, err := MetricBeat(context.Background(), tt.args.client, tt.args.beat())
 			if (err != nil) != tt.wantErr {
 				t.Errorf("MetricBeat() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/controller/common/stackmon/config.go
+++ b/pkg/controller/common/stackmon/config.go
@@ -17,12 +17,10 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/association"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/certificates"
-	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/name"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/settings"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/stackmon/monitoring"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/volume"
@@ -179,59 +177,20 @@ type inputConfigData struct {
 	TotalFieldsLimit int
 }
 
-// buildMetricbeatBaseConfig builds the base configuration for Metricbeat with the Elasticsearch or Kibana modules used
-// to collect metrics for Stack Monitoring
-func buildMetricbeatBaseConfig(
-	client k8s.Client,
-	associationType commonv1.AssociationType,
-	nsn types.NamespacedName,
-	namer name.Namer,
-	url string,
-	basePath string,
-	username string,
-	password string,
-	isTLS bool,
-	configTemplate string,
+func RenderTemplate(v semver.Version, configTemplate string, params any) (string, error) {
+	// render the config template with the config data
+	var beatConfig bytes.Buffer
+	err := template.Must(template.New("").Funcs(TemplateFuncs(v)).Parse(configTemplate)).Execute(&beatConfig, params)
+	if err != nil {
+		return "", err
+	}
+	return beatConfig.String(), nil
+}
+
+func TemplateFuncs(
 	version semver.Version,
-) (string, volume.VolumeLike, error) {
-	hasCA := false
-	if isTLS {
-		var err error
-		hasCA, err = certificates.PublicCertsHasCACert(client, namer, nsn.Namespace, nsn.Name)
-		if err != nil {
-			return "", nil, err
-		}
-	}
-
-	configData := inputConfigData{
-		Username: username,
-		Password: password,
-		URL:      url,      // Metricbeat in the sidecar connects to the monitored resource using `localhost`
-		BasePath: basePath, // for the Metricbeat Kibana module
-		IsSSL:    isTLS,    // enable SSL configuration based on whether the monitored resource has TLS enabled
-		HasCA:    hasCA,    // the CA is optional to support custom certificate issued by a well-known CA, so without provided CA to configure
-		Version:  version,  // Version of the monitored resource
-	}
-
-	// See https://github.com/elastic/cloud-on-k8s/pull/8284
-	// The default index template for metricbeat exceeds the default
-	// index mapping total fields limit.
-	if version.GTE(semver.MustParse("8.15.0")) {
-		configData.TotalFieldsLimit = 12500
-	}
-
-	var caVolume volume.VolumeLike
-	if configData.HasCA {
-		caVolume = volume.NewSecretVolumeWithMountPath(
-			certificates.PublicCertsSecretName(namer, nsn.Name),
-			fmt.Sprintf("%s-local-ca", string(associationType)),
-			fmt.Sprintf("/mnt/elastic-internal/%s/%s/%s/certs", string(associationType), nsn.Namespace, nsn.Name),
-		)
-
-		configData.CAPath = filepath.Join(caVolume.VolumeMount().MountPath, certificates.CAFileName)
-	}
-
-	templateFuncMap := template.FuncMap{
+) template.FuncMap {
+	return template.FuncMap{
 		"isVersionGTE": func(minAllowedVersion string) (bool, error) {
 			minAllowedSemver, err := semver.Parse(minAllowedVersion)
 			if err != nil {
@@ -239,13 +198,11 @@ func buildMetricbeatBaseConfig(
 			}
 			return version.GTE(minAllowedSemver), nil
 		},
+		"CAPath": func(caVolume volume.VolumeLike) string {
+			if caVolume == nil {
+				return ""
+			}
+			return filepath.Join(caVolume.VolumeMount().MountPath, certificates.CAFileName)
+		},
 	}
-	// render the config template with the config data
-	var metricbeatConfig bytes.Buffer
-	err := template.Must(template.New("").Funcs(templateFuncMap).Parse(configTemplate)).Execute(&metricbeatConfig, configData)
-	if err != nil {
-		return "", nil, err
-	}
-
-	return metricbeatConfig.String(), caVolume, nil
 }

--- a/pkg/controller/common/stackmon/config.go
+++ b/pkg/controller/common/stackmon/config.go
@@ -163,20 +163,6 @@ func mergeConfig(rawConfig string, config map[string]interface{}) ([]byte, error
 	return cfgBytes, nil
 }
 
-// inputConfigData holds data to configure the Metricbeat Elasticsearch and Kibana modules used
-// to collect metrics for Stack Monitoring
-type inputConfigData struct {
-	BasePath         string
-	URL              string
-	Username         string
-	Password         string
-	IsSSL            bool
-	HasCA            bool
-	CAPath           string
-	Version          semver.Version
-	TotalFieldsLimit int
-}
-
 func RenderTemplate(v semver.Version, configTemplate string, params any) (string, error) {
 	// render the config template with the config data
 	var beatConfig bytes.Buffer

--- a/pkg/controller/common/stackmon/config_test.go
+++ b/pkg/controller/common/stackmon/config_test.go
@@ -8,16 +8,13 @@ import (
 	"context"
 	"testing"
 
-	"github.com/blang/semver/v4"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
-	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/name"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/stackmon/monitoring"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/k8s"
 )
@@ -121,140 +118,6 @@ param2: value2
 			// Compare Beat configuration
 			assert.Equal(t, tt.want.secret.Name, got.secret.Name)
 			assert.Equal(t, tt.want.secret.Data, got.secret.Data)
-		})
-	}
-}
-
-func TestBuildMetricbeatBaseConfig(t *testing.T) {
-	tests := []struct {
-		name        string
-		isTLS       bool
-		certsSecret *corev1.Secret
-		hasCA       bool
-		baseConfig  string
-		basePath    string
-		version     semver.Version
-	}{
-		{
-			name:  "with TLS and a CA",
-			isTLS: true,
-			certsSecret: &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{Name: "name-es-http-certs-public", Namespace: "namespace"},
-				Data: map[string][]byte{
-					"tls.crt": []byte("1234567890"),
-					"ca.crt":  []byte("1234567890"),
-				},
-			},
-			baseConfig: `
-				hosts: ["scheme://localhost:1234"]
-				username: elastic-internal-monitoring
-				password: 1234567890
-				ssl.enabled: true
-				ssl.verification_mode: "certificate"
-				ingest_pipeline: "enabled"
-				ssl.certificate_authorities: ["/mnt/elastic-internal/xx-monitoring/namespace/name/certs/ca.crt"]`,
-			version: semver.MustParse("8.7.0"),
-		},
-		{
-			name:  "with TLS and no CA",
-			isTLS: true,
-			certsSecret: &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{Name: "name-es-http-certs-public", Namespace: "namespace"},
-				Data: map[string][]byte{
-					"tls.crt": []byte("1234567890"),
-				},
-			},
-			baseConfig: `
-				hosts: ["scheme://localhost:1234"]
-				username: elastic-internal-monitoring
-				password: 1234567890
-				ssl.enabled: true
-				ssl.verification_mode: "certificate"
-				ingest_pipeline: "enabled"`,
-			version: semver.MustParse("8.7.0"),
-		},
-		{
-			name:  "without TLS",
-			isTLS: false,
-			baseConfig: `
-				hosts: ["scheme://localhost:1234"]
-				username: elastic-internal-monitoring
-				password: 1234567890
-				ssl.enabled: false
-				ssl.verification_mode: "certificate"
-				ingest_pipeline: "enabled"`,
-			version: semver.MustParse("8.7.0"),
-		},
-		{
-			name:  "with version less than 8.7.0",
-			isTLS: false,
-			baseConfig: `
-				hosts: ["scheme://localhost:1234"]
-				username: elastic-internal-monitoring
-				password: 1234567890
-				ssl.enabled: false
-				ssl.verification_mode: "certificate"`,
-			version: semver.MustParse("8.6.0"),
-		},
-		{
-			name:     "with basepath",
-			isTLS:    false,
-			basePath: "/kibana",
-			baseConfig: `
-				hosts: ["scheme://localhost:1234"]
-				basepath: /kibana
-				username: elastic-internal-monitoring
-				password: 1234567890
-				ssl.enabled: false
-				ssl.verification_mode: "certificate"
-				ingest_pipeline: "enabled"`,
-			version: semver.MustParse("8.7.0"),
-		},
-	}
-	baseConfigTemplate := `
-				hosts: ["{{ .URL }}"]
-				{{- with .BasePath }}
-				basepath: {{ . }}
-				{{- end }}
-				username: {{ .Username }}
-				password: {{ .Password }}
-				ssl.enabled: {{ .IsSSL }}
-				ssl.verification_mode: "certificate"
-				{{- if isVersionGTE "8.7.0" }}
-				ingest_pipeline: "enabled"
-				{{- end }}
-				{{- if .HasCA }}
-				ssl.certificate_authorities: ["{{ .CAPath }}"]
-				{{- end }}`
-
-	sampleURL := "scheme://localhost:1234"
-	internalUsersSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: "name-es-internal-users", Namespace: "namespace"},
-		Data:       map[string][]byte{"elastic-internal-monitoring": []byte("1234567890")},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			initObjects := []client.Object{internalUsersSecret}
-			if tc.certsSecret != nil {
-				initObjects = append(initObjects, tc.certsSecret)
-			}
-			fakeClient := k8s.NewFakeClient(initObjects...)
-			baseConfig, _, err := buildMetricbeatBaseConfig(
-				fakeClient,
-				"xx-monitoring",
-				types.NamespacedName{Namespace: "namespace", Name: "name"},
-				name.NewNamer("es"),
-				sampleURL,
-				tc.basePath,
-				"elastic-internal-monitoring",
-				"1234567890",
-				tc.isTLS,
-				baseConfigTemplate,
-				tc.version,
-			)
-			assert.NoError(t, err)
-			assert.Equal(t, tc.baseConfig, baseConfig)
 		})
 	}
 }

--- a/pkg/controller/common/stackmon/monitoring/monitoring_test.go
+++ b/pkg/controller/common/stackmon/monitoring/monitoring_test.go
@@ -66,7 +66,7 @@ func TestIsReconcilable(t *testing.T) {
 					},
 				},
 				AssocConfs: map[commonv1.ObjectSelector]commonv1.AssociationConf{
-					commonv1.ObjectSelector{Name: "m1", Namespace: "b"}: {URL: "https://es.xyz", AuthSecretName: "-"},
+					{Name: "m1", Namespace: "b"}: {URL: "https://es.xyz", AuthSecretName: "-"},
 				},
 			},
 			want: true,
@@ -82,7 +82,7 @@ func TestIsReconcilable(t *testing.T) {
 					},
 				},
 				AssocConfs: map[commonv1.ObjectSelector]commonv1.AssociationConf{
-					commonv1.ObjectSelector{Name: "m1", Namespace: "b"}: {URL: "https://es.xyz", AuthSecretName: "-"},
+					{Name: "m1", Namespace: "b"}: {URL: "https://es.xyz", AuthSecretName: "-"},
 				},
 			},
 			want: true,
@@ -101,7 +101,7 @@ func TestIsReconcilable(t *testing.T) {
 					},
 				},
 				AssocConfs: map[commonv1.ObjectSelector]commonv1.AssociationConf{
-					commonv1.ObjectSelector{Name: "m1", Namespace: "b"}: {URL: "https://es.xyz", AuthSecretName: "-"},
+					{Name: "m1", Namespace: "b"}: {URL: "https://es.xyz", AuthSecretName: "-"},
 				},
 			},
 			want: false,
@@ -120,7 +120,7 @@ func TestIsReconcilable(t *testing.T) {
 					},
 				},
 				AssocConfs: map[commonv1.ObjectSelector]commonv1.AssociationConf{
-					commonv1.ObjectSelector{Name: "m1", Namespace: "b"}: {URL: "https://es.xyz", AuthSecretName: "-"},
+					{Name: "m1", Namespace: "b"}: {URL: "https://es.xyz", AuthSecretName: "-"},
 				},
 			},
 			want: false,
@@ -139,7 +139,7 @@ func TestIsReconcilable(t *testing.T) {
 					},
 				},
 				AssocConfs: map[commonv1.ObjectSelector]commonv1.AssociationConf{
-					commonv1.ObjectSelector{Name: "m1", Namespace: "b"}: {URL: "https://m1.xyz", AuthSecretName: "-"},
+					{Name: "m1", Namespace: "b"}: {URL: "https://m1.xyz", AuthSecretName: "-"},
 				},
 			},
 			want: true,

--- a/pkg/controller/common/stackmon/sidecar.go
+++ b/pkg/controller/common/stackmon/sidecar.go
@@ -102,6 +102,8 @@ func NewBeatSidecar(ctx context.Context, client k8s.Client, beatName string, ima
 	}, nil
 }
 
+// CAVolume returns a volume containing the CA certificate for the monitored resource if TLS is enabled.
+// If TLS is not enabled or no (self-signed) CA is in use, it returns nil.
 func CAVolume(
 	c k8s.Client,
 	nsn types.NamespacedName,
@@ -121,4 +123,14 @@ func CAVolume(
 		fmt.Sprintf("%s-local-ca", string(associationType)),
 		fmt.Sprintf("/mnt/elastic-internal/%s/%s/%s/certs", string(associationType), nsn.Namespace, nsn.Name),
 	), nil
+}
+
+// TemplateParams are commonly used parameters to render a Beats configuration template.
+// Stack monitoring implementations can choose to implement their own template parameters if needed.
+type TemplateParams struct {
+	URL      string
+	Username string
+	Password string
+	IsSSL    bool
+	CAVolume volume.VolumeLike
 }

--- a/pkg/controller/common/stackmon/sidecar.go
+++ b/pkg/controller/common/stackmon/sidecar.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/blang/semver/v4"
+
 	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/container"

--- a/pkg/controller/elasticsearch/stackmon/__snapshots__/sidecar_test.snap
+++ b/pkg/controller/elasticsearch/stackmon/__snapshots__/sidecar_test.snap
@@ -187,3 +187,719 @@ setup.template.settings:
 # Elasticsearch output configuration is generated
 
 ---
+
+[TestWithMonitoring/without_monitoring - 1]
+{
+ "metadata": {
+  "creationTimestamp": null
+ },
+ "spec": {
+  "automountServiceAccountToken": false,
+  "containers": [
+   {
+    "name": "elasticsearch",
+    "resources": {}
+   }
+  ]
+ }
+}
+---
+
+[TestWithMonitoring/with_metrics_monitoring - 1]
+{
+ "metadata": {
+  "annotations": {
+   "elasticsearch.k8s.elastic.co/monitoring-config-hash": "421654492"
+  },
+  "creationTimestamp": null
+ },
+ "spec": {
+  "automountServiceAccountToken": false,
+  "containers": [
+   {
+    "name": "elasticsearch",
+    "resources": {}
+   },
+   {
+    "args": [
+     "-c",
+     "/etc/metricbeat-config/metricbeat.yml",
+     "-e"
+    ],
+    "env": [
+     {
+      "name": "POD_IP",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "status.podIP"
+       }
+      }
+     },
+     {
+      "name": "POD_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.name"
+       }
+      }
+     },
+     {
+      "name": "NODE_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "spec.nodeName"
+       }
+      }
+     },
+     {
+      "name": "NAMESPACE",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.namespace"
+       }
+      }
+     }
+    ],
+    "image": "docker.elastic.co/beats/metricbeat:7.14.0",
+    "name": "metricbeat",
+    "resources": {},
+    "securityContext": {
+     "allowPrivilegeEscalation": false,
+     "capabilities": {
+      "drop": [
+       "ALL"
+      ]
+     },
+     "privileged": false,
+     "readOnlyRootFilesystem": true
+    },
+    "volumeMounts": [
+     {
+      "mountPath": "/etc/metricbeat-config",
+      "name": "sample-metricbeat-config",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/mnt/elastic-internal/es-monitoring-association/observability/monitoring/certs",
+      "name": "es-monitoring-03f555-ca",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/mnt/elastic-internal/es-monitoring/aerospace/sample/certs",
+      "name": "es-monitoring-local-ca",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/usr/share/metricbeat/data",
+      "name": "metricbeat-data"
+     }
+    ]
+   }
+  ],
+  "volumes": [
+   {
+    "name": "es-monitoring-03f555-ca",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-es-monitoring-observability-monitoring-ca"
+    }
+   },
+   {
+    "name": "es-monitoring-local-ca",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-es-http-certs-public"
+    }
+   },
+   {
+    "emptyDir": {},
+    "name": "metricbeat-data"
+   },
+   {
+    "name": "sample-metricbeat-config",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-es-monitoring-metricbeat-config"
+    }
+   }
+  ]
+ }
+}
+---
+
+[TestWithMonitoring/with_logs_monitoring - 1]
+{
+ "metadata": {
+  "annotations": {
+   "elasticsearch.k8s.elastic.co/monitoring-config-hash": "3392808927"
+  },
+  "creationTimestamp": null
+ },
+ "spec": {
+  "automountServiceAccountToken": false,
+  "containers": [
+   {
+    "env": [
+     {
+      "name": "ES_LOG_STYLE",
+      "value": "file"
+     }
+    ],
+    "name": "elasticsearch",
+    "resources": {}
+   },
+   {
+    "args": [
+     "-c",
+     "/etc/filebeat-config/filebeat.yml",
+     "-e"
+    ],
+    "env": [
+     {
+      "name": "POD_IP",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "status.podIP"
+       }
+      }
+     },
+     {
+      "name": "POD_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.name"
+       }
+      }
+     },
+     {
+      "name": "NODE_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "spec.nodeName"
+       }
+      }
+     },
+     {
+      "name": "NAMESPACE",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.namespace"
+       }
+      }
+     }
+    ],
+    "image": "docker.elastic.co/beats/filebeat:7.14.0",
+    "name": "filebeat",
+    "resources": {},
+    "securityContext": {
+     "allowPrivilegeEscalation": false,
+     "capabilities": {
+      "drop": [
+       "ALL"
+      ]
+     },
+     "privileged": false,
+     "readOnlyRootFilesystem": true
+    },
+    "volumeMounts": [
+     {
+      "mountPath": "/etc/filebeat-config",
+      "name": "sample-filebeat-config",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/mnt/elastic-internal/es-monitoring-association/observability/monitoring/certs",
+      "name": "es-monitoring-03f555-ca",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/usr/share/filebeat/data",
+      "name": "filebeat-data"
+     },
+     {
+      "mountPath": "/usr/share/elasticsearch/logs",
+      "name": "elasticsearch-logs"
+     }
+    ]
+   }
+  ],
+  "volumes": [
+   {
+    "name": "es-monitoring-03f555-ca",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-es-monitoring-observability-monitoring-ca"
+    }
+   },
+   {
+    "emptyDir": {},
+    "name": "filebeat-data"
+   },
+   {
+    "name": "sample-filebeat-config",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-es-monitoring-filebeat-config"
+    }
+   }
+  ]
+ }
+}
+---
+
+[TestWithMonitoring/with_metrics_and_logs_monitoring - 1]
+{
+ "metadata": {
+  "annotations": {
+   "elasticsearch.k8s.elastic.co/monitoring-config-hash": "1805099278"
+  },
+  "creationTimestamp": null
+ },
+ "spec": {
+  "automountServiceAccountToken": false,
+  "containers": [
+   {
+    "env": [
+     {
+      "name": "ES_LOG_STYLE",
+      "value": "file"
+     }
+    ],
+    "name": "elasticsearch",
+    "resources": {}
+   },
+   {
+    "args": [
+     "-c",
+     "/etc/metricbeat-config/metricbeat.yml",
+     "-e"
+    ],
+    "env": [
+     {
+      "name": "POD_IP",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "status.podIP"
+       }
+      }
+     },
+     {
+      "name": "POD_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.name"
+       }
+      }
+     },
+     {
+      "name": "NODE_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "spec.nodeName"
+       }
+      }
+     },
+     {
+      "name": "NAMESPACE",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.namespace"
+       }
+      }
+     }
+    ],
+    "image": "docker.elastic.co/beats/metricbeat:7.14.0",
+    "name": "metricbeat",
+    "resources": {},
+    "securityContext": {
+     "allowPrivilegeEscalation": false,
+     "capabilities": {
+      "drop": [
+       "ALL"
+      ]
+     },
+     "privileged": false,
+     "readOnlyRootFilesystem": true
+    },
+    "volumeMounts": [
+     {
+      "mountPath": "/etc/metricbeat-config",
+      "name": "sample-metricbeat-config",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/mnt/elastic-internal/es-monitoring-association/observability/monitoring/certs",
+      "name": "es-monitoring-03f555-ca",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/mnt/elastic-internal/es-monitoring/aerospace/sample/certs",
+      "name": "es-monitoring-local-ca",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/usr/share/metricbeat/data",
+      "name": "metricbeat-data"
+     }
+    ]
+   },
+   {
+    "args": [
+     "-c",
+     "/etc/filebeat-config/filebeat.yml",
+     "-e"
+    ],
+    "env": [
+     {
+      "name": "POD_IP",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "status.podIP"
+       }
+      }
+     },
+     {
+      "name": "POD_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.name"
+       }
+      }
+     },
+     {
+      "name": "NODE_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "spec.nodeName"
+       }
+      }
+     },
+     {
+      "name": "NAMESPACE",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.namespace"
+       }
+      }
+     }
+    ],
+    "image": "docker.elastic.co/beats/filebeat:7.14.0",
+    "name": "filebeat",
+    "resources": {},
+    "securityContext": {
+     "allowPrivilegeEscalation": false,
+     "capabilities": {
+      "drop": [
+       "ALL"
+      ]
+     },
+     "privileged": false,
+     "readOnlyRootFilesystem": true
+    },
+    "volumeMounts": [
+     {
+      "mountPath": "/etc/filebeat-config",
+      "name": "sample-filebeat-config",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/mnt/elastic-internal/es-monitoring-association/observability/monitoring/certs",
+      "name": "es-monitoring-03f555-ca",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/usr/share/filebeat/data",
+      "name": "filebeat-data"
+     },
+     {
+      "mountPath": "/usr/share/elasticsearch/logs",
+      "name": "elasticsearch-logs"
+     }
+    ]
+   }
+  ],
+  "volumes": [
+   {
+    "name": "es-monitoring-03f555-ca",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-es-logs-observability-monitoring-ca"
+    }
+   },
+   {
+    "name": "es-monitoring-local-ca",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-es-http-certs-public"
+    }
+   },
+   {
+    "emptyDir": {},
+    "name": "filebeat-data"
+   },
+   {
+    "emptyDir": {},
+    "name": "metricbeat-data"
+   },
+   {
+    "name": "sample-filebeat-config",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-es-monitoring-filebeat-config"
+    }
+   },
+   {
+    "name": "sample-metricbeat-config",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-es-monitoring-metricbeat-config"
+    }
+   }
+  ]
+ }
+}
+---
+
+[TestWithMonitoring/with_metrics_and_logs_monitoring_with_different_es_ref - 1]
+{
+ "metadata": {
+  "annotations": {
+   "elasticsearch.k8s.elastic.co/monitoring-config-hash": "1086800329"
+  },
+  "creationTimestamp": null
+ },
+ "spec": {
+  "automountServiceAccountToken": false,
+  "containers": [
+   {
+    "env": [
+     {
+      "name": "ES_LOG_STYLE",
+      "value": "file"
+     }
+    ],
+    "name": "elasticsearch",
+    "resources": {}
+   },
+   {
+    "args": [
+     "-c",
+     "/etc/metricbeat-config/metricbeat.yml",
+     "-e"
+    ],
+    "env": [
+     {
+      "name": "POD_IP",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "status.podIP"
+       }
+      }
+     },
+     {
+      "name": "POD_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.name"
+       }
+      }
+     },
+     {
+      "name": "NODE_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "spec.nodeName"
+       }
+      }
+     },
+     {
+      "name": "NAMESPACE",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.namespace"
+       }
+      }
+     }
+    ],
+    "image": "docker.elastic.co/beats/metricbeat:7.14.0",
+    "name": "metricbeat",
+    "resources": {},
+    "securityContext": {
+     "allowPrivilegeEscalation": false,
+     "capabilities": {
+      "drop": [
+       "ALL"
+      ]
+     },
+     "privileged": false,
+     "readOnlyRootFilesystem": true
+    },
+    "volumeMounts": [
+     {
+      "mountPath": "/etc/metricbeat-config",
+      "name": "sample-metricbeat-config",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/mnt/elastic-internal/es-monitoring-association/observability/monitoring/certs",
+      "name": "es-monitoring-03f555-ca",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/mnt/elastic-internal/es-monitoring/aerospace/sample/certs",
+      "name": "es-monitoring-local-ca",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/usr/share/metricbeat/data",
+      "name": "metricbeat-data"
+     }
+    ]
+   },
+   {
+    "args": [
+     "-c",
+     "/etc/filebeat-config/filebeat.yml",
+     "-e"
+    ],
+    "env": [
+     {
+      "name": "POD_IP",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "status.podIP"
+       }
+      }
+     },
+     {
+      "name": "POD_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.name"
+       }
+      }
+     },
+     {
+      "name": "NODE_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "spec.nodeName"
+       }
+      }
+     },
+     {
+      "name": "NAMESPACE",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.namespace"
+       }
+      }
+     }
+    ],
+    "image": "docker.elastic.co/beats/filebeat:7.14.0",
+    "name": "filebeat",
+    "resources": {},
+    "securityContext": {
+     "allowPrivilegeEscalation": false,
+     "capabilities": {
+      "drop": [
+       "ALL"
+      ]
+     },
+     "privileged": false,
+     "readOnlyRootFilesystem": true
+    },
+    "volumeMounts": [
+     {
+      "mountPath": "/etc/filebeat-config",
+      "name": "sample-filebeat-config",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/mnt/elastic-internal/es-monitoring-association/observability/logs/certs",
+      "name": "es-monitoring-584a4d-ca",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/usr/share/filebeat/data",
+      "name": "filebeat-data"
+     },
+     {
+      "mountPath": "/usr/share/elasticsearch/logs",
+      "name": "elasticsearch-logs"
+     }
+    ]
+   }
+  ],
+  "volumes": [
+   {
+    "name": "es-monitoring-03f555-ca",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-es-monitoring-observability-monitoring-ca"
+    }
+   },
+   {
+    "name": "es-monitoring-584a4d-ca",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-es-logs-observability-monitoring-ca"
+    }
+   },
+   {
+    "name": "es-monitoring-local-ca",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-es-http-certs-public"
+    }
+   },
+   {
+    "emptyDir": {},
+    "name": "filebeat-data"
+   },
+   {
+    "emptyDir": {},
+    "name": "metricbeat-data"
+   },
+   {
+    "name": "sample-filebeat-config",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-es-monitoring-filebeat-config"
+    }
+   },
+   {
+    "name": "sample-metricbeat-config",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-es-monitoring-metricbeat-config"
+    }
+   }
+  ]
+ }
+}
+---

--- a/pkg/controller/elasticsearch/stackmon/__snapshots__/sidecar_test.snap
+++ b/pkg/controller/elasticsearch/stackmon/__snapshots__/sidecar_test.snap
@@ -1,0 +1,189 @@
+
+[TestMetricbeatConfig/default - 1]
+metricbeat.modules:
+  # https://www.elastic.co/guide/en/beats/metricbeat/7.14/metricbeat-module-elasticsearch.html
+  - module: elasticsearch
+    metricsets:
+      - ccr
+      - cluster_stats
+      - enrich
+      - index
+      - index_recovery
+      - index_summary
+      - ml_job
+      - node
+      - node_stats
+      - pending_tasks
+      - shard
+
+    period: 10s
+    xpack.enabled: true
+    hosts: ["https://localhost:9200"]
+    username: elastic
+    password: secret
+    ssl.enabled: true
+    # The ssl verification_mode is set to `certificate` in the config template to verify that the certificate is signed by a trusted authority,
+    # but does not perform any hostname verification. This is used when SSL is enabled with or without CA, to support self-signed certificate
+    # with a custom CA or custom certificates with or without a CA that most likely are not issued for `localhost`.
+    ssl.verification_mode: "certificate"
+    ssl.certificate_authorities: ["/mount/ca.crt"]
+
+processors:
+  - add_cloud_metadata: {}
+  - add_host_metadata: {}
+
+# Elasticsearch output configuration is generated
+
+---
+
+[TestMetricbeatConfig/no_CA - 1]
+metricbeat.modules:
+  # https://www.elastic.co/guide/en/beats/metricbeat/7.14/metricbeat-module-elasticsearch.html
+  - module: elasticsearch
+    metricsets:
+      - ccr
+      - cluster_stats
+      - enrich
+      - index
+      - index_recovery
+      - index_summary
+      - ml_job
+      - node
+      - node_stats
+      - pending_tasks
+      - shard
+
+    period: 10s
+    xpack.enabled: true
+    hosts: ["https://localhost:9200"]
+    username: elastic
+    password: secret
+    ssl.enabled: true
+    # The ssl verification_mode is set to `certificate` in the config template to verify that the certificate is signed by a trusted authority,
+    # but does not perform any hostname verification. This is used when SSL is enabled with or without CA, to support self-signed certificate
+    # with a custom CA or custom certificates with or without a CA that most likely are not issued for `localhost`.
+    ssl.verification_mode: "certificate"
+
+processors:
+  - add_cloud_metadata: {}
+  - add_host_metadata: {}
+
+# Elasticsearch output configuration is generated
+
+---
+
+[TestMetricbeatConfig/post_8.7.0_with_ingest - 1]
+metricbeat.modules:
+  # https://www.elastic.co/guide/en/beats/metricbeat/7.14/metricbeat-module-elasticsearch.html
+  - module: elasticsearch
+    metricsets:
+      - ccr
+      - cluster_stats
+      - enrich
+      - index
+      - index_recovery
+      - index_summary
+      - ingest_pipeline
+      - ml_job
+      - node
+      - node_stats
+      - pending_tasks
+      - shard
+
+    period: 10s
+    xpack.enabled: true
+    hosts: ["https://localhost:9200"]
+    username: elastic
+    password: secret
+    ssl.enabled: true
+    # The ssl verification_mode is set to `certificate` in the config template to verify that the certificate is signed by a trusted authority,
+    # but does not perform any hostname verification. This is used when SSL is enabled with or without CA, to support self-signed certificate
+    # with a custom CA or custom certificates with or without a CA that most likely are not issued for `localhost`.
+    ssl.verification_mode: "certificate"
+    ssl.certificate_authorities: ["/mount/ca.crt"]
+
+processors:
+  - add_cloud_metadata: {}
+  - add_host_metadata: {}
+setup.template.settings:
+  index.mapping.total_fields.limit: 12500
+
+# Elasticsearch output configuration is generated
+
+---
+
+[TestMetricbeatConfig/no_TLS - 1]
+metricbeat.modules:
+  # https://www.elastic.co/guide/en/beats/metricbeat/7.14/metricbeat-module-elasticsearch.html
+  - module: elasticsearch
+    metricsets:
+      - ccr
+      - cluster_stats
+      - enrich
+      - index
+      - index_recovery
+      - index_summary
+      - ml_job
+      - node
+      - node_stats
+      - pending_tasks
+      - shard
+
+    period: 10s
+    xpack.enabled: true
+    hosts: ["https://localhost:9200"]
+    username: elastic
+    password: secret
+    ssl.enabled: false
+    # The ssl verification_mode is set to `certificate` in the config template to verify that the certificate is signed by a trusted authority,
+    # but does not perform any hostname verification. This is used when SSL is enabled with or without CA, to support self-signed certificate
+    # with a custom CA or custom certificates with or without a CA that most likely are not issued for `localhost`.
+    ssl.verification_mode: "certificate"
+
+processors:
+  - add_cloud_metadata: {}
+  - add_host_metadata: {}
+
+# Elasticsearch output configuration is generated
+
+---
+
+[TestMetricbeatConfig/latest_ES_versions:_higher_field_limit - 1]
+metricbeat.modules:
+  # https://www.elastic.co/guide/en/beats/metricbeat/7.14/metricbeat-module-elasticsearch.html
+  - module: elasticsearch
+    metricsets:
+      - ccr
+      - cluster_stats
+      - enrich
+      - index
+      - index_recovery
+      - index_summary
+      - ingest_pipeline
+      - ml_job
+      - node
+      - node_stats
+      - pending_tasks
+      - shard
+
+    period: 10s
+    xpack.enabled: true
+    hosts: ["https://localhost:9200"]
+    username: elastic
+    password: secret
+    ssl.enabled: true
+    # The ssl verification_mode is set to `certificate` in the config template to verify that the certificate is signed by a trusted authority,
+    # but does not perform any hostname verification. This is used when SSL is enabled with or without CA, to support self-signed certificate
+    # with a custom CA or custom certificates with or without a CA that most likely are not issued for `localhost`.
+    ssl.verification_mode: "certificate"
+    ssl.certificate_authorities: ["/mount/ca.crt"]
+
+processors:
+  - add_cloud_metadata: {}
+  - add_host_metadata: {}
+setup.template.settings:
+  index.mapping.total_fields.limit: 12500
+
+# Elasticsearch output configuration is generated
+
+---

--- a/pkg/controller/elasticsearch/stackmon/metricbeat.tpl.yml
+++ b/pkg/controller/elasticsearch/stackmon/metricbeat.tpl.yml
@@ -27,17 +27,17 @@ metricbeat.modules:
     # but does not perform any hostname verification. This is used when SSL is enabled with or without CA, to support self-signed certificate
     # with a custom CA or custom certificates with or without a CA that most likely are not issued for `localhost`.
     ssl.verification_mode: "certificate"
-    {{- if .HasCA }}
-    ssl.certificate_authorities: ["{{ .CAPath }}"]
+    {{- with .CAVolume }}
+    ssl.certificate_authorities: ["{{ CAPath . }}"]
     {{- end }}
 
 processors:
   - add_cloud_metadata: {}
   - add_host_metadata: {}
 
-{{- if gt .TotalFieldsLimit 0 }}
+{{- if isVersionGTE "8.15.0" }}
 setup.template.settings:
-  index.mapping.total_fields.limit: {{ .TotalFieldsLimit }}
+  index.mapping.total_fields.limit: 12500
 {{- end }}
 
 # Elasticsearch output configuration is generated

--- a/pkg/controller/elasticsearch/stackmon/sidecar.go
+++ b/pkg/controller/elasticsearch/stackmon/sidecar.go
@@ -12,6 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/blang/semver/v4"
+
 	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/defaults"

--- a/pkg/controller/elasticsearch/stackmon/sidecar.go
+++ b/pkg/controller/elasticsearch/stackmon/sidecar.go
@@ -17,7 +17,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/stackmon"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/stackmon/monitoring"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/version"
-	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/volume"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/network"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/securitycontext"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/user"
@@ -47,13 +46,7 @@ func Metricbeat(ctx context.Context, client k8s.Client, es esv1.Elasticsearch) (
 		return stackmon.BeatSidecar{}, err
 	}
 
-	input := struct {
-		URL      string
-		Username string
-		Password string
-		IsSSL    bool
-		CAVolume volume.VolumeLike
-	}{
+	input := stackmon.TemplateParams{
 		URL:      fmt.Sprintf("%s://localhost:%d", es.Spec.HTTP.Protocol(), network.HTTPPort),
 		Username: username,
 		Password: password,

--- a/pkg/controller/elasticsearch/stackmon/sidecar.go
+++ b/pkg/controller/elasticsearch/stackmon/sidecar.go
@@ -42,7 +42,7 @@ func Metricbeat(ctx context.Context, client k8s.Client, es esv1.Elasticsearch) (
 		return stackmon.BeatSidecar{}, err
 	}
 
-	caVolume, err := stackmon.CAVolume(client, k8s.ExtractNamespacedName(&es), esv1.ESNamer, commonv1.KbMonitoringAssociationType /*???*/, es.Spec.HTTP.TLS.Enabled())
+	caVolume, err := stackmon.CAVolume(client, k8s.ExtractNamespacedName(&es), esv1.ESNamer, commonv1.EsMonitoringAssociationType, es.Spec.HTTP.TLS.Enabled())
 	if err != nil {
 		return stackmon.BeatSidecar{}, err
 	}

--- a/pkg/controller/elasticsearch/stackmon/sidecar.go
+++ b/pkg/controller/elasticsearch/stackmon/sidecar.go
@@ -11,8 +11,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/blang/semver/v4"
-
 	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/defaults"
@@ -55,14 +53,12 @@ func Metricbeat(ctx context.Context, client k8s.Client, es esv1.Elasticsearch) (
 		Password string
 		IsSSL    bool
 		CAVolume volume.VolumeLike
-		Version  semver.Version
 	}{
 		URL:      fmt.Sprintf("%s://localhost:%d", es.Spec.HTTP.Protocol(), network.HTTPPort),
 		Username: username,
 		Password: password,
 		IsSSL:    es.Spec.HTTP.TLS.Enabled(),
 		CAVolume: caVolume,
-		Version:  v,
 	}
 
 	cfg, err := stackmon.RenderTemplate(v, metricbeatConfigTemplate, input)

--- a/pkg/controller/elasticsearch/stackmon/sidecar_test.go
+++ b/pkg/controller/elasticsearch/stackmon/sidecar_test.go
@@ -9,6 +9,12 @@ import (
 	"testing"
 
 	"github.com/blang/semver/v4"
+	"github.com/gkampitakis/go-snaps/snaps"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/defaults"
@@ -17,11 +23,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/volume"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/k8s"
-	"github.com/gkampitakis/go-snaps/snaps"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestWithMonitoring(t *testing.T) {

--- a/pkg/controller/elasticsearch/stackmon/sidecar_test.go
+++ b/pkg/controller/elasticsearch/stackmon/sidecar_test.go
@@ -137,23 +137,6 @@ func TestWithMonitoring(t *testing.T) {
 	}
 }
 
-func assertSecurityContext(t *testing.T, securityContext *corev1.SecurityContext) {
-	t.Helper()
-	require.NotNil(t, securityContext)
-	require.NotNil(t, securityContext.Privileged)
-	require.False(t, *securityContext.Privileged)
-	require.NotNil(t, securityContext.Capabilities)
-	droppedCapabilities := securityContext.Capabilities.Drop
-	hasDropAllCapability := false
-	for _, capability := range droppedCapabilities {
-		if capability == "ALL" {
-			hasDropAllCapability = true
-			break
-		}
-	}
-	require.True(t, hasDropAllCapability, "ALL capability not found in securityContext.Capabilities.Drop")
-}
-
 func TestMetricbeatConfig(t *testing.T) {
 	volumeFixture := volume.NewSecretVolumeWithMountPath(
 		"secret-name",

--- a/pkg/controller/kibana/stackmon/__snapshots__/sidecar_test.snap
+++ b/pkg/controller/kibana/stackmon/__snapshots__/sidecar_test.snap
@@ -1,0 +1,809 @@
+
+[TestWithMonitoring/without_monitoring - 1]
+{
+ "metadata": {
+  "creationTimestamp": null
+ },
+ "spec": {
+  "automountServiceAccountToken": false,
+  "containers": [
+   {
+    "name": "kibana",
+    "resources": {}
+   }
+  ]
+ }
+}
+---
+
+[TestWithMonitoring/with_metrics_monitoring - 1]
+{
+ "metadata": {
+  "annotations": {
+   "kibana.k8s.elastic.co/monitoring-config-hash": "1132877422"
+  },
+  "creationTimestamp": null
+ },
+ "spec": {
+  "automountServiceAccountToken": false,
+  "containers": [
+   {
+    "name": "kibana",
+    "resources": {}
+   },
+   {
+    "args": [
+     "-c",
+     "/etc/metricbeat-config/metricbeat.yml",
+     "-e"
+    ],
+    "env": [
+     {
+      "name": "POD_IP",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "status.podIP"
+       }
+      }
+     },
+     {
+      "name": "POD_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.name"
+       }
+      }
+     },
+     {
+      "name": "NODE_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "spec.nodeName"
+       }
+      }
+     },
+     {
+      "name": "NAMESPACE",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.namespace"
+       }
+      }
+     }
+    ],
+    "image": "docker.elastic.co/beats/metricbeat:7.14.0",
+    "name": "metricbeat",
+    "resources": {},
+    "volumeMounts": [
+     {
+      "mountPath": "/etc/metricbeat-config",
+      "name": "sample-metricbeat-config",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/mnt/elastic-internal/kb-monitoring-association/observability/monitoring/certs",
+      "name": "kb-monitoring-03f555-ca",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/mnt/elastic-internal/kb-monitoring/aerospace/sample/certs",
+      "name": "kb-monitoring-local-ca",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/usr/share/metricbeat/data",
+      "name": "metricbeat-data"
+     }
+    ]
+   }
+  ],
+  "volumes": [
+   {
+    "name": "kb-monitoring-03f555-ca",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-es-monitoring-observability-monitoring-ca"
+    }
+   },
+   {
+    "name": "kb-monitoring-local-ca",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-kb-http-certs-public"
+    }
+   },
+   {
+    "emptyDir": {},
+    "name": "metricbeat-data"
+   },
+   {
+    "name": "sample-metricbeat-config",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-kb-monitoring-metricbeat-config"
+    }
+   }
+  ]
+ }
+}
+---
+
+[TestWithMonitoring/with_logs_monitoring - 1]
+{
+ "metadata": {
+  "annotations": {
+   "kibana.k8s.elastic.co/monitoring-config-hash": "95064241"
+  },
+  "creationTimestamp": null
+ },
+ "spec": {
+  "automountServiceAccountToken": false,
+  "containers": [
+   {
+    "name": "kibana",
+    "resources": {},
+    "volumeMounts": [
+     {
+      "mountPath": "/usr/share/kibana/logs",
+      "name": "kibana-logs"
+     }
+    ]
+   },
+   {
+    "args": [
+     "-c",
+     "/etc/filebeat-config/filebeat.yml",
+     "-e"
+    ],
+    "env": [
+     {
+      "name": "POD_IP",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "status.podIP"
+       }
+      }
+     },
+     {
+      "name": "POD_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.name"
+       }
+      }
+     },
+     {
+      "name": "NODE_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "spec.nodeName"
+       }
+      }
+     },
+     {
+      "name": "NAMESPACE",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.namespace"
+       }
+      }
+     }
+    ],
+    "image": "docker.elastic.co/beats/filebeat:7.14.0",
+    "name": "filebeat",
+    "resources": {},
+    "volumeMounts": [
+     {
+      "mountPath": "/etc/filebeat-config",
+      "name": "sample-filebeat-config",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/mnt/elastic-internal/kb-monitoring-association/observability/monitoring/certs",
+      "name": "kb-monitoring-03f555-ca",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/usr/share/filebeat/data",
+      "name": "filebeat-data"
+     },
+     {
+      "mountPath": "/usr/share/kibana/logs",
+      "name": "kibana-logs"
+     }
+    ]
+   }
+  ],
+  "volumes": [
+   {
+    "emptyDir": {},
+    "name": "filebeat-data"
+   },
+   {
+    "name": "kb-monitoring-03f555-ca",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-es-monitoring-observability-monitoring-ca"
+    }
+   },
+   {
+    "emptyDir": {},
+    "name": "kibana-logs"
+   },
+   {
+    "name": "sample-filebeat-config",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-kb-monitoring-filebeat-config"
+    }
+   }
+  ]
+ }
+}
+---
+
+[TestWithMonitoring/with_metrics_and_logs_monitoring - 1]
+{
+ "metadata": {
+  "annotations": {
+   "kibana.k8s.elastic.co/monitoring-config-hash": "1633666673"
+  },
+  "creationTimestamp": null
+ },
+ "spec": {
+  "automountServiceAccountToken": false,
+  "containers": [
+   {
+    "name": "kibana",
+    "resources": {},
+    "volumeMounts": [
+     {
+      "mountPath": "/usr/share/kibana/logs",
+      "name": "kibana-logs"
+     }
+    ]
+   },
+   {
+    "args": [
+     "-c",
+     "/etc/metricbeat-config/metricbeat.yml",
+     "-e"
+    ],
+    "env": [
+     {
+      "name": "POD_IP",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "status.podIP"
+       }
+      }
+     },
+     {
+      "name": "POD_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.name"
+       }
+      }
+     },
+     {
+      "name": "NODE_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "spec.nodeName"
+       }
+      }
+     },
+     {
+      "name": "NAMESPACE",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.namespace"
+       }
+      }
+     }
+    ],
+    "image": "docker.elastic.co/beats/metricbeat:7.14.0",
+    "name": "metricbeat",
+    "resources": {},
+    "volumeMounts": [
+     {
+      "mountPath": "/etc/metricbeat-config",
+      "name": "sample-metricbeat-config",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/mnt/elastic-internal/kb-monitoring-association/observability/monitoring/certs",
+      "name": "kb-monitoring-03f555-ca",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/mnt/elastic-internal/kb-monitoring/aerospace/sample/certs",
+      "name": "kb-monitoring-local-ca",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/usr/share/metricbeat/data",
+      "name": "metricbeat-data"
+     }
+    ]
+   },
+   {
+    "args": [
+     "-c",
+     "/etc/filebeat-config/filebeat.yml",
+     "-e"
+    ],
+    "env": [
+     {
+      "name": "POD_IP",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "status.podIP"
+       }
+      }
+     },
+     {
+      "name": "POD_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.name"
+       }
+      }
+     },
+     {
+      "name": "NODE_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "spec.nodeName"
+       }
+      }
+     },
+     {
+      "name": "NAMESPACE",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.namespace"
+       }
+      }
+     }
+    ],
+    "image": "docker.elastic.co/beats/filebeat:7.14.0",
+    "name": "filebeat",
+    "resources": {},
+    "volumeMounts": [
+     {
+      "mountPath": "/etc/filebeat-config",
+      "name": "sample-filebeat-config",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/mnt/elastic-internal/kb-monitoring-association/observability/monitoring/certs",
+      "name": "kb-monitoring-03f555-ca",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/usr/share/filebeat/data",
+      "name": "filebeat-data"
+     },
+     {
+      "mountPath": "/usr/share/kibana/logs",
+      "name": "kibana-logs"
+     }
+    ]
+   }
+  ],
+  "volumes": [
+   {
+    "emptyDir": {},
+    "name": "filebeat-data"
+   },
+   {
+    "name": "kb-monitoring-03f555-ca",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-es-logs-observability-monitoring-ca"
+    }
+   },
+   {
+    "name": "kb-monitoring-local-ca",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-kb-http-certs-public"
+    }
+   },
+   {
+    "emptyDir": {},
+    "name": "kibana-logs"
+   },
+   {
+    "emptyDir": {},
+    "name": "metricbeat-data"
+   },
+   {
+    "name": "sample-filebeat-config",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-kb-monitoring-filebeat-config"
+    }
+   },
+   {
+    "name": "sample-metricbeat-config",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-kb-monitoring-metricbeat-config"
+    }
+   }
+  ]
+ }
+}
+---
+
+[TestWithMonitoring/with_metrics_and_logs_monitoring_with_different_es_ref - 1]
+{
+ "metadata": {
+  "annotations": {
+   "kibana.k8s.elastic.co/monitoring-config-hash": "1902028541"
+  },
+  "creationTimestamp": null
+ },
+ "spec": {
+  "automountServiceAccountToken": false,
+  "containers": [
+   {
+    "name": "kibana",
+    "resources": {},
+    "volumeMounts": [
+     {
+      "mountPath": "/usr/share/kibana/logs",
+      "name": "kibana-logs"
+     }
+    ]
+   },
+   {
+    "args": [
+     "-c",
+     "/etc/metricbeat-config/metricbeat.yml",
+     "-e"
+    ],
+    "env": [
+     {
+      "name": "POD_IP",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "status.podIP"
+       }
+      }
+     },
+     {
+      "name": "POD_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.name"
+       }
+      }
+     },
+     {
+      "name": "NODE_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "spec.nodeName"
+       }
+      }
+     },
+     {
+      "name": "NAMESPACE",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.namespace"
+       }
+      }
+     }
+    ],
+    "image": "docker.elastic.co/beats/metricbeat:7.14.0",
+    "name": "metricbeat",
+    "resources": {},
+    "volumeMounts": [
+     {
+      "mountPath": "/etc/metricbeat-config",
+      "name": "sample-metricbeat-config",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/mnt/elastic-internal/kb-monitoring-association/observability/monitoring/certs",
+      "name": "kb-monitoring-03f555-ca",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/mnt/elastic-internal/kb-monitoring/aerospace/sample/certs",
+      "name": "kb-monitoring-local-ca",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/usr/share/metricbeat/data",
+      "name": "metricbeat-data"
+     }
+    ]
+   },
+   {
+    "args": [
+     "-c",
+     "/etc/filebeat-config/filebeat.yml",
+     "-e"
+    ],
+    "env": [
+     {
+      "name": "POD_IP",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "status.podIP"
+       }
+      }
+     },
+     {
+      "name": "POD_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.name"
+       }
+      }
+     },
+     {
+      "name": "NODE_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "spec.nodeName"
+       }
+      }
+     },
+     {
+      "name": "NAMESPACE",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.namespace"
+       }
+      }
+     }
+    ],
+    "image": "docker.elastic.co/beats/filebeat:7.14.0",
+    "name": "filebeat",
+    "resources": {},
+    "volumeMounts": [
+     {
+      "mountPath": "/etc/filebeat-config",
+      "name": "sample-filebeat-config",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/mnt/elastic-internal/kb-monitoring-association/observability/logs/certs",
+      "name": "kb-monitoring-584a4d-ca",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/usr/share/filebeat/data",
+      "name": "filebeat-data"
+     },
+     {
+      "mountPath": "/usr/share/kibana/logs",
+      "name": "kibana-logs"
+     }
+    ]
+   }
+  ],
+  "volumes": [
+   {
+    "emptyDir": {},
+    "name": "filebeat-data"
+   },
+   {
+    "name": "kb-monitoring-03f555-ca",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-es-monitoring-observability-monitoring-ca"
+    }
+   },
+   {
+    "name": "kb-monitoring-584a4d-ca",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-es-logs-observability-monitoring-ca"
+    }
+   },
+   {
+    "name": "kb-monitoring-local-ca",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-kb-http-certs-public"
+    }
+   },
+   {
+    "emptyDir": {},
+    "name": "kibana-logs"
+   },
+   {
+    "emptyDir": {},
+    "name": "metricbeat-data"
+   },
+   {
+    "name": "sample-filebeat-config",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-kb-monitoring-filebeat-config"
+    }
+   },
+   {
+    "name": "sample-metricbeat-config",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-kb-monitoring-metricbeat-config"
+    }
+   }
+  ]
+ }
+}
+---
+
+[TestMetricbeatConfig/no_monitoring - 1]
+
+---
+
+[TestMetricbeatConfig/with_metrics_monitoring - 1]
+metricbeat:
+    modules:
+        - hosts:
+            - https://localhost:5601
+          metricsets:
+            - stats
+            - status
+          module: kibana
+          password: 1234567890
+          period: 10s
+          ssl:
+            certificate_authorities:
+                - /mnt/elastic-internal/kb-monitoring/aerospace/sample/certs/ca.crt
+            enabled: true
+            verification_mode: certificate
+          username: elastic-internal-monitoring
+          xpack:
+            enabled: true
+output:
+    elasticsearch:
+        hosts:
+            - https://monitoring-es-http.observability.svc:9200
+        password: "1234567890"
+        ssl:
+            certificate_authorities:
+                - /mnt/elastic-internal/kb-monitoring-association/observability/monitoring/certs/ca.crt
+            verification_mode: certificate
+        username: aerospace-sample-observability-monitoring-beat-es-mon-user
+processors:
+    - add_cloud_metadata: null
+    - add_host_metadata: null
+
+---
+
+[TestMetricbeatConfig/with_monitoring_no_CA - 1]
+metricbeat:
+    modules:
+        - hosts:
+            - https://localhost:5601
+          metricsets:
+            - stats
+            - status
+          module: kibana
+          password: 1234567890
+          period: 10s
+          ssl:
+            enabled: true
+            verification_mode: certificate
+          username: elastic-internal-monitoring
+          xpack:
+            enabled: true
+output:
+    elasticsearch:
+        hosts:
+            - https://monitoring-es-http.observability.svc:9200
+        password: "1234567890"
+        ssl:
+            certificate_authorities:
+                - /mnt/elastic-internal/kb-monitoring-association/observability/monitoring/certs/ca.crt
+            verification_mode: certificate
+        username: aerospace-sample-observability-monitoring-beat-es-mon-user
+processors:
+    - add_cloud_metadata: null
+    - add_host_metadata: null
+
+---
+
+[TestMetricbeatConfig/with_metrics_monitoring_no_TLS - 1]
+metricbeat:
+    modules:
+        - hosts:
+            - http://localhost:5601
+          metricsets:
+            - stats
+            - status
+          module: kibana
+          password: 1234567890
+          period: 10s
+          ssl:
+            enabled: false
+            verification_mode: certificate
+          username: elastic-internal-monitoring
+          xpack:
+            enabled: true
+output:
+    elasticsearch:
+        hosts:
+            - https://monitoring-es-http.observability.svc:9200
+        password: "1234567890"
+        ssl:
+            certificate_authorities:
+                - /mnt/elastic-internal/kb-monitoring-association/observability/monitoring/certs/ca.crt
+            verification_mode: certificate
+        username: aerospace-sample-observability-monitoring-beat-es-mon-user
+processors:
+    - add_cloud_metadata: null
+    - add_host_metadata: null
+
+---
+
+[TestMetricbeatConfig/with_metrics_monitoring_and_basePath - 1]
+metricbeat:
+    modules:
+        - basepath: /prefix
+          hosts:
+            - https://localhost:5601
+          metricsets:
+            - stats
+            - status
+          module: kibana
+          password: 1234567890
+          period: 10s
+          ssl:
+            certificate_authorities:
+                - /mnt/elastic-internal/kb-monitoring/aerospace/sample/certs/ca.crt
+            enabled: true
+            verification_mode: certificate
+          username: elastic-internal-monitoring
+          xpack:
+            enabled: true
+output:
+    elasticsearch:
+        hosts:
+            - https://monitoring-es-http.observability.svc:9200
+        password: "1234567890"
+        ssl:
+            certificate_authorities:
+                - /mnt/elastic-internal/kb-monitoring-association/observability/monitoring/certs/ca.crt
+            verification_mode: certificate
+        username: aerospace-sample-observability-monitoring-beat-es-mon-user
+processors:
+    - add_cloud_metadata: null
+    - add_host_metadata: null
+
+---

--- a/pkg/controller/kibana/stackmon/metricbeat.tpl.yml
+++ b/pkg/controller/kibana/stackmon/metricbeat.tpl.yml
@@ -17,8 +17,8 @@ metricbeat.modules:
     # but does not perform any hostname verification. This is used when SSL is enabled with or without CA, to support self-signed certificate
     # with a custom CA or custom certificates with or without a CA that most likely are not issued for `localhost`.
     ssl.verification_mode: "certificate"
-    {{- if .HasCA }}
-    ssl.certificate_authorities: ["{{ .CAPath }}"]
+    {{- with .CAVolume }}
+    ssl.certificate_authorities: ["{{ CAPath . }}"]
     {{- end }}
 
 processors:

--- a/pkg/controller/kibana/stackmon/sidecar.go
+++ b/pkg/controller/kibana/stackmon/sidecar.go
@@ -19,6 +19,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/stackmon"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/stackmon/monitoring"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/stackmon/validations"
+	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/volume"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/user"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/kibana/network"
@@ -60,19 +61,40 @@ func Metricbeat(ctx context.Context, client k8s.Client, kb kbv1.Kibana, basePath
 		}
 	}
 
+	v, err := version.Parse(kb.Spec.Version)
+	if err != nil {
+		return stackmon.BeatSidecar{}, err // error unlikely and should have been caught during validation
+	}
+	type inputConfigData struct {
+		BasePath string
+		URL      string
+		Username string
+		Password string
+		IsSSL    bool
+		CAVolume volume.VolumeLike
+	}
+
+	configData := inputConfigData{
+		Username: username,
+		Password: password,
+		URL:      fmt.Sprintf("%s://localhost:%d", kb.Spec.HTTP.Protocol(), network.HTTPPort), // Metricbeat in the sidecar connects to the monitored resource using `localhost`
+		BasePath: basePath,
+		IsSSL:    kb.Spec.HTTP.TLS.Enabled(), // enable SSL configuration based on whether the monitored resource has TLS enabled
+		CAVolume: stackmon.CAVolume(k8s.ExtractNamespacedName(&kb), kbv1.KBNamer, commonv1.KbMonitoringAssociationType),
+	}
+
+	cfg, err := stackmon.RenderTemplate(v, metricbeatConfigTemplate, configData)
+	if err != nil {
+		return stackmon.BeatSidecar{}, err
+	}
+
 	metricbeat, err := stackmon.NewMetricBeatSidecar(
 		ctx,
 		client,
-		commonv1.KbMonitoringAssociationType,
 		&kb,
 		kb.Spec.Version,
-		metricbeatConfigTemplate,
-		kbv1.KBNamer,
-		fmt.Sprintf("%s://localhost:%d", kb.Spec.HTTP.Protocol(), network.HTTPPort),
-		basePath,
-		username,
-		password,
-		kb.Spec.HTTP.TLS.Enabled(),
+		configData.CAVolume,
+		cfg,
 	)
 	if err != nil {
 		return stackmon.BeatSidecar{}, err

--- a/pkg/controller/kibana/stackmon/sidecar_test.go
+++ b/pkg/controller/kibana/stackmon/sidecar_test.go
@@ -9,15 +9,16 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/gkampitakis/go-snaps/snaps"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 	kbv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/kibana/v1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/defaults"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/stackmon/monitoring"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/k8s"
-	"github.com/gkampitakis/go-snaps/snaps"
-	"github.com/stretchr/testify/assert"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (
@@ -91,7 +92,6 @@ var (
 )
 
 func TestWithMonitoring(t *testing.T) {
-
 	tests := []struct {
 		name string
 		kb   func() kbv1.Kibana
@@ -152,7 +152,6 @@ func TestWithMonitoring(t *testing.T) {
 			actual, err := json.MarshalIndent(builder.PodTemplate, " ", "")
 			assert.NoError(t, err)
 			snaps.MatchJSON(t, actual)
-
 		})
 	}
 }

--- a/pkg/controller/logstash/stackmon/__snapshots__/sidecar_test.snap
+++ b/pkg/controller/logstash/stackmon/__snapshots__/sidecar_test.snap
@@ -141,3 +141,739 @@ processors:
 # Elasticsearch output configuration is generated
 
 ---
+
+[TestWithMonitoring/without_monitoring - 1]
+{
+ "metadata": {
+  "creationTimestamp": null
+ },
+ "spec": {
+  "automountServiceAccountToken": false,
+  "containers": [
+   {
+    "name": "logstash",
+    "resources": {}
+   }
+  ]
+ }
+}
+---
+
+[TestWithMonitoring/with_metrics_monitoring - 1]
+{
+ "metadata": {
+  "annotations": {
+   "logstash.k8s.elastic.co/monitoring-config-hash": "625208580"
+  },
+  "creationTimestamp": null
+ },
+ "spec": {
+  "automountServiceAccountToken": false,
+  "containers": [
+   {
+    "name": "logstash",
+    "resources": {}
+   },
+   {
+    "args": [
+     "-c",
+     "/etc/metricbeat-config/metricbeat.yml",
+     "-e"
+    ],
+    "env": [
+     {
+      "name": "POD_IP",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "status.podIP"
+       }
+      }
+     },
+     {
+      "name": "POD_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.name"
+       }
+      }
+     },
+     {
+      "name": "NODE_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "spec.nodeName"
+       }
+      }
+     },
+     {
+      "name": "NAMESPACE",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.namespace"
+       }
+      }
+     }
+    ],
+    "image": "docker.elastic.co/beats/metricbeat:8.6.0",
+    "name": "metricbeat",
+    "resources": {},
+    "volumeMounts": [
+     {
+      "mountPath": "/etc/metricbeat-config",
+      "name": "sample-metricbeat-config",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/mnt/elastic-internal/ls-monitoring-association/observability/monitoring/certs",
+      "name": "ls-monitoring-03f555-ca",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/usr/share/metricbeat/data",
+      "name": "metricbeat-data"
+     }
+    ]
+   }
+  ],
+  "volumes": [
+   {
+    "name": "ls-monitoring-03f555-ca",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-es-monitoring-observability-monitoring-ca"
+    }
+   },
+   {
+    "emptyDir": {},
+    "name": "metricbeat-data"
+   },
+   {
+    "name": "sample-metricbeat-config",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-ls-monitoring-metricbeat-config"
+    }
+   }
+  ]
+ }
+}
+---
+
+[TestWithMonitoring/with_TLS_metrics_monitoring - 1]
+{
+ "metadata": {
+  "annotations": {
+   "logstash.k8s.elastic.co/monitoring-config-hash": "2320787694"
+  },
+  "creationTimestamp": null
+ },
+ "spec": {
+  "automountServiceAccountToken": false,
+  "containers": [
+   {
+    "name": "logstash",
+    "resources": {}
+   },
+   {
+    "args": [
+     "-c",
+     "/etc/metricbeat-config/metricbeat.yml",
+     "-e"
+    ],
+    "env": [
+     {
+      "name": "POD_IP",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "status.podIP"
+       }
+      }
+     },
+     {
+      "name": "POD_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.name"
+       }
+      }
+     },
+     {
+      "name": "NODE_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "spec.nodeName"
+       }
+      }
+     },
+     {
+      "name": "NAMESPACE",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.namespace"
+       }
+      }
+     }
+    ],
+    "image": "docker.elastic.co/beats/metricbeat:8.6.0",
+    "name": "metricbeat",
+    "resources": {},
+    "volumeMounts": [
+     {
+      "mountPath": "/etc/metricbeat-config",
+      "name": "sample-metricbeat-config",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/mnt/elastic-internal/ls-monitoring-association/observability/monitoring/certs",
+      "name": "ls-monitoring-03f555-ca",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/mnt/elastic-internal/ls-monitoring/aerospace/sample/certs",
+      "name": "ls-monitoring-local-ca",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/usr/share/metricbeat/data",
+      "name": "metricbeat-data"
+     }
+    ]
+   }
+  ],
+  "volumes": [
+   {
+    "name": "ls-monitoring-03f555-ca",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-es-monitoring-observability-monitoring-ca"
+    }
+   },
+   {
+    "name": "ls-monitoring-local-ca",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-ls-http-certs-public"
+    }
+   },
+   {
+    "emptyDir": {},
+    "name": "metricbeat-data"
+   },
+   {
+    "name": "sample-metricbeat-config",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-ls-monitoring-metricbeat-config"
+    }
+   }
+  ]
+ }
+}
+---
+
+[TestWithMonitoring/with_logs_monitoring - 1]
+{
+ "metadata": {
+  "annotations": {
+   "logstash.k8s.elastic.co/monitoring-config-hash": "983125293"
+  },
+  "creationTimestamp": null
+ },
+ "spec": {
+  "automountServiceAccountToken": false,
+  "containers": [
+   {
+    "env": [
+     {
+      "name": "LOG_STYLE",
+      "value": "file"
+     }
+    ],
+    "name": "logstash",
+    "resources": {}
+   },
+   {
+    "args": [
+     "-c",
+     "/etc/filebeat-config/filebeat.yml",
+     "-e"
+    ],
+    "env": [
+     {
+      "name": "POD_IP",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "status.podIP"
+       }
+      }
+     },
+     {
+      "name": "POD_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.name"
+       }
+      }
+     },
+     {
+      "name": "NODE_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "spec.nodeName"
+       }
+      }
+     },
+     {
+      "name": "NAMESPACE",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.namespace"
+       }
+      }
+     }
+    ],
+    "image": "docker.elastic.co/beats/filebeat:8.6.0",
+    "name": "filebeat",
+    "resources": {},
+    "volumeMounts": [
+     {
+      "mountPath": "/etc/filebeat-config",
+      "name": "sample-filebeat-config",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/mnt/elastic-internal/ls-monitoring-association/observability/monitoring/certs",
+      "name": "ls-monitoring-03f555-ca",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/usr/share/filebeat/data",
+      "name": "filebeat-data"
+     },
+     {
+      "mountPath": "/usr/share/logstash/logs",
+      "name": "logstash-logs"
+     }
+    ]
+   }
+  ],
+  "volumes": [
+   {
+    "emptyDir": {},
+    "name": "filebeat-data"
+   },
+   {
+    "name": "ls-monitoring-03f555-ca",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-es-monitoring-observability-monitoring-ca"
+    }
+   },
+   {
+    "name": "sample-filebeat-config",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-ls-monitoring-filebeat-config"
+    }
+   }
+  ]
+ }
+}
+---
+
+[TestWithMonitoring/with_metrics_and_logs_monitoring - 1]
+{
+ "metadata": {
+  "annotations": {
+   "logstash.k8s.elastic.co/monitoring-config-hash": "808554888"
+  },
+  "creationTimestamp": null
+ },
+ "spec": {
+  "automountServiceAccountToken": false,
+  "containers": [
+   {
+    "env": [
+     {
+      "name": "LOG_STYLE",
+      "value": "file"
+     }
+    ],
+    "name": "logstash",
+    "resources": {}
+   },
+   {
+    "args": [
+     "-c",
+     "/etc/metricbeat-config/metricbeat.yml",
+     "-e"
+    ],
+    "env": [
+     {
+      "name": "POD_IP",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "status.podIP"
+       }
+      }
+     },
+     {
+      "name": "POD_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.name"
+       }
+      }
+     },
+     {
+      "name": "NODE_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "spec.nodeName"
+       }
+      }
+     },
+     {
+      "name": "NAMESPACE",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.namespace"
+       }
+      }
+     }
+    ],
+    "image": "docker.elastic.co/beats/metricbeat:8.6.0",
+    "name": "metricbeat",
+    "resources": {},
+    "volumeMounts": [
+     {
+      "mountPath": "/etc/metricbeat-config",
+      "name": "sample-metricbeat-config",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/mnt/elastic-internal/ls-monitoring-association/observability/monitoring/certs",
+      "name": "ls-monitoring-03f555-ca",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/usr/share/metricbeat/data",
+      "name": "metricbeat-data"
+     }
+    ]
+   },
+   {
+    "args": [
+     "-c",
+     "/etc/filebeat-config/filebeat.yml",
+     "-e"
+    ],
+    "env": [
+     {
+      "name": "POD_IP",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "status.podIP"
+       }
+      }
+     },
+     {
+      "name": "POD_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.name"
+       }
+      }
+     },
+     {
+      "name": "NODE_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "spec.nodeName"
+       }
+      }
+     },
+     {
+      "name": "NAMESPACE",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.namespace"
+       }
+      }
+     }
+    ],
+    "image": "docker.elastic.co/beats/filebeat:8.6.0",
+    "name": "filebeat",
+    "resources": {},
+    "volumeMounts": [
+     {
+      "mountPath": "/etc/filebeat-config",
+      "name": "sample-filebeat-config",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/mnt/elastic-internal/ls-monitoring-association/observability/monitoring/certs",
+      "name": "ls-monitoring-03f555-ca",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/usr/share/filebeat/data",
+      "name": "filebeat-data"
+     },
+     {
+      "mountPath": "/usr/share/logstash/logs",
+      "name": "logstash-logs"
+     }
+    ]
+   }
+  ],
+  "volumes": [
+   {
+    "emptyDir": {},
+    "name": "filebeat-data"
+   },
+   {
+    "name": "ls-monitoring-03f555-ca",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-es-logs-observability-monitoring-ca"
+    }
+   },
+   {
+    "emptyDir": {},
+    "name": "metricbeat-data"
+   },
+   {
+    "name": "sample-filebeat-config",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-ls-monitoring-filebeat-config"
+    }
+   },
+   {
+    "name": "sample-metricbeat-config",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-ls-monitoring-metricbeat-config"
+    }
+   }
+  ]
+ }
+}
+---
+
+[TestWithMonitoring/with_metrics_and_logs_monitoring_with_different_es_ref - 1]
+{
+ "metadata": {
+  "annotations": {
+   "logstash.k8s.elastic.co/monitoring-config-hash": "2399876695"
+  },
+  "creationTimestamp": null
+ },
+ "spec": {
+  "automountServiceAccountToken": false,
+  "containers": [
+   {
+    "env": [
+     {
+      "name": "LOG_STYLE",
+      "value": "file"
+     }
+    ],
+    "name": "logstash",
+    "resources": {}
+   },
+   {
+    "args": [
+     "-c",
+     "/etc/metricbeat-config/metricbeat.yml",
+     "-e"
+    ],
+    "env": [
+     {
+      "name": "POD_IP",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "status.podIP"
+       }
+      }
+     },
+     {
+      "name": "POD_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.name"
+       }
+      }
+     },
+     {
+      "name": "NODE_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "spec.nodeName"
+       }
+      }
+     },
+     {
+      "name": "NAMESPACE",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.namespace"
+       }
+      }
+     }
+    ],
+    "image": "docker.elastic.co/beats/metricbeat:8.6.0",
+    "name": "metricbeat",
+    "resources": {},
+    "volumeMounts": [
+     {
+      "mountPath": "/etc/metricbeat-config",
+      "name": "sample-metricbeat-config",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/mnt/elastic-internal/ls-monitoring-association/observability/monitoring/certs",
+      "name": "ls-monitoring-03f555-ca",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/usr/share/metricbeat/data",
+      "name": "metricbeat-data"
+     }
+    ]
+   },
+   {
+    "args": [
+     "-c",
+     "/etc/filebeat-config/filebeat.yml",
+     "-e"
+    ],
+    "env": [
+     {
+      "name": "POD_IP",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "status.podIP"
+       }
+      }
+     },
+     {
+      "name": "POD_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.name"
+       }
+      }
+     },
+     {
+      "name": "NODE_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "spec.nodeName"
+       }
+      }
+     },
+     {
+      "name": "NAMESPACE",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.namespace"
+       }
+      }
+     }
+    ],
+    "image": "docker.elastic.co/beats/filebeat:8.6.0",
+    "name": "filebeat",
+    "resources": {},
+    "volumeMounts": [
+     {
+      "mountPath": "/etc/filebeat-config",
+      "name": "sample-filebeat-config",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/mnt/elastic-internal/ls-monitoring-association/observability/logs/certs",
+      "name": "ls-monitoring-584a4d-ca",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/usr/share/filebeat/data",
+      "name": "filebeat-data"
+     },
+     {
+      "mountPath": "/usr/share/logstash/logs",
+      "name": "logstash-logs"
+     }
+    ]
+   }
+  ],
+  "volumes": [
+   {
+    "emptyDir": {},
+    "name": "filebeat-data"
+   },
+   {
+    "name": "ls-monitoring-03f555-ca",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-es-monitoring-observability-monitoring-ca"
+    }
+   },
+   {
+    "name": "ls-monitoring-584a4d-ca",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-es-logs-observability-monitoring-ca"
+    }
+   },
+   {
+    "emptyDir": {},
+    "name": "metricbeat-data"
+   },
+   {
+    "name": "sample-filebeat-config",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-ls-monitoring-filebeat-config"
+    }
+   },
+   {
+    "name": "sample-metricbeat-config",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-ls-monitoring-metricbeat-config"
+    }
+   }
+  ]
+ }
+}
+---

--- a/pkg/controller/logstash/stackmon/__snapshots__/sidecar_test.snap
+++ b/pkg/controller/logstash/stackmon/__snapshots__/sidecar_test.snap
@@ -1,0 +1,143 @@
+
+[TestMetricbeatConfig/default - 1]
+metricbeat.modules:
+  - module: logstash
+    metricsets:
+      - node
+      - node_stats
+    period: 10s
+    hosts: ["https://localhost:9200"]
+    xpack.enabled: true
+    
+    username: elastic
+    
+    
+    password: password
+    
+    ssl.enabled: true
+    # The ssl verification_mode is set to `certificate` in the config template to verify that the certificate is signed by a trusted authority,
+    # but does not perform any hostname verification. This is used when SSL is enabled with or without CA, to support self-signed certificate
+    # with a custom CA or custom certificates with or without a CA that most likely are not issued for `localhost`.
+    ssl.verification_mode: "certificate"
+    ssl.certificate_authorities: ["/mount/ca.crt"]
+
+processors:
+  - add_cloud_metadata: {}
+  - add_host_metadata: {}
+
+# Elasticsearch output configuration is generated
+
+---
+
+[TestMetricbeatConfig/no_password - 1]
+metricbeat.modules:
+  - module: logstash
+    metricsets:
+      - node
+      - node_stats
+    period: 10s
+    hosts: ["https://localhost:9200"]
+    xpack.enabled: true
+    
+    username: elastic
+    
+    
+    ssl.enabled: true
+    # The ssl verification_mode is set to `certificate` in the config template to verify that the certificate is signed by a trusted authority,
+    # but does not perform any hostname verification. This is used when SSL is enabled with or without CA, to support self-signed certificate
+    # with a custom CA or custom certificates with or without a CA that most likely are not issued for `localhost`.
+    ssl.verification_mode: "certificate"
+    ssl.certificate_authorities: ["/mount/ca.crt"]
+
+processors:
+  - add_cloud_metadata: {}
+  - add_host_metadata: {}
+
+# Elasticsearch output configuration is generated
+
+---
+
+[TestMetricbeatConfig/no_user_+_password - 1]
+metricbeat.modules:
+  - module: logstash
+    metricsets:
+      - node
+      - node_stats
+    period: 10s
+    hosts: ["https://localhost:9200"]
+    xpack.enabled: true
+    
+    
+    ssl.enabled: true
+    # The ssl verification_mode is set to `certificate` in the config template to verify that the certificate is signed by a trusted authority,
+    # but does not perform any hostname verification. This is used when SSL is enabled with or without CA, to support self-signed certificate
+    # with a custom CA or custom certificates with or without a CA that most likely are not issued for `localhost`.
+    ssl.verification_mode: "certificate"
+    ssl.certificate_authorities: ["/mount/ca.crt"]
+
+processors:
+  - add_cloud_metadata: {}
+  - add_host_metadata: {}
+
+# Elasticsearch output configuration is generated
+
+---
+
+[TestMetricbeatConfig/no_TLS - 1]
+metricbeat.modules:
+  - module: logstash
+    metricsets:
+      - node
+      - node_stats
+    period: 10s
+    hosts: ["https://localhost:9200"]
+    xpack.enabled: true
+    
+    username: elastic
+    
+    
+    password: password
+    
+    ssl.enabled: false
+    # The ssl verification_mode is set to `certificate` in the config template to verify that the certificate is signed by a trusted authority,
+    # but does not perform any hostname verification. This is used when SSL is enabled with or without CA, to support self-signed certificate
+    # with a custom CA or custom certificates with or without a CA that most likely are not issued for `localhost`.
+    ssl.verification_mode: "certificate"
+    ssl.certificate_authorities: ["/mount/ca.crt"]
+
+processors:
+  - add_cloud_metadata: {}
+  - add_host_metadata: {}
+
+# Elasticsearch output configuration is generated
+
+---
+
+[TestMetricbeatConfig/no_CA - 1]
+metricbeat.modules:
+  - module: logstash
+    metricsets:
+      - node
+      - node_stats
+    period: 10s
+    hosts: ["https://localhost:9200"]
+    xpack.enabled: true
+    
+    username: elastic
+    
+    
+    password: password
+    
+    ssl.enabled: true
+    # The ssl verification_mode is set to `certificate` in the config template to verify that the certificate is signed by a trusted authority,
+    # but does not perform any hostname verification. This is used when SSL is enabled with or without CA, to support self-signed certificate
+    # with a custom CA or custom certificates with or without a CA that most likely are not issued for `localhost`.
+    ssl.verification_mode: "certificate"
+
+processors:
+  - add_cloud_metadata: {}
+  - add_host_metadata: {}
+
+# Elasticsearch output configuration is generated
+
+---

--- a/pkg/controller/logstash/stackmon/metricbeat.tpl.yml
+++ b/pkg/controller/logstash/stackmon/metricbeat.tpl.yml
@@ -17,8 +17,8 @@ metricbeat.modules:
     # but does not perform any hostname verification. This is used when SSL is enabled with or without CA, to support self-signed certificate
     # with a custom CA or custom certificates with or without a CA that most likely are not issued for `localhost`.
     ssl.verification_mode: "certificate"
-    {{- if .HasCA }}
-    ssl.certificate_authorities: ["{{ .CAPath }}"]
+    {{- with .CAVolume }}
+    ssl.certificate_authorities: ["{{ CAPath . }}"]
     {{- end }}
 
 processors:

--- a/pkg/controller/logstash/stackmon/sidecar.go
+++ b/pkg/controller/logstash/stackmon/sidecar.go
@@ -16,6 +16,8 @@ import (
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/defaults"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/stackmon"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/stackmon/monitoring"
+	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/version"
+	commonvol "github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/volume"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/logstash/configs"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/logstash/network"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/logstash/volume"
@@ -35,19 +37,37 @@ func Metricbeat(ctx context.Context, client k8s.Client, logstash logstashv1alpha
 		protocol = "https"
 	}
 
+	v, err := version.Parse(logstash.Spec.Version)
+	if err != nil {
+		return stackmon.BeatSidecar{}, err
+	}
+
+	input := struct {
+		URL      string
+		Username string
+		Password string
+		IsSSL    bool
+		CAVolume commonvol.VolumeLike
+	}{
+		URL:      fmt.Sprintf("%s://localhost:%d", protocol, network.HTTPPort),
+		Username: apiServer.Username,
+		Password: apiServer.Password,
+		IsSSL:    useTLS,
+		CAVolume: stackmon.CAVolume(k8s.ExtractNamespacedName(&logstash), logstashv1alpha1.Namer, commonv1.LogstashMonitoringAssociationType),
+	}
+
+	cfg, err := stackmon.RenderTemplate(v, metricbeatConfigTemplate, input)
+	if err != nil {
+		return stackmon.BeatSidecar{}, err
+	}
+
 	metricbeat, err := stackmon.NewMetricBeatSidecar(
 		ctx,
 		client,
-		commonv1.LogstashMonitoringAssociationType,
 		&logstash,
 		logstash.Spec.Version,
-		metricbeatConfigTemplate,
-		logstashv1alpha1.Namer,
-		fmt.Sprintf("%s://localhost:%d", protocol, network.HTTPPort),
-		"",
-		apiServer.Username,
-		apiServer.Password,
-		useTLS,
+		input.CAVolume,
+		cfg,
 	)
 	if err != nil {
 		return stackmon.BeatSidecar{}, err

--- a/pkg/controller/logstash/stackmon/sidecar.go
+++ b/pkg/controller/logstash/stackmon/sidecar.go
@@ -17,7 +17,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/stackmon"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/stackmon/monitoring"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/version"
-	commonvol "github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/volume"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/logstash/configs"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/logstash/network"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/logstash/volume"
@@ -47,13 +46,7 @@ func Metricbeat(ctx context.Context, client k8s.Client, logstash logstashv1alpha
 		return stackmon.BeatSidecar{}, err
 	}
 
-	input := struct {
-		URL      string
-		Username string
-		Password string
-		IsSSL    bool
-		CAVolume commonvol.VolumeLike
-	}{
+	input := stackmon.TemplateParams{
 		URL:      fmt.Sprintf("%s://localhost:%d", protocol, network.HTTPPort),
 		Username: apiServer.Username,
 		Password: apiServer.Password,

--- a/pkg/controller/logstash/stackmon/sidecar_test.go
+++ b/pkg/controller/logstash/stackmon/sidecar_test.go
@@ -153,7 +153,6 @@ func TestWithMonitoring(t *testing.T) {
 			actual, err := json.MarshalIndent(builder.PodTemplate, " ", "")
 			assert.NoError(t, err)
 			snaps.MatchJSON(t, actual)
-
 		})
 	}
 }

--- a/pkg/controller/logstash/stackmon/sidecar_test.go
+++ b/pkg/controller/logstash/stackmon/sidecar_test.go
@@ -6,6 +6,7 @@ package stackmon
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"testing"
@@ -175,22 +176,25 @@ func TestWithMonitoring(t *testing.T) {
 			assert.NoError(t, err)
 
 			assert.Equal(t, tc.containersLength, len(builder.PodTemplate.Spec.Containers))
+			println(tc.name)
 			for _, v := range builder.PodTemplate.Spec.Volumes {
-				fmt.Println(v)
+				y, _ := json.Marshal(v)
+				fmt.Println(string(y))
 			}
-			assert.Equal(t, tc.podVolumesLength, len(builder.PodTemplate.Spec.Volumes))
+			println("------------------------")
+			assert.Equal(t, tc.podVolumesLength, len(builder.PodTemplate.Spec.Volumes), "pod volumes")
 
 			if monitoring.IsMetricsDefined(&ls) {
 				for _, c := range builder.PodTemplate.Spec.Containers {
 					if c.Name == "metricbeat" {
-						assert.Equal(t, tc.metricsVolumeMountsLength, len(c.VolumeMounts))
+						assert.Equal(t, tc.metricsVolumeMountsLength, len(c.VolumeMounts), "metrics volume mounts")
 					}
 				}
 			}
 			if monitoring.IsLogsDefined(&ls) {
 				for _, c := range builder.PodTemplate.Spec.Containers {
 					if c.Name == "filebeat" {
-						assert.Equal(t, tc.logVolumeMountsLength, len(c.VolumeMounts))
+						assert.Equal(t, tc.logVolumeMountsLength, len(c.VolumeMounts), "logs volume mounts")
 					}
 				}
 			}


### PR DESCRIPTION
Fixes #8314

This PR introduces the following changes: 
* separate template rendering from the shared stack monitoring code as we have have introduced a few application specific config settings in the templates and Beat was not using the shared rendering to begin with
* test the actual templates used in production code instead of a synthetic template in the shared code
* modify existing tests to use snapshots instead of counting volumes/volume mounts (more verbose but easier to verify in my opinion, better diffs on test failures) 

Not addressed:
* `stackmon.Metricbeat|Filebeat` are called twice: once for generating the config secret and once to generate the side cars (duplicated work)