### PR TITLE
[E2E][OCP] Restrict the use of the eck-e2e SCC to Agent and Beat Pods

### DIFF
--- a/config/e2e/scc.yaml
+++ b/config/e2e/scc.yaml
@@ -41,9 +41,20 @@ supplementalGroups:
   type: RunAsAny
 users:
 - system:serviceaccount:{{ .E2ENamespace }}:e2e-agent
-groups:
-  {{- range .Operator.ManagedNamespaces }}
-- system:serviceaccounts:{{ . }}
-  {{- end }}
+groups: [] # Do not set namespaces here, use the cluster role below to assign this SCC to specific ServiceAccounts and Pods.
 volumes:
 - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: use-scc-eck-e2e
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - eck-e2e
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use

--- a/test/e2e/agent/config_test.go
+++ b/test/e2e/agent/config_test.go
@@ -141,6 +141,7 @@ func TestFleetMode(t *testing.T) {
 		fleetServerBuilder := agent.NewBuilder(name + "-fs").
 			WithNamespace(agentNS).
 			WithRoles(agent.AgentFleetModeRoleName).
+			WithOpenShiftRoles(test.UseSCCRole).
 			WithDeployment().
 			WithFleetMode().
 			WithFleetServer().
@@ -152,6 +153,7 @@ func TestFleetMode(t *testing.T) {
 
 		agentBuilder := agent.NewBuilder(name + "-ea").
 			WithRoles(agent.AgentFleetModeRoleName).
+			WithOpenShiftRoles(test.UseSCCRole).
 			WithFleetMode().
 			WithKibanaRef(kbBuilder.Ref()).
 			WithFleetServerRef(fleetServerBuilder.Ref())
@@ -167,6 +169,7 @@ func TestFleetMode(t *testing.T) {
 		fleetServerBuilder := agent.NewBuilder(name + "-fs").
 			WithNamespace(fleetNS).
 			WithRoles(agent.AgentFleetModeRoleName).
+			WithOpenShiftRoles(test.UseSCCRole).
 			WithDeployment().
 			WithFleetMode().
 			WithFleetServer().
@@ -178,6 +181,7 @@ func TestFleetMode(t *testing.T) {
 
 		agentBuilder := agent.NewBuilder(name + "-ea").
 			WithRoles(agent.AgentFleetModeRoleName).
+			WithOpenShiftRoles(test.UseSCCRole).
 			WithFleetMode().
 			WithKibanaRef(kbBuilder.Ref()).
 			WithFleetServerRef(fleetServerBuilder.Ref())

--- a/test/e2e/agent/tls_test.go
+++ b/test/e2e/agent/tls_test.go
@@ -49,6 +49,7 @@ func TestFleetAgentWithoutTLS(t *testing.T) {
 
 	fleetServerBuilder := agent.NewBuilder(name + "-fs").
 		WithRoles(agent.AgentFleetModeRoleName).
+		WithOpenShiftRoles(test.UseSCCRole).
 		WithVersion(v.String()).
 		WithDeployment().
 		WithFleetMode().
@@ -62,6 +63,7 @@ func TestFleetAgentWithoutTLS(t *testing.T) {
 
 	agentBuilder := agent.NewBuilder(name + "-ea").
 		WithRoles(agent.AgentFleetModeRoleName).
+		WithOpenShiftRoles(test.UseSCCRole).
 		WithVersion(v.String()).
 		WithFleetMode().
 		WithKibanaRef(kbBuilder.Ref()).

--- a/test/e2e/agent/upgrade_test.go
+++ b/test/e2e/agent/upgrade_test.go
@@ -32,6 +32,7 @@ func TestAgentVersionUpgradeToLatest8x(t *testing.T) {
 
 	fleetServerBuilder := agent.NewBuilder(name + "-fs").
 		WithRoles(agent.AgentFleetModeRoleName).
+		WithOpenShiftRoles(test.UseSCCRole).
 		WithVersion(srcVersion).
 		WithDeployment().
 		WithFleetMode().
@@ -44,6 +45,7 @@ func TestAgentVersionUpgradeToLatest8x(t *testing.T) {
 
 	agentBuilder := agent.NewBuilder(name + "-ea").
 		WithRoles(agent.AgentFleetModeRoleName).
+		WithOpenShiftRoles(test.UseSCCRole).
 		WithVersion(srcVersion).
 		WithFleetMode().
 		WithKibanaRef(kbBuilder.Ref()).

--- a/test/e2e/beat/config_test.go
+++ b/test/e2e/beat/config_test.go
@@ -38,6 +38,7 @@ func TestFilebeatDefaultConfig(t *testing.T) {
 
 	fbBuilder := beat.NewBuilder(name).
 		WithRoles(beat.AutodiscoverClusterRoleName).
+		WithOpenShiftRoles(test.UseSCCRole).
 		WithType(filebeat.Type).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithESValidations(
@@ -81,6 +82,7 @@ func TestMetricbeatDefaultConfig(t *testing.T) {
 			mbBuilder := beat.NewBuilder(name).
 				WithType(metricbeat.Type).
 				WithRoles(beat.MetricbeatClusterRoleName, beat.AutodiscoverClusterRoleName).
+				WithOpenShiftRoles(test.UseSCCRole).
 				WithElasticsearchRef(esBuilder.Ref()).
 				WithESValidations(
 					beat.HasEventFromBeat(metricbeat.Type),
@@ -149,6 +151,7 @@ func TestBeatSecureSettings(t *testing.T) {
 	fbBuilder := beat.NewBuilder(name).
 		WithType(filebeat.Type).
 		WithRoles(beat.AutodiscoverClusterRoleName).
+		WithOpenShiftRoles(test.UseSCCRole).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithSecureSettings(secretName).
 		WithObjects(secret).
@@ -221,6 +224,7 @@ processors:
 	fbBuilder := beat.NewBuilder(name).
 		WithType(filebeat.Type).
 		WithRoles(beat.AutodiscoverClusterRoleName).
+		WithOpenShiftRoles(test.UseSCCRole).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithConfigRef(secretName).
 		WithObjects(secret).
@@ -254,6 +258,7 @@ func TestAuditbeatConfig(t *testing.T) {
 		WithType(auditbeat.Type).
 		WithKibanaRef(kbBuilder.Ref()).
 		WithRoles(beat.AutodiscoverClusterRoleName).
+		WithOpenShiftRoles(test.UseSCCRole).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithESValidations(
 			beat.HasEventFromBeat(auditbeat.Type),
@@ -280,6 +285,7 @@ func TestPacketbeatConfig(t *testing.T) {
 		WithType(packetbeat.Type).
 		WithKibanaRef(kbBuilder.Ref()).
 		WithRoles(beat.AutodiscoverClusterRoleName).
+		WithOpenShiftRoles(test.UseSCCRole).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithESValidations(
 			beat.HasEventFromBeat(packetbeat.Type),
@@ -311,6 +317,7 @@ func TestJournalbeatConfig(t *testing.T) {
 	jbBuilder := beat.NewBuilder(name).
 		WithType(journalbeat.Type).
 		WithRoles(beat.AutodiscoverClusterRoleName).
+		WithOpenShiftRoles(test.UseSCCRole).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithESValidations(
 			beat.HasEventFromBeat(journalbeat.Type),

--- a/test/e2e/beat/recipes_test.go
+++ b/test/e2e/beat/recipes_test.go
@@ -71,6 +71,7 @@ func TestFilebeatAutodiscoverByMetadataRecipe(t *testing.T) {
 	customize := func(builder beat.Builder) beat.Builder {
 		return builder.
 			WithRoles(beat.AutodiscoverClusterRoleName).
+			WithOpenShiftRoles(test.UseSCCRole).
 			WithESValidations(
 				beat.HasEventFromPod(podLabel.Name),
 				beat.HasMessageContaining(goodLog),

--- a/test/e2e/beat/setup_test.go
+++ b/test/e2e/beat/setup_test.go
@@ -46,6 +46,7 @@ func TestBeatKibanaRefWithTLSDisabled(t *testing.T) {
 	fbBuilder := beat.NewBuilder(name).
 		WithType(filebeat.Type).
 		WithRoles(beat.AutodiscoverClusterRoleName).
+		WithOpenShiftRoles(test.UseSCCRole).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithKibanaRef(kbBuilder.Ref())
 
@@ -74,6 +75,7 @@ func TestBeatKibanaRef(t *testing.T) {
 	fbBuilder := beat.NewBuilder(name).
 		WithType(filebeat.Type).
 		WithRoles(beat.AutodiscoverClusterRoleName).
+		WithOpenShiftRoles(test.UseSCCRole).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithKibanaRef(kbBuilder.Ref())
 
@@ -82,6 +84,7 @@ func TestBeatKibanaRef(t *testing.T) {
 	mbBuilder := beat.NewBuilder(name).
 		WithType(metricbeat.Type).
 		WithRoles(beat.AutodiscoverClusterRoleName).
+		WithOpenShiftRoles(test.UseSCCRole).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithKibanaRef(kbBuilder.Ref()).
 		WithRoles(beat.MetricbeatClusterRoleName)
@@ -90,6 +93,7 @@ func TestBeatKibanaRef(t *testing.T) {
 
 	hbBuilder := beat.NewBuilder(name).
 		WithType(heartbeat.Type).
+		WithOpenShiftRoles(test.UseSCCRole).
 		WithDeployment().
 		WithElasticsearchRef(esBuilder.Ref())
 

--- a/test/e2e/beat/upgrade_test.go
+++ b/test/e2e/beat/upgrade_test.go
@@ -37,6 +37,7 @@ func TestBeatVersionUpgradeToLatest7x(t *testing.T) {
 
 	fbBuilder := beat.NewBuilder(name).
 		WithRoles(beat.AutodiscoverClusterRoleName).
+		WithOpenShiftRoles(test.UseSCCRole).
 		WithType(filebeat.Type).
 		WithDeploymentStrategy(appsv1.DeploymentStrategy{
 			Type: appsv1.RecreateDeploymentStrategyType,
@@ -76,6 +77,7 @@ func TestVersionUpgradeToLatest8x(t *testing.T) {
 
 	fbBuilder := beat.NewBuilder(name).
 		WithRoles(beat.AutodiscoverClusterRoleName).
+		WithOpenShiftRoles(test.UseSCCRole).
 		WithType(filebeat.Type).
 		WithDeploymentStrategy(appsv1.DeploymentStrategy{
 			Type: appsv1.RecreateDeploymentStrategyType,

--- a/test/e2e/test/agent/builder.go
+++ b/test/e2e/test/agent/builder.go
@@ -352,6 +352,13 @@ func (b Builder) WithPodTemplateServiceAccount(name string) Builder {
 	return b
 }
 
+func (b Builder) WithOpenShiftRoles(clusterRoleNames ...string) Builder {
+	if !test.Ctx().OcpCluster {
+		return b
+	}
+	return b.WithRoles(clusterRoleNames...)
+}
+
 func (b Builder) WithRoles(clusterRoleNames ...string) Builder {
 	resultBuilder := b
 	for _, clusterRoleName := range clusterRoleNames {
@@ -395,28 +402,6 @@ func bind(b Builder, clusterRoleName string) Builder {
 	}
 
 	b.AdditionalObjects = append(b.AdditionalObjects, crb)
-
-	if test.Ctx().OcpCluster {
-		// Allow Agent Pods to use the custom privileged SCC defined in config/e2e/scc.yaml
-		sccRoleBinding := &rbacv1.ClusterRoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf("%s-%s-binding", "use-scc-eck-e2e", b.Agent.Name),
-			},
-			Subjects: []rbacv1.Subject{
-				{
-					Kind:      "ServiceAccount",
-					Name:      saName,
-					Namespace: b.Agent.Namespace,
-				},
-			},
-			RoleRef: rbacv1.RoleRef{
-				APIGroup: rbacv1.GroupName,
-				Kind:     "ClusterRole",
-				Name:     "use-scc-eck-e2e",
-			},
-		}
-		b.AdditionalObjects = append(b.AdditionalObjects, sccRoleBinding)
-	}
 
 	return b
 }

--- a/test/e2e/test/agent/builder.go
+++ b/test/e2e/test/agent/builder.go
@@ -396,6 +396,28 @@ func bind(b Builder, clusterRoleName string) Builder {
 
 	b.AdditionalObjects = append(b.AdditionalObjects, crb)
 
+	if test.Ctx().OcpCluster {
+		// Allow Agent Pods to use the custom privileged SCC defined in config/e2e/scc.yaml
+		sccRoleBinding := &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("%s-%s-binding", "use-scc-eck-e2e", b.Agent.Name),
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      saName,
+					Namespace: b.Agent.Namespace,
+				},
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: rbacv1.GroupName,
+				Kind:     "ClusterRole",
+				Name:     "use-scc-eck-e2e",
+			},
+		}
+		b.AdditionalObjects = append(b.AdditionalObjects, sccRoleBinding)
+	}
+
 	return b
 }
 

--- a/test/e2e/test/beat/builder.go
+++ b/test/e2e/test/beat/builder.go
@@ -260,6 +260,28 @@ func bind(b Builder, clusterRoleName string) Builder {
 
 	b.AdditionalObjects = append(b.AdditionalObjects, crb)
 
+	if test.Ctx().OcpCluster {
+		// Allow Beat Pods to use the custom privileged SCC defined in config/e2e/scc.yaml
+		sccRoleBinding := &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("%s-%s-binding", "use-scc-eck-e2e", b.Beat.Name),
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      saName,
+					Namespace: b.Beat.Namespace,
+				},
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: rbacv1.GroupName,
+				Kind:     "ClusterRole",
+				Name:     "use-scc-eck-e2e",
+			},
+		}
+		b.AdditionalObjects = append(b.AdditionalObjects, sccRoleBinding)
+	}
+
 	return b
 }
 

--- a/test/e2e/test/scc.go
+++ b/test/e2e/test/scc.go
@@ -1,0 +1,9 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package test
+
+const (
+	UseSCCRole = "use-scc-eck-e2e"
+)


### PR DESCRIPTION
Follow up of https://github.com/elastic/cloud-on-k8s/pull/8343

This PR restricts the use of our privileged custom SCC to specific service accounts only:

```
(⎈|admin:michael-e2e-mercury)➜ k get pods -o go-template='{{- range .items -}}{{ .metadata.name }} is using SCC {{index .metadata.annotations "openshift.io/scc"}}{{printf "\n"}}{{- end -}}'
test-agent-fleet-6tqg-es-masterdata-1 is using SCC restricted-v2
test-agent-fleet-6tqg-es-masterdata-2 is using SCC restricted-v2
test-agent-fleet-ea-s4rp-agent-nblkj is using SCC eck-e2e
test-agent-fleet-ea-s4rp-agent-t5phl is using SCC eck-e2e
test-agent-fleet-ea-s4rp-agent-zxz8n is using SCC eck-e2e
test-agent-fleet-t5bh-kb-77544484c7-ms6zp is using SCC restricted-v2
```