### PR TITLE
Add support in documentation for k8s 1.32.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Current features:
 
 Supported versions:
 
-*  Kubernetes 1.27-1.31
+*  Kubernetes 1.27-1.32
 *  OpenShift 4.12-4.17
 *  Elasticsearch, Kibana, APM Server: 6.8+, 7.1+, 8+
 *  Enterprise Search: 7.7+, 8+

--- a/docs/supported-versions.asciidoc
+++ b/docs/supported-versions.asciidoc
@@ -1,6 +1,6 @@
 ECK is compatible with:
 
-* Kubernetes 1.27-1.31
+* Kubernetes 1.27-1.32
 * OpenShift 4.12-4.17
 * Google Kubernetes Engine (GKE), Azure Kubernetes Service (AKS), and Amazon Elastic Kubernetes Service (EKS)
 * Helm: 3.2.0+

--- a/hack/operatorhub/templates/csv.tpl
+++ b/hack/operatorhub/templates/csv.tpl
@@ -284,7 +284,7 @@ spec:
     Supported versions:
 
 
-    * Kubernetes 1.27-1.31
+    * Kubernetes 1.27-1.32
 
     * OpenShift 4.12-4.17
 


### PR DESCRIPTION
Do we also want to update this: https://github.com/elastic/cloud-on-k8s/blob/8b2cf421bc370a81d08bf3cd2c605614077824d1/hack/api-docs/config.yaml#L19

And this seems to have been missed in `main`: https://github.com/elastic/cloud-on-k8s/blob/8b2cf421bc370a81d08bf3cd2c605614077824d1/hack/operatorhub/templates/csv.tpl#L287