### PR TITLE
[E2E][OCP] Set privileged SCC to additional Agents and Beats instances

### DIFF
--- a/test/e2e/agent/config_test.go
+++ b/test/e2e/agent/config_test.go
@@ -105,6 +105,7 @@ func TestMultipleOutputConfig(t *testing.T) {
 			agent.ToOutput(esBuilder1.Ref(), "default"),
 			agent.ToOutput(esBuilder2.Ref(), "monitoring"),
 		).
+		WithOpenShiftRoles(test.UseSCCRole).
 		WithESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default"), "monitoring").
 		WithESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.filebeat", "default"), "monitoring").
 		WithESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default"), "monitoring").

--- a/test/e2e/agent/config_test.go
+++ b/test/e2e/agent/config_test.go
@@ -34,6 +34,7 @@ func TestSystemIntegrationConfig(t *testing.T) {
 
 	agentBuilder := agent.NewBuilder(name).
 		WithElasticsearchRefs(agent.ToOutput(esBuilder.Ref(), "default")).
+		WithOpenShiftRoles(test.UseSCCRole).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.filebeat", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default")).
@@ -73,6 +74,7 @@ func TestAgentConfigRef(t *testing.T) {
 		WithConfigRef(secretName).
 		WithObjects(secret).
 		WithElasticsearchRefs(agent.ToOutput(esBuilder.Ref(), "default")).
+		WithOpenShiftRoles(test.UseSCCRole).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.filebeat", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default")).

--- a/test/e2e/beat/config_test.go
+++ b/test/e2e/beat/config_test.go
@@ -117,6 +117,7 @@ func TestHeartbeatConfig(t *testing.T) {
 		WithType(heartbeat.Type).
 		WithDeployment().
 		WithElasticsearchRef(esBuilder.Ref()).
+		WithOpenShiftRoles(test.UseSCCRole).
 		WithESValidations(
 			beat.HasEventFromBeat(heartbeat.Type),
 			beat.HasEvent("monitor.status:up"))

--- a/test/e2e/global_ca_test.go
+++ b/test/e2e/global_ca_test.go
@@ -59,7 +59,8 @@ func TestGlobalCA(t *testing.T) {
 	testPod := beat.NewPodBuilder(name)
 	agent := elasticagent.NewBuilder(name).
 		WithElasticsearchRefs(elasticagent.ToOutput(es.Ref(), "default")).
-		WithDefaultESValidation(elasticagent.HasWorkingDataStream(elasticagent.LogsType, "elastic_agent", "default"))
+		WithDefaultESValidation(elasticagent.HasWorkingDataStream(elasticagent.LogsType, "elastic_agent", "default")).
+		WithOpenShiftRoles(test.UseSCCRole)
 	agent = elasticagent.ApplyYamls(t, agent, e2e_agent.E2EAgentSystemIntegrationConfig, e2e_agent.E2EAgentSystemIntegrationPodTemplate)
 	ls := logstash.NewBuilder(name).
 		WithNodeCount(1).

--- a/test/e2e/global_ca_test.go
+++ b/test/e2e/global_ca_test.go
@@ -63,6 +63,7 @@ func TestGlobalCA(t *testing.T) {
 		WithOpenShiftRoles(test.UseSCCRole)
 	agent = elasticagent.ApplyYamls(t, agent, e2e_agent.E2EAgentSystemIntegrationConfig, e2e_agent.E2EAgentSystemIntegrationPodTemplate)
 	ls := logstash.NewBuilder(name).
+		WithRestrictedSecurityContext().
 		WithNodeCount(1).
 		WithElasticsearchRefs(
 			logstashv1alpha1.ElasticsearchCluster{

--- a/test/e2e/logstash/keystore_test.go
+++ b/test/e2e/logstash/keystore_test.go
@@ -169,7 +169,7 @@ filter {
 					},
 				},
 			},
-		})
+		}).WithRestrictedSecurityContext()
 
 	steps := test.StepsFunc(func(k *test.K8sClient) test.StepList {
 		return test.StepList{

--- a/test/e2e/logstash/logstash_test.go
+++ b/test/e2e/logstash/logstash_test.go
@@ -41,7 +41,7 @@ func TestLogstashWithEnv(t *testing.T) {
 					},
 				},
 			},
-		})
+		}).WithRestrictedSecurityContext()
 	test.Sequence(nil, test.EmptySteps, logstashBuilder).RunSequential(t)
 }
 

--- a/test/e2e/logstash/stack_monitoring_test.go
+++ b/test/e2e/logstash/stack_monitoring_test.go
@@ -116,7 +116,8 @@ func TestLogstashResolvingDollarVariableInStackMonitoring(t *testing.T) {
 			"api.auth.basic.username":   "${API_USERNAME}",
 			"api.auth.basic.password":   "${API_PASSWORD}",
 		}).
-		WithExpectedAPIServer(configs.APIServer{Username: username, Password: password})
+		WithExpectedAPIServer(configs.APIServer{Username: username, Password: password}).
+		WithRestrictedSecurityContext()
 
 	// checks that the sidecar beats have sent data in the monitoring clusters
 	// check config secret has correct API_KEYSTORE_PASS value

--- a/test/e2e/stack_test.go
+++ b/test/e2e/stack_test.go
@@ -60,12 +60,13 @@ func initialBuildersToUpgrade(t *testing.T, initialVersion string) ([]test.Build
 	ent := enterprisesearch.NewBuilder("ent").
 		WithNodeCount(1).
 		WithVersion(initialVersion). // pre 8.x doesn't require any config, but we change the version after calling
-		WithoutConfig().             // NewBuilder which relies on the version from test.Ctx(), so removing config here
+		WithoutConfig(). // NewBuilder which relies on the version from test.Ctx(), so removing config here
 		WithElasticsearchRef(esRef).
 		WithRestrictedSecurityContext()
 	fb := beat.NewBuilder("fb").
 		WithType(filebeat.Type).
 		WithRoles(beat.AutodiscoverClusterRoleName).
+		WithOpenShiftRoles(test.UseSCCRole).
 		WithVersion(initialVersion).
 		WithElasticsearchRef(esRef).
 		WithKibanaRef(kbRef)
@@ -97,8 +98,8 @@ func TestVersionUpgradeOrdering(t *testing.T) {
 }
 
 func TestVersionUpgradeOrderingWithLogstash(t *testing.T) {
-	initialVersion := "8.6.0"
-	initialBuilders, updatedBuilders, stackVersions := initialBuildersToUpgrade(t, "8.6.0")
+	initialVersion := "8.12.0"
+	initialBuilders, updatedBuilders, stackVersions := initialBuildersToUpgrade(t, initialVersion)
 
 	ls := logstash.NewBuilder("ls").WithVersion(initialVersion).
 		WithElasticsearchRefs(

--- a/test/e2e/stack_test.go
+++ b/test/e2e/stack_test.go
@@ -102,6 +102,7 @@ func TestVersionUpgradeOrderingWithLogstash(t *testing.T) {
 	initialBuilders, updatedBuilders, stackVersions := initialBuildersToUpgrade(t, initialVersion)
 
 	ls := logstash.NewBuilder("ls").WithVersion(initialVersion).
+		WithRestrictedSecurityContext().
 		WithElasticsearchRefs(
 			// associate logstash to the es ref stored in the stackVersions
 			logstashv1alpha1.ElasticsearchCluster{

--- a/test/e2e/test/logstash/builder.go
+++ b/test/e2e/test/logstash/builder.go
@@ -51,6 +51,7 @@ func newBuilder(name, randSuffix string) Builder {
 			},
 		},
 	}.
+		WithRestrictedSecurityContext().
 		WithSuffix(randSuffix).
 		WithLabel(run.TestNameLabel, name).
 		WithPodLabel(run.TestNameLabel, name).


### PR DESCRIPTION
Follow up of https://github.com/elastic/cloud-on-k8s/pull/8348

I missed some Agent and Beat instances in the first PR.

Created as a draft, still processing the logs of the failed tests...