### PR TITLE
[2.16.1-wip] [2.16.1] Release notes, highlights, known issues (#8412)

### DIFF
--- a/docs/release-notes/2.16.1.asciidoc
+++ b/docs/release-notes/2.16.1.asciidoc
@@ -1,0 +1,25 @@
+:issue: https://github.com/elastic/cloud-on-k8s/issues/
+:pull: https://github.com/elastic/cloud-on-k8s/pull/
+
+[[release-notes-2.16.1]]
+== {n} version 2.16.1
+
+
+[[bug-2.16.1]]
+[float]
+=== Bug fixes
+
+* Add an additional volume for Kibana logs when hardened security context is enabled {pull}8380[#8380]
+* Allow persisting of Kibana plugins when hardened security context is enabled {pull}8389[#8389]
+
+[[security-2.16.1]]
+[float]
+=== Security updates
+
+* Updated golang.org/x/net to mitigate CVE-2024-45338 {pull}8372[#8372]
+
+[[docs-2.16.1]]
+[float]
+=== Documentation improvements
+
+* Update Kubernetes supported versions to 1.27-1.32 {pull}8403[#8403]

--- a/docs/release-notes/highlights-2.16.0.asciidoc
+++ b/docs/release-notes/highlights-2.16.0.asciidoc
@@ -2,6 +2,13 @@
 == 2.16.0 release highlights
 
 [float]
+[id="{p}-2160-known-issues"]
+=== Known issues
+
+- Enabling a Kibana hardened security context (only supported in Kibana 7.10+) as well as enabling Kibana audit logs will cause Kibana to go into a `CrashLoopBackoff` state with the error `read-only file system, open '/usr/share/kibana/logs/audit.log'`.
+- Enabling a Kibana hardened security context (only supported in Kibana 7.10+) as well as utilizing Kibana plugins would cause the plugins to fail to load.
+
+[float]
 [id="{p}-2160-new-and-notable"]
 === New and notable
 

--- a/docs/release-notes/highlights-2.16.1.asciidoc
+++ b/docs/release-notes/highlights-2.16.1.asciidoc
@@ -1,0 +1,12 @@
+[[release-highlights-2.16.1]]
+== 2.16.1 release highlights
+
+[float]
+[id="{p}-2161-new-and-notable"]
+=== Bug fix
+
+This release fixes an issue introduced in ECK 2.16.0 where enabling a Kibana hardened security context as well as enabling Kibana audit logs would cause Kibana to go into a `CrashLoopBackoff` state with the error `read-only file system, open '/usr/share/kibana/logs/audit.log'`.
+
+This release also fixes an additional issue in ECK 2.16.0 where enabling a Kibana hardened security context and utilizing Kibana plugins would cause the plugins to fail to load.
+
+Also refer to <<{p}-2160-known-issues>> for more information.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.16.1-wip`:
 - [[2.16.1] Release notes, highlights, known issues (#8412)](https://github.com/elastic/cloud-on-k8s/pull/8412)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)