### PR TITLE
[2.16.1] Bump versions of helm charts

### DIFF
--- a/deploy/eck-operator/Chart.yaml
+++ b/deploy/eck-operator/Chart.yaml
@@ -10,9 +10,9 @@ home: https://github.com/elastic/cloud-on-k8s
 
 type: application
 
-version: 2.16.0
+version: 2.16.1
 
-appVersion: 2.16.0
+appVersion: 2.16.1
 
 kubeVersion: ">=1.21.0-0"
 
@@ -32,5 +32,5 @@ maintainers:
 
 dependencies:
   - name: eck-operator-crds
-    version: 2.16.0
+    version: 2.16.1
     condition: installCRDs

--- a/deploy/eck-operator/charts/eck-operator-crds/Chart.yaml
+++ b/deploy/eck-operator/charts/eck-operator-crds/Chart.yaml
@@ -8,9 +8,9 @@ description: ECK operator Custom Resource Definitions
 
 type: application
 
-version: 2.16.0
+version: 2.16.1
 
-appVersion: 2.16.0
+appVersion: 2.16.1
 
 home: https://github.com/elastic/cloud-on-k8s
 

--- a/deploy/eck-operator/templates/tests/statefulset_test.yaml
+++ b/deploy/eck-operator/templates/tests/statefulset_test.yaml
@@ -8,38 +8,38 @@ tests:
     set:
       config.ubiOnly: true
       image.fips: true
-      image.tag: "2.16.0"
+      image.tag: "2.16.1"
     asserts:
       - template: statefulset.yaml
         equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.elastic.co/eck/eck-operator-ubi-fips:2.16.0"
+          value: "docker.elastic.co/eck/eck-operator-ubi-fips:2.16.1"
   - it: ECK image, no fips, no ubi
     set:
-      image.tag: "2.16.0"
+      image.tag: "2.16.1"
     asserts:
       - template: statefulset.yaml
         equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.elastic.co/eck/eck-operator:2.16.0"
+          value: "docker.elastic.co/eck/eck-operator:2.16.1"
   - it: ECK image, fips, no ubi
     set:
       image.fips: true
-      image.tag: "2.16.0"
+      image.tag: "2.16.1"
     asserts:
       - template: statefulset.yaml
         equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.elastic.co/eck/eck-operator-fips:2.16.0"
+          value: "docker.elastic.co/eck/eck-operator-fips:2.16.1"
   - it: ECK image, no fips, ubi
     set:
       config.ubiOnly: true
-      image.tag: "2.16.0"
+      image.tag: "2.16.1"
     asserts:
       - template: statefulset.yaml
         equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.elastic.co/eck/eck-operator-ubi:2.16.0"
+          value: "docker.elastic.co/eck/eck-operator-ubi:2.16.1"
   - it: should have automount service account tokens set by default
     asserts:
       - template: statefulset.yaml
@@ -75,8 +75,8 @@ tests:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: elastic-operator
-            app.kubernetes.io/version: 2.16.0
-            helm.sh/chart: eck-operator-2.16.0
+            app.kubernetes.io/version: 2.16.1
+            helm.sh/chart: eck-operator-2.16.1
             key2: value2
   - it: should use the specified webhook secret name
     set:


### PR DESCRIPTION
**note this is going into the `2.16.1-wip` branch.**

This also bumps the versions of helm charts (other version bumps were a commit straight to `2.16.1-wip` branch.)

This is the reason https://github.com/elastic/cloud-on-k8s/pull/8408 is failing CI checks.