### PR TITLE
Only conditionally set Kibana default security context.

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -353,7 +353,7 @@ func Command() *cobra.Command {
 	cmd.Flags().String(
 		operator.SetDefaultSecurityContextFlag,
 		"auto-detect",
-		"Enables setting the default security context with fsGroup=1000 for Elasticsearch 8.0+ Pods. Ignored pre-8.0. Possible values: true, false, auto-detect",
+		"Enables setting the default security context with fsGroup=1000 for Elasticsearch 8.0+ Pods and Kibana 7.10+ Pods. Possible values: true, false, auto-detect",
 	)
 
 	// hide development mode flags from the usage message

--- a/docs/release-notes/highlights-2.16.0.asciidoc
+++ b/docs/release-notes/highlights-2.16.0.asciidoc
@@ -19,7 +19,7 @@ Refer to the <<{p}-remote-clusters>> section for more information.
 [id="{p}-2160-hardened-kb-security-context"]
 === Hardened Security Context for Kibana container
 
-The default `SecurityContext` of the Kibana containers has been hardened, it includes the following specification by default in version 7.10.0 and above:
+The default `SecurityContext` of the Kibana containers has been hardened, it includes the following specification by default in version 7.10.0 and above when `set-default-security-context` is either `true` or `auto-detect`:
 
 [source,yaml]
 ----

--- a/pkg/controller/common/operator/parameters.go
+++ b/pkg/controller/common/operator/parameters.go
@@ -42,7 +42,7 @@ type Parameters struct {
 	// MaxConcurrentReconciles controls the number of goroutines per controller.
 	MaxConcurrentReconciles int
 	// SetDefaultSecurityContext enables setting the default security context
-	// with fsGroup=1000 for Elasticsearch 8.0+ Pods. Ignored pre-8.0
+	// with fsGroup=1000 for Elasticsearch 8.0+ Pods, and Kibana 7.10+ Pods.
 	SetDefaultSecurityContext bool
 	// ValidateStorageClass specifies whether the operator should retrieve storage classes to verify volume expansion support.
 	// Can be disabled if cluster-wide storage class RBAC access is not available.

--- a/pkg/controller/kibana/driver.go
+++ b/pkg/controller/kibana/driver.go
@@ -178,7 +178,7 @@ func (d *driver) Reconcile(
 	span, _ := apm.StartSpan(ctx, "reconcile_deployment", tracing.SpanTypeApp)
 	defer span.End()
 
-	deploymentParams, err := d.deploymentParams(ctx, kb, kibanaPolicyCfg.PodAnnotations, basePath)
+	deploymentParams, err := d.deploymentParams(ctx, kb, kibanaPolicyCfg.PodAnnotations, basePath, params.SetDefaultSecurityContext)
 	if err != nil {
 		return results.WithError(err)
 	}
@@ -225,7 +225,7 @@ func (d *driver) getStrategyType(kb *kbv1.Kibana) (appsv1.DeploymentStrategyType
 	return appsv1.RollingUpdateDeploymentStrategyType, nil
 }
 
-func (d *driver) deploymentParams(ctx context.Context, kb *kbv1.Kibana, policyAnnotations map[string]string, basePath string) (deployment.Params, error) {
+func (d *driver) deploymentParams(ctx context.Context, kb *kbv1.Kibana, policyAnnotations map[string]string, basePath string, setDefaultSecurityContext bool) (deployment.Params, error) {
 	initContainersParameters, err := newInitContainersParameters(kb)
 	if err != nil {
 		return deployment.Params{}, err
@@ -247,7 +247,7 @@ func (d *driver) deploymentParams(ctx context.Context, kb *kbv1.Kibana, policyAn
 	if err != nil {
 		return deployment.Params{}, err
 	}
-	kibanaPodSpec, err := NewPodTemplateSpec(ctx, d.client, *kb, keystoreResources, volumes, basePath)
+	kibanaPodSpec, err := NewPodTemplateSpec(ctx, d.client, *kb, keystoreResources, volumes, basePath, setDefaultSecurityContext)
 	if err != nil {
 		return deployment.Params{}, err
 	}

--- a/pkg/controller/kibana/driver_test.go
+++ b/pkg/controller/kibana/driver_test.go
@@ -19,6 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
@@ -376,6 +377,9 @@ func TestDriverDeploymentParams(t *testing.T) {
 			want: func() deployment.Params {
 				p := expectedDeploymentParams()
 				p.PodTemplateSpec.Labels["kibana.k8s.elastic.co/version"] = "7.10.0"
+				p.PodTemplateSpec.Spec.SecurityContext = &corev1.PodSecurityContext{
+					FSGroup: ptr.To[int64](1000),
+				}
 				return p
 			}(),
 			wantErr: false,
@@ -392,7 +396,7 @@ func TestDriverDeploymentParams(t *testing.T) {
 			d, err := newDriver(client, w, record.NewFakeRecorder(100), kb, corev1.IPv4Protocol)
 			require.NoError(t, err)
 
-			got, err := d.deploymentParams(context.Background(), kb, tt.args.policyAnnotations, "")
+			got, err := d.deploymentParams(context.Background(), kb, tt.args.policyAnnotations, "", true)
 			if tt.wantErr {
 				require.Error(t, err)
 				return

--- a/pkg/controller/kibana/driver_test.go
+++ b/pkg/controller/kibana/driver_test.go
@@ -642,7 +642,6 @@ func expectedDeploymentParams() deployment.Params {
 					SecurityContext: &defaultSecurityContext,
 				}},
 				AutomountServiceAccountToken: &falseVal,
-				SecurityContext:              &defaultPodSecurityContext,
 			},
 		},
 	}

--- a/pkg/controller/kibana/pod.go
+++ b/pkg/controller/kibana/pod.go
@@ -40,6 +40,7 @@ const (
 	KibanaBasePathEnvName        = "SERVER_BASEPATH"
 	KibanaRewriteBasePathEnvName = "SERVER_REWRITEBASEPATH"
 	defaultFSGroup               = 1000
+	defaultFSUser                = 1000
 )
 
 var (

--- a/pkg/controller/kibana/pod.go
+++ b/pkg/controller/kibana/pod.go
@@ -12,7 +12,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/ptr"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/elastic/go-ucfg"
@@ -142,9 +141,7 @@ func NewPodTemplateSpec(
 	// root filesystem on restart.
 	if v.GTE(version.From(7, 10, 0)) && setDefaultSecurityContext {
 		builder.WithContainersSecurityContext(defaultSecurityContext).
-			WithPodSecurityContext(corev1.PodSecurityContext{
-				FSGroup: ptr.To[int64](defaultFSGroup),
-			}).
+			WithPodSecurityContext(defaultPodSecurityContext).
 			WithVolumes(TempVolume.Volume()).WithVolumeMounts(TempVolume.VolumeMount()).
 			WithVolumes(PluginsVolume.Volume()).WithVolumeMounts(PluginsVolume.VolumeMount())
 	}

--- a/pkg/controller/kibana/pod.go
+++ b/pkg/controller/kibana/pod.go
@@ -138,8 +138,7 @@ func NewPodTemplateSpec(
 	// of browser bundles to happen on plugin install, which would attempt a write to the
 	// root filesystem on restart.
 	if v.GTE(version.From(7, 10, 0)) {
-		builder.WithPodSecurityContext(defaultPodSecurityContext).
-			WithContainersSecurityContext(defaultSecurityContext).
+		builder.WithContainersSecurityContext(defaultSecurityContext).
 			WithVolumes(TempVolume.Volume()).WithVolumeMounts(TempVolume.VolumeMount()).
 			WithVolumes(PluginsVolume.Volume()).WithVolumeMounts(PluginsVolume.VolumeMount())
 	}

--- a/pkg/controller/kibana/pod_test.go
+++ b/pkg/controller/kibana/pod_test.go
@@ -372,7 +372,7 @@ func TestNewPodTemplateSpec(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			bp, err := GetKibanaBasePath(tt.kb)
 			require.NoError(t, err)
-			got, err := NewPodTemplateSpec(context.Background(), k8s.NewFakeClient(), tt.kb, tt.keystore, []commonvolume.VolumeLike{}, bp)
+			got, err := NewPodTemplateSpec(context.Background(), k8s.NewFakeClient(), tt.kb, tt.keystore, []commonvolume.VolumeLike{}, bp, true)
 			assert.NoError(t, err)
 			tt.assertions(got)
 		})

--- a/pkg/controller/kibana/pod_test.go
+++ b/pkg/controller/kibana/pod_test.go
@@ -222,7 +222,6 @@ func TestNewPodTemplateSpec(t *testing.T) {
 				assert.Len(t, pod.Spec.InitContainers[0].VolumeMounts, 5)
 				assert.Len(t, pod.Spec.Volumes, 3)
 				assert.Len(t, GetKibanaContainer(pod.Spec).VolumeMounts, 3)
-				assert.Equal(t, pod.Spec.SecurityContext, &defaultPodSecurityContext)
 				assert.Equal(t, GetKibanaContainer(pod.Spec).SecurityContext, &defaultSecurityContext)
 			},
 		},

--- a/pkg/controller/kibana/securitycontext.go
+++ b/pkg/controller/kibana/securitycontext.go
@@ -19,10 +19,5 @@ var (
 		},
 		Privileged:             ptr.To(bool(false)),
 		ReadOnlyRootFilesystem: ptr.To(bool(true)),
-		RunAsUser:              ptr.To(int64(1000)),
-		RunAsGroup:             ptr.To(int64(1000)),
-	}
-	defaultPodSecurityContext = corev1.PodSecurityContext{
-		FSGroup: ptr.To(int64(1000)),
 	}
 )

--- a/pkg/controller/kibana/securitycontext.go
+++ b/pkg/controller/kibana/securitycontext.go
@@ -19,7 +19,7 @@ var (
 		},
 		Privileged:             ptr.To(bool(false)),
 		ReadOnlyRootFilesystem: ptr.To(bool(true)),
-		RunAsUser:              ptr.To(int64(defaultFSGroup)),
+		RunAsUser:              ptr.To(int64(defaultFSUser)),
 		RunAsGroup:             ptr.To(int64(defaultFSGroup)),
 	}
 	defaultPodSecurityContext = corev1.PodSecurityContext{

--- a/pkg/controller/kibana/securitycontext.go
+++ b/pkg/controller/kibana/securitycontext.go
@@ -20,4 +20,7 @@ var (
 		Privileged:             ptr.To(bool(false)),
 		ReadOnlyRootFilesystem: ptr.To(bool(true)),
 	}
+	defaultPodSecurityContext = corev1.PodSecurityContext{
+		FSGroup: ptr.To(int64(1000)),
+	}
 )

--- a/pkg/controller/kibana/securitycontext.go
+++ b/pkg/controller/kibana/securitycontext.go
@@ -19,8 +19,10 @@ var (
 		},
 		Privileged:             ptr.To(bool(false)),
 		ReadOnlyRootFilesystem: ptr.To(bool(true)),
+		RunAsUser:              ptr.To(int64(defaultFSGroup)),
+		RunAsGroup:             ptr.To(int64(defaultFSGroup)),
 	}
 	defaultPodSecurityContext = corev1.PodSecurityContext{
-		FSGroup: ptr.To(int64(1000)),
+		FSGroup: ptr.To(int64(defaultFSGroup)),
 	}
 )


### PR DESCRIPTION
While preparing for upcoming release during OCP testing, it was found that the default security context for Kibana fails:

```
Error creating: pods "quickstart-kb-78dccccd95-" is forbidden: unable to validate against any security context constraint: [provider "anyuid": Forbidden: not usable by user or serviceaccount, provider restricted-v2: .spec.securityContext.fsGroup: Invalid value: []int64{1000}: 1000 is not an allowed group, provider restricted-v2: .initContainers[0].runAsUser: Invalid value: 1000: must be in the ranges: [1000700000, 1000709999], provider restricted-v2: .containers[0].runAsUser: Invalid value: 1000: must be in the ranges: [1000700000, 1000709999], ...]
```

The Kibana default security context was not following the previous pattern set with Elasticsearch where we only set this when the relevant flag `set-default-security-context`. This adjusts this to follow that pattern.