### PR TITLE
[2.6] [2.15] Update 'current' volume-claim-template link to be version specific. (#8349)

### DIFF
--- a/docs/operating-eck/eck-permissions.asciidoc
+++ b/docs/operating-eck/eck-permissions.asciidoc
@@ -61,7 +61,7 @@ These permissions are needed by the Service Account that ECK operator runs as.
 |Pod||no|Assuring expected Pods presence during Elasticsearch reconciliation, safely deleting Pods during configuration changes and validating `podTemplate` by dry-run creation of Pods.
 |Endpoint||no|Checking availability of service endpoints.
 |Event||no|Emitting events concerning reconciliation progress and issues.
-|PersistentVolumeClaim||no|Expanding existing volumes. Check link:https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-volume-claim-templates.html#k8s_updating_the_volume_claim_settings[docs] to learn more.
+|PersistentVolumeClaim||no|Expanding existing volumes. Check link:https://www.elastic.co/guide/en/cloud-on-k8s/{eck_release_branch}/k8s-volume-claim-templates.html#k8s_updating_the_volume_claim_settings[docs] to learn more.
 |Secret||no|Reading/writing configuration, passwords, certificates, and so on.
 |Service||no|Creating Services fronting Elastic Stack applications.
 |ConfigMap||no|Reading/writing configuration.
@@ -69,7 +69,7 @@ These permissions are needed by the Service Account that ECK operator runs as.
 |Deployment|apps|no|Deploying Kibana, APM Server, EnterpriseSearch, Maps, Beats or Elastic Agent.
 |DaemonSet|apps|no|Deploying Beats or Elastic Agent.
 |PodDisruptionBudget|policy|no|Ensuring update safety for Elasticsearch. Check link:https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-pod-disruption-budget.html[docs] to learn more.
-|StorageClass|storage.k8s.io|yes|Validating storage expansion support. Check link:https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-volume-claim-templates.html#k8s_updating_the_volume_claim_settings[docs] to learn more.
+|StorageClass|storage.k8s.io|yes|Validating storage expansion support. Check link:https://www.elastic.co/guide/en/cloud-on-k8s/{eck_release_branch}/k8s-volume-claim-templates.html#k8s_updating_the_volume_claim_settings[docs] to learn more.
 |coreauthorization.k8s.io|SubjectAccessReview|yes|Controlling access between referenced resources. Check link:https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-restrict-cross-namespace-associations.html[docs] to learn more.
 |===
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `2.15` to `2.6`:
 - [[2.15] Update &#x27;current&#x27; volume-claim-template link to be version specific. (#8349)](https://github.com/elastic/cloud-on-k8s/pull/8349)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)