### PR TITLE
[2.16.1-wip] Add 2.16.1 release notes/highlights to index. (#8419)

### DIFF
--- a/docs/release-notes/highlights.asciidoc
+++ b/docs/release-notes/highlights.asciidoc
@@ -5,6 +5,7 @@
 --
 This section summarizes the most important changes in each release. For the full list, check <<eck-release-notes>>.
 
+* <<release-highlights-2.16.1>>
 * <<release-highlights-2.16.0>>
 * <<release-highlights-2.15.0>>
 * <<release-highlights-2.14.0>>
@@ -50,6 +51,7 @@ This section summarizes the most important changes in each release. For the full
 
 --
 
+include::highlights-2.16.1.asciidoc[]
 include::highlights-2.16.0.asciidoc[]
 include::highlights-2.15.0.asciidoc[]
 include::highlights-2.14.0.asciidoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.16.1-wip`:
 - [Add 2.16.1 release notes/highlights to index. (#8419)](https://github.com/elastic/cloud-on-k8s/pull/8419)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)