### PR TITLE
Adjust machine type for ocp ci tests.

### DIFF
--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -95,7 +95,7 @@ plans:
   clusterName: ci
   clientVersion: 4.17.0
   provider: ocp
-  machineType: n1-standard-8
+  machineType: n1-highmem-8
   serviceAccount: true
   ocp:
     region: europe-west6

--- a/test/e2e/logstash/logstash_test.go
+++ b/test/e2e/logstash/logstash_test.go
@@ -19,6 +19,7 @@ import (
 func TestSingleLogstash(t *testing.T) {
 	name := "test-single-logstash"
 	logstashBuilder := logstash.NewBuilder(name).
+		WithOpenShiftRoles(test.UseSCCRole).
 		WithNodeCount(1)
 	test.Sequence(nil, test.EmptySteps, logstashBuilder).RunSequential(t)
 }


### PR DESCRIPTION
From ocp tests: `0/6 nodes are available: 3 Insufficient memory`
Test: TestCustomHTTPCA

Do we want to try adjusting to 
```
-  machineType: n1-standard-8
+  machineType: n1-highmem-8
```

Which is `$0.548` vs `$0.44` and goes from 30GB to 52GB ram.