### PR TITLE
[E2E] Increase Agent memory from 640Mi to 756Mi

### DIFF
--- a/test/e2e/test/agent/builder.go
+++ b/test/e2e/test/agent/builder.go
@@ -179,11 +179,11 @@ func (b Builder) MoreResourcesForIssue4730() Builder {
 	return b.WithResources(
 		corev1.ResourceRequirements{
 			Limits: map[corev1.ResourceName]resource.Quantity{
-				corev1.ResourceMemory: resource.MustParse("640Mi"),
+				corev1.ResourceMemory: resource.MustParse("756Mi"),
 				corev1.ResourceCPU:    resource.MustParse("200m"),
 			},
 			Requests: map[corev1.ResourceName]resource.Quantity{
-				corev1.ResourceMemory: resource.MustParse("640Mi"),
+				corev1.ResourceMemory: resource.MustParse("756Mi"),
 				corev1.ResourceCPU:    resource.MustParse("200m"),
 			},
 		},


### PR DESCRIPTION
* Should fix https://github.com/elastic/cloud-on-k8s/issues/8331
* Relates to https://github.com/elastic/cloud-on-k8s/issues/7790
* Follow up of https://github.com/elastic/cloud-on-k8s/pull/8021 which already increased memory to `640Mi`