### PR TITLE
[2.16] Backport release notes + highlights

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -6,6 +6,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-2.16.0>>
 * <<release-notes-2.15.0>>
 * <<release-notes-2.14.0>>
 * <<release-notes-2.13.0>>
@@ -50,6 +51,7 @@ This section summarizes the changes in each release.
 
 --
 
+include::release-notes/2.16.0.asciidoc[]
 include::release-notes/2.15.0.asciidoc[]
 include::release-notes/2.14.0.asciidoc[]
 include::release-notes/2.13.0.asciidoc[]

--- a/docs/release-notes/2.16.0.asciidoc
+++ b/docs/release-notes/2.16.0.asciidoc
@@ -54,6 +54,7 @@
 [float]
 === Misc
 
+* Enterprise Search transition to Elasticsearch {pull}8323[#8323] (issue: {issue}8308[#8308])
 * fix(deps): update module golang.org/x/crypto to v0.29.0 {pull}8240[#8240]
 * chore(deps): update registry.access.redhat.com/ubi9/ubi-minimal docker tag to v9.5-1731604394 {pull}8237[#8237]
 * chore(deps): update go to v1.23.3 {pull}8190[#8190]
@@ -61,4 +62,3 @@
 * fix(deps): update k8s versions {pull}8163[#8163]
 * chore(deps): update wolfi (versioned) {pull}8162[#8162]
 * fix(deps): update module github.com/prometheus/client_golang to v1.20.5 {pull}8133[#8133]
-

--- a/docs/release-notes/2.16.0.asciidoc
+++ b/docs/release-notes/2.16.0.asciidoc
@@ -22,6 +22,7 @@
 * Make Helm chart consistent in respect to handling of 'spec'. (eck-kibana) {pull}8192[#8192]
 * Set default hardened security context for Kibana. {pull}8086[#8086] (issue: {issue}7787[#7787])
 * Add a setting in the Helm chart to deploy FIPS compliant ECK image. {pull}8272[#8272] (issue: {issue}8204[#8204])
+* Remove kube-rbac-proxy and adjust default approach to securing the metrics endpoint. {pull}8302[#8302] (issue: {issue}8279[#8279])
 
 [[bug-2.16.0]]
 [float]
@@ -29,6 +30,7 @@
 
 * Allow Beats stack monitoring without elasticseachRef. {pull}8273[#8273] (issue: {issue}8194[#8194])
 * Add recommened roles for Elastic Agent on Kubernetes. {pull}8188[#8188] (issue: {issue}8168[#8168])
+* Set 'basePath' in Metricbeat when using stack monitoring {pull}8311[#8311] (issue: {issue}8310[#8310])
 
 [[docs-2.16.0]]
 [float]

--- a/docs/release-notes/2.16.0.asciidoc
+++ b/docs/release-notes/2.16.0.asciidoc
@@ -62,3 +62,4 @@
 * fix(deps): update k8s versions {pull}8163[#8163]
 * chore(deps): update wolfi (versioned) {pull}8162[#8162]
 * fix(deps): update module github.com/prometheus/client_golang to v1.20.5 {pull}8133[#8133]
+* fix(deps): Bump golang.org/x/crypto from 0.29.0 to 0.31.0 {pull}8341[#8341]

--- a/docs/release-notes/2.16.0.asciidoc
+++ b/docs/release-notes/2.16.0.asciidoc
@@ -48,7 +48,7 @@
 * Add note on how to access generated Kibana encryption keys. {pull}8150[#8150] (issue: {issue}8129[#8129])
 * Move Troubleshooting section to top level of table of contents. {pull}8145[#8145] (issue: {issue}8131[#8131])
 * Add is_managed: true to Agent policies. {pull}8125[#8125] (issue: {issue}7290[#7290])
-* Adds a secure settings link to K8s docs and note the need to be base64 encoded. {pull}8113[#8113]   * 
+* Adds a secure settings link to K8s docs and note the need to be base64 encoded. {pull}8113[#8113]
 
 [[nogroup-2.16.0]]
 [float]

--- a/docs/release-notes/2.16.0.asciidoc
+++ b/docs/release-notes/2.16.0.asciidoc
@@ -1,0 +1,62 @@
+:issue: https://github.com/elastic/cloud-on-k8s/issues/
+:pull: https://github.com/elastic/cloud-on-k8s/pull/
+
+[[release-notes-2.16.0]]
+== {n} version 2.16.0
+
+
+
+[[feature-2.16.0]]
+[float]
+=== New features
+
+* Support remote clusters using API keys {pull}8089[#8089] (issues: {issue}7818[#7818], {issue}8167[#8167])
+
+[[enhancement-2.16.0]]
+[float]
+=== Enhancements
+
+* Make Helm chart consistent in respect to handling of 'spec'. (eck-fleet-server) {pull}8285[#8285]
+* Make Helm chart consistent in respect to handling of 'spec'. (eck-beats) {pull}8248[#8248]
+* Make Helm chart consistent in respect to handling of 'spec'. (eck-agent) {pull}8246[#8246]
+* Make Helm chart consistent in respect to handling of 'spec'. (eck-kibana) {pull}8192[#8192]
+* Set default hardened security context for Kibana. {pull}8086[#8086] (issue: {issue}7787[#7787])
+* Add a setting in the Helm chart to deploy FIPS compliant ECK image. {pull}8272[#8272] (issue: {issue}8204[#8204])
+
+[[bug-2.16.0]]
+[float]
+=== Bug fixes
+
+* Allow Beats stack monitoring without elasticseachRef. {pull}8273[#8273] (issue: {issue}8194[#8194])
+* Add recommened roles for Elastic Agent on Kubernetes. {pull}8188[#8188] (issue: {issue}8168[#8168])
+
+[[docs-2.16.0]]
+[float]
+=== Documentation improvements
+
+* Optimization of the quickstart sections. {pull}8128[#8128]
+* Optimization of overview and support help. {pull}8130[#8130]
+* Remove node.remote_cluster_client from examples. {pull}8274[#8274]
+* Update the guidance for the stack config policy/role mapping issue. {pull}8247[#8247]
+* Update stack monitoring documentation. {pull}8198[#8198]
+* Document remote clusters using API keys. {pull}8181[#8181] (issue: {issue}8167[#8167])
+* Add Kibana to the Enterprise search sample. {pull}8166[#8166] (issue: {issue}5090[#5090])
+* Add explanation line for es ingress 9300 port. {pull}8164[#8164] (issue: {issue}7833[#7833])
+* Clarify high availability recommendations in Elasticsearch orchestration docs. {pull}8151[#8151]
+* Add note on how to access generated Kibana encryption keys. {pull}8150[#8150] (issue: {issue}8129[#8129])
+* Move Troubleshooting section to top level of table of contents. {pull}8145[#8145] (issue: {issue}8131[#8131])
+* Add is_managed: true to Agent policies. {pull}8125[#8125] (issue: {issue}7290[#7290])
+* Adds a secure settings link to K8s docs and note the need to be base64 encoded. {pull}8113[#8113]   * 
+
+[[nogroup-2.16.0]]
+[float]
+=== Misc
+
+* fix(deps): update module golang.org/x/crypto to v0.29.0 {pull}8240[#8240]
+* chore(deps): update registry.access.redhat.com/ubi9/ubi-minimal docker tag to v9.5-1731604394 {pull}8237[#8237]
+* chore(deps): update go to v1.23.3 {pull}8190[#8190]
+* fix(deps): update module github.com/prometheus/common to v0.60.1 {pull}8178[#8178]
+* fix(deps): update k8s versions {pull}8163[#8163]
+* chore(deps): update wolfi (versioned) {pull}8162[#8162]
+* fix(deps): update module github.com/prometheus/client_golang to v1.20.5 {pull}8133[#8133]
+

--- a/docs/release-notes/highlights-2.16.0.asciidoc
+++ b/docs/release-notes/highlights-2.16.0.asciidoc
@@ -1,0 +1,42 @@
+[[release-highlights-2.16.0]]
+== 2.16.0 release highlights
+
+[float]
+[id="{p}-2160-new-and-notable"]
+=== New and notable
+
+New and notable changes in version 2.16.0.
+
+[float]
+[id="{p}-2160-remote-clusters-using-api-keys"]
+=== Remote clusters support using API keys
+
+ECK 2.16.0 includes a technical preview for connecting to remote clusters using API key authentication.
+
+Refer to the <<{p}-remote-clusters>> section for more information. 
+
+[float]
+[id="{p}-2160-hardened-kb-security-context"]
+=== Hardened Security Context for Kibana container
+
+The default `SecurityContext` of the Kibana containers has been hardened, it includes the following specification by default in version 7.10.0 and above:
+
+[source,yaml]
+----
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+    - ALL
+  privileged: false
+  readOnlyRootFilesystem: true
+----
+
+[float]
+[id="{p}-2160-breaking-changes"]
+=== eck-fleet-server Helm chart breaking changes
+
+The `eck-fleet-server` Helm chart has had the default values updated to remove the setting of the deployment model to be `deployment`.
+This was required because of an upstream Helm bug when using parent/child charts. Refer to https://github.com/elastic/cloud-on-k8s/issues/7429 for details.
+
+Check <<release-notes-2.16.0>> for the full list of changes.

--- a/docs/release-notes/highlights-2.16.0.asciidoc
+++ b/docs/release-notes/highlights-2.16.0.asciidoc
@@ -19,7 +19,7 @@ Refer to the <<{p}-remote-clusters>> section for more information.
 [id="{p}-2160-hardened-kb-security-context"]
 === Hardened Security Context for Kibana container
 
-The default `SecurityContext` of the Kibana containers has been hardened, it includes the following specification by default in version 7.10.0 and above:
+The default `SecurityContext` of the Kibana containers has been hardened, it includes the following specification by default in version 7.10.0 and above when `set-default-security-context` is either `true` or `auto-detect`:
 
 [source,yaml]
 ----

--- a/docs/release-notes/highlights.asciidoc
+++ b/docs/release-notes/highlights.asciidoc
@@ -5,6 +5,7 @@
 --
 This section summarizes the most important changes in each release. For the full list, check <<eck-release-notes>>.
 
+* <<release-highlights-2.16.0>>
 * <<release-highlights-2.15.0>>
 * <<release-highlights-2.14.0>>
 * <<release-highlights-2.13.0>>
@@ -49,6 +50,7 @@ This section summarizes the most important changes in each release. For the full
 
 --
 
+include::highlights-2.16.0.asciidoc[]
 include::highlights-2.15.0.asciidoc[]
 include::highlights-2.14.0.asciidoc[]
 include::highlights-2.13.0.asciidoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.16`:
 - [2.16 release notes and highlights (#8301)](https://github.com/elastic/cloud-on-k8s/pull/8301)
 - [Adjust 2.16 release notes from recent changes. (#8316)](https://github.com/elastic/cloud-on-k8s/pull/8316)
 - [Remove trailing &#x27;*&#x27; in release notes. (#8319)](https://github.com/elastic/cloud-on-k8s/pull/8319)
 - [Add enterprise search transition to release notes. (#8326)](https://github.com/elastic/cloud-on-k8s/pull/8326)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)