### PR TITLE
Small UX improvement during Fleet setup

### DIFF
--- a/pkg/controller/agent/driver.go
+++ b/pkg/controller/agent/driver.go
@@ -21,7 +21,6 @@ import (
 	commonassociation "github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/association"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/defaults"
-	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/events"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/operator"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/tracing"
@@ -136,12 +135,6 @@ func internalReconcile(params Params) (*reconciler.Results, agentv1alpha1.AgentS
 
 	fleetToken := maybeReconcileFleetEnrollment(params, results)
 	if results.HasRequeue() || results.HasError() {
-		if results.HasRequeue() {
-			// we requeue if Kibana is unavailable: surface this condition to the user
-			message := "Delaying deployment of Elastic Agent in Fleet Mode as Kibana is not available yet"
-			params.Logger().Info(message)
-			params.EventRecorder.Event(&params.Agent, corev1.EventTypeWarning, events.EventReasonDelayed, message)
-		}
 		return results, params.Status
 	}
 

--- a/pkg/controller/agent/fleet.go
+++ b/pkg/controller/agent/fleet.go
@@ -238,6 +238,8 @@ func maybeReconcileFleetEnrollment(params Params, result *reconciler.Results) En
 		return EnrollmentAPIKey{}
 	}
 
+	log := params.Logger()
+
 	reachable, err := isKibanaReachable(params.Context, params.Client, params.Agent.Spec.KibanaRef.WithDefaultNamespace(params.Agent.Namespace).NamespacedName())
 	if err != nil {
 		result.WithError(err)
@@ -246,7 +248,7 @@ func maybeReconcileFleetEnrollment(params Params, result *reconciler.Results) En
 	if !reachable {
 		// we requeue if Kibana is unavailable: surface this condition to the user
 		message := "Delaying deployment of Elastic Agent in Fleet Mode as Kibana is not available yet"
-		params.Logger().Info(message)
+		log.Info(message)
 		params.EventRecorder.Event(&params.Agent, corev1.EventTypeWarning, events.EventReasonDelayed, message)
 		result.WithResult(reconcile.Result{Requeue: true})
 		return EnrollmentAPIKey{}
@@ -263,18 +265,18 @@ func maybeReconcileFleetEnrollment(params Params, result *reconciler.Results) En
 		newFleetAPI(
 			params.OperatorParams.Dialer,
 			kbConnectionSettings,
-			params.Logger()),
+			log),
 	)
 	switch {
 	case commonhttp.IsUnauthorized(err):
 		message := "ECK cannot setup Fleet enrollment. Waiting for Kibana credentials. This should be a transient issue."
-		params.Logger().V(1).Info(err.Error())
-		params.Logger().Info(message)
+		log.V(1).Info(err.Error())
+		log.Info(message)
 		params.EventRecorder.Event(&params.Agent, corev1.EventTypeWarning, events.EventReasonDelayed, message)
 		result.WithResult(reconcile.Result{Requeue: true})
 	case commonhttp.IsNotFound(err):
 		message := fmt.Sprintf("ECK cannot setup Fleet enrollment. This is likely a mis-configuration. %s", err.Error())
-		params.Logger().Info(message)
+		log.Info(message)
 		params.EventRecorder.Event(&params.Agent, corev1.EventTypeWarning, events.EventReasonUnexpected, message)
 		result.WithResult(reconcile.Result{Requeue: true})
 	case err != nil:


### PR DESCRIPTION
This tries to address some long-standing UX issues with the Fleet setup in ECK: 
* clearer error messages 
* distinguish transient errors (e.g. user creation) from actual misconfigurations
* provide more context from HTTP error responses to narrow down the root cause in case of actual user error

Transient error (401) during user creation is communicated as such in the event
```
26m Warning Delayed agent/fleet-server ECK cannot setup Fleet enrollment. Waiting for Kibana credentials. This should be a transient issue.
```
In addition adds a debug log statment in the operator logs. The intent here is to allow debugging persistent 401 errors that are not related to propagation delays in k8s secrets and ES hot-reloading the credentials: 
```
2024-12-19T12:37:15.924+0100	DEBUG	agent-controller	failed to request https://kibana-kb-http.default.svc:5601/api/fleet/setup, status is 401, [security_exception
	Root causes:
		security_exception: unable to authenticate user [default-elastic-agent-agent-kb-user] for REST request [/_security/_authenticate]]: unable to authenticate user [default-elastic-agent-agent-kb-user] for REST request [/_security/_authenticate]	{"service.version": "2.17.0-SNAPSHOT+fc606c33", "iteration": "225", "namespace": "default", "agent_name": "elastic-agent"}
```


Persistent 404 error (here incorrect policyID)  with additional context in the k8s event and log statement 
```
16m Warning Unexpected agent/fleet-server ECK cannot setup Fleet enrollment. This is likely a mis-configuration. failed to request https://kibana-kb-http.default.svc:5601/api/fleet/enrollment_api_keys, status is 404, Agent policy "eck-fleet-server-policy" not found
```