### PR TITLE
Fix Kibana hardened security context version gate.

### DIFF
--- a/pkg/controller/kibana/initcontainer/configmap.go
+++ b/pkg/controller/kibana/initcontainer/configmap.go
@@ -25,7 +25,7 @@ import (
 )
 
 // HardenedSecurityContextSupportedVersion is the version in which a hardened security context is supported.
-var HardenedSecurityContextSupportedVersion = version.From(7, 9, 0)
+var HardenedSecurityContextSupportedVersion = version.From(7, 10, 0)
 
 // NewScriptsConfigMapVolume creates a new volume for the ConfigMap containing scripts used by the Kibana init container.
 func NewScriptsConfigMapVolume(kbName string) volume.ConfigMapVolume {


### PR DESCRIPTION
There was a typo when defining the version from which a hardened security context is supported in Kibana. The correct version is >= 7.10.

see https://github.com/elastic/cloud-on-k8s/pull/8412#discussion_r1917854173