### PR TITLE
[2.16.1-wip] Fix kibana Hardened Security Context version gate. (#8413)

### DIFF
--- a/pkg/controller/kibana/initcontainer/configmap.go
+++ b/pkg/controller/kibana/initcontainer/configmap.go
@@ -25,7 +25,7 @@ import (
 )
 
 // HardenedSecurityContextSupportedVersion is the version in which a hardened security context is supported.
-var HardenedSecurityContextSupportedVersion = version.From(7, 9, 0)
+var HardenedSecurityContextSupportedVersion = version.From(7, 10, 0)
 
 // NewScriptsConfigMapVolume creates a new volume for the ConfigMap containing scripts used by the Kibana init container.
 func NewScriptsConfigMapVolume(kbName string) volume.ConfigMapVolume {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.16.1-wip`:
 - [Fix kibana Hardened Security Context version gate. (#8413)](https://github.com/elastic/cloud-on-k8s/pull/8413)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)