### PR TITLE
[2.16] Add missing release-notes, not only highlights. (#8423)

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -6,6 +6,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-2.16.1>>
 * <<release-notes-2.16.0>>
 * <<release-notes-2.15.0>>
 * <<release-notes-2.14.0>>
@@ -51,6 +52,7 @@ This section summarizes the changes in each release.
 
 --
 
+include::release-notes/2.16.1.asciidoc[]
 include::release-notes/2.16.0.asciidoc[]
 include::release-notes/2.15.0.asciidoc[]
 include::release-notes/2.14.0.asciidoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.16`:
 - [Add dmissing release-notes, not only highlights. (#8423)](https://github.com/elastic/cloud-on-k8s/pull/8423)

<!--- Backport version: 8.9.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)