### PR TITLE
[E2E] Fix deleteTestResources

### DIFF
--- a/test/e2e/test/utils.go
+++ b/test/e2e/test/utils.go
@@ -189,7 +189,7 @@ func SkipUntilResolution(t *testing.T, knownIssueNumber int) {
 	t.Skipf("Skip until we understand why it is failing, see https://github.com/elastic/cloud-on-k8s/issues/%d", knownIssueNumber)
 }
 
-// This simulates "kubectl delete elastic" in the e2e namespace.
+// deleteTestResources simulates "kubectl delete elastic" in the e2e namespace.
 func deleteTestResources(ctx context.Context) error {
 	cfg, err := config.GetConfig()
 	if err != nil {
@@ -214,8 +214,11 @@ func deleteTestResources(ctx context.Context) error {
 		}
 	}
 
+	dynamicClient, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("while creating dynamic client to delete resources: %v", err)
+	}
 	for _, namespace := range Ctx().Operator.ManagedNamespaces {
-		dynamicClient := dynamic.New(clntset.RESTClient())
 		for gv, resources := range groupVersionToResourceListMap {
 			gvSlice := strings.Split(gv, "/")
 			if len(gvSlice) != 2 {

--- a/test/e2e/test/utils.go
+++ b/test/e2e/test/utils.go
@@ -214,6 +214,7 @@ func deleteTestResources(ctx context.Context) error {
 		}
 	}
 
+	// Dynamic client must be built from the configuration, not by reusing the existing REST client using clntset.RESTClient()
 	dynamicClient, err := dynamic.NewForConfig(cfg)
 	if err != nil {
 		return fmt.Errorf("while creating dynamic client to delete resources: %v", err)

--- a/test/e2e/test/utils.go
+++ b/test/e2e/test/utils.go
@@ -217,7 +217,7 @@ func deleteTestResources(ctx context.Context) error {
 	// Dynamic client must be built from the configuration, not by reusing the existing REST client using clntset.RESTClient()
 	dynamicClient, err := dynamic.NewForConfig(cfg)
 	if err != nil {
-		return fmt.Errorf("while creating dynamic client to delete resources: %v", err)
+		return fmt.Errorf("while creating dynamic client to delete resources: %w", err)
 	}
 	for _, namespace := range Ctx().Operator.ManagedNamespaces {
 		for gv, resources := range groupVersionToResourceListMap {


### PR DESCRIPTION
Creating a dynamic client from `clntset.RESTClient()` does not seem to work.
It was also already reported a while back in https://github.com/openshift/client-go/issues/92#issuecomment-464269221, this PR implements the same fix: using `NewForConfig(cfg)` instead.

Fix https://github.com/elastic/cloud-on-k8s/issues/8391