### PR TITLE
Chown for elasticsearch folder recursively

### DIFF
--- a/pkg/controller/elasticsearch/initcontainer/prepare_fs_script.go
+++ b/pkg/controller/elasticsearch/initcontainer/prepare_fs_script.go
@@ -130,7 +130,7 @@ var scriptTemplate = template.Must(template.New("").Parse(
 	if [[ $EUID -eq 0 ]]; then
 		{{range .ChownToElasticsearch}}
 			echo "chowning {{.}} to elasticsearch:elasticsearch"
-			chown -v elasticsearch:elasticsearch {{.}}
+			chown -vR elasticsearch:elasticsearch {{.}}
 		{{end}}
 	fi
 	echo "chown duration: $(duration $chown_start) sec."


### PR DESCRIPTION
RedHat Linux is causing a 'Permission denied' error for subfolders and files because chown was not applied recursively. As a result, when changing the Elasticsearch UID/GID, the Elasticsearch container fails with an 'Access Denied' error for the data/* files.

<!--
Thank you for your interest in contributing to Elastic Cloud on Kubernetes!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/cloud-on-k8s/tree/main/CONTRIBUTING.md)?
- If you submit code, is your pull request against main? We recommend pull requests against main. We will backport them as needed.
