### PR TITLE
Add additional volume for Kibana logs when hardened security context is enabled

### DIFF
--- a/pkg/controller/kibana/driver_test.go
+++ b/pkg/controller/kibana/driver_test.go
@@ -532,6 +532,12 @@ func expectedDeploymentParams() deployment.Params {
 						},
 					},
 					{
+						Name: "kibana-logs",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
+						},
+					},
+					{
 						Name: "kibana-plugins",
 						VolumeSource: corev1.VolumeSource{
 							EmptyDir: &corev1.EmptyDirVolumeSource{},
@@ -587,6 +593,11 @@ func expectedDeploymentParams() deployment.Params {
 							MountPath: DataVolumeMountPath,
 						},
 						{
+							Name:      "kibana-logs",
+							ReadOnly:  falseVal,
+							MountPath: "/usr/share/kibana/logs",
+						},
+						{
 							Name:      "kibana-plugins",
 							ReadOnly:  falseVal,
 							MountPath: "/usr/share/kibana/plugins",
@@ -631,6 +642,11 @@ func expectedDeploymentParams() deployment.Params {
 							Name:      DataVolumeName,
 							ReadOnly:  falseVal,
 							MountPath: DataVolumeMountPath,
+						},
+						{
+							Name:      "kibana-logs",
+							ReadOnly:  falseVal,
+							MountPath: "/usr/share/kibana/logs",
 						},
 						{
 							Name:      "kibana-plugins",

--- a/pkg/controller/kibana/pod.go
+++ b/pkg/controller/kibana/pod.go
@@ -55,7 +55,7 @@ var (
 	// the Kibana pod has readOnlyRootFilesystem set to true.
 	PluginsVolume = volume.NewEmptyDirVolume(PluginsVolumeName, PluginsVolumeMountPath)
 
-	// LogsVolume can be used to persist logs after installation when
+	// LogsVolume can be used to persist logs even when
 	// the Kibana pod has readOnlyRootFilesystem set to true.
 	LogsVolume = volume.NewEmptyDirVolume(LogsVolumeName, LogsVolumeMountPath)
 

--- a/pkg/controller/kibana/pod.go
+++ b/pkg/controller/kibana/pod.go
@@ -55,7 +55,7 @@ var (
 	// the Kibana pod has readOnlyRootFilesystem set to true.
 	PluginsVolume = volume.NewEmptyDirVolume(PluginsVolumeName, PluginsVolumeMountPath)
 
-	// LogsVolume can be used to persist logs after installation via an init container when
+	// LogsVolume can be used to persist logs after installation when
 	// the Kibana pod has readOnlyRootFilesystem set to true.
 	LogsVolume = volume.NewEmptyDirVolume(LogsVolumeName, LogsVolumeMountPath)
 

--- a/pkg/controller/kibana/pod.go
+++ b/pkg/controller/kibana/pod.go
@@ -35,6 +35,8 @@ const (
 	DataVolumeMountPath          = "/usr/share/kibana/data"
 	PluginsVolumeName            = "kibana-plugins"
 	PluginsVolumeMountPath       = "/usr/share/kibana/plugins"
+	LogsVolumeName               = "kibana-logs"
+	LogsVolumeMountPath          = "/usr/share/kibana/logs"
 	TempVolumeName               = "temp-volume"
 	TempVolumeMountPath          = "/tmp"
 	KibanaBasePathEnvName        = "SERVER_BASEPATH"
@@ -52,6 +54,10 @@ var (
 	// PluginsVolume can be used to persist plugins after installation via an init container when
 	// the Kibana pod has readOnlyRootFilesystem set to true.
 	PluginsVolume = volume.NewEmptyDirVolume(PluginsVolumeName, PluginsVolumeMountPath)
+
+	// LogsVolume can be used to persist logs after installation via an init container when
+	// the Kibana pod has readOnlyRootFilesystem set to true.
+	LogsVolume = volume.NewEmptyDirVolume(LogsVolumeName, LogsVolumeMountPath)
 
 	// TempVolume can be used for some reporting features when the Kibana pod has
 	// readOnlyRootFilesystem set to true.
@@ -143,8 +149,9 @@ func NewPodTemplateSpec(
 	if v.GTE(version.From(7, 10, 0)) && setDefaultSecurityContext {
 		builder.WithContainersSecurityContext(defaultSecurityContext).
 			WithPodSecurityContext(defaultPodSecurityContext).
-			WithVolumes(TempVolume.Volume()).WithVolumeMounts(TempVolume.VolumeMount()).
-			WithVolumes(PluginsVolume.Volume()).WithVolumeMounts(PluginsVolume.VolumeMount())
+			WithVolumes(LogsVolume.Volume()).WithVolumeMounts(LogsVolume.VolumeMount()).
+			WithVolumes(PluginsVolume.Volume()).WithVolumeMounts(PluginsVolume.VolumeMount()).
+			WithVolumes(TempVolume.Volume()).WithVolumeMounts(TempVolume.VolumeMount())
 	}
 
 	if keystore != nil {

--- a/pkg/controller/kibana/pod_test.go
+++ b/pkg/controller/kibana/pod_test.go
@@ -219,9 +219,9 @@ func TestNewPodTemplateSpec(t *testing.T) {
 			}},
 			assertions: func(pod corev1.PodTemplateSpec) {
 				assert.Len(t, pod.Spec.InitContainers, 1)
-				assert.Len(t, pod.Spec.InitContainers[0].VolumeMounts, 5)
-				assert.Len(t, pod.Spec.Volumes, 3)
-				assert.Len(t, GetKibanaContainer(pod.Spec).VolumeMounts, 3)
+				assert.Len(t, pod.Spec.InitContainers[0].VolumeMounts, 6)
+				assert.Len(t, pod.Spec.Volumes, 4)
+				assert.Len(t, GetKibanaContainer(pod.Spec).VolumeMounts, 4)
 				assert.Equal(t, GetKibanaContainer(pod.Spec).SecurityContext, &defaultSecurityContext)
 			},
 		},


### PR DESCRIPTION
related: #8378 

This adds an additional volume to the Kibana pod when the hardened security context is enabled as `readOnlyRootFilesystem` is set to `true`.