### PR TITLE
Enable copying of ECK images to Amazon ECR

### DIFF
--- a/.buildkite/pipeline-release.yml
+++ b/.buildkite/pipeline-release.yml
@@ -25,6 +25,18 @@ steps:
                   IMAGES_TAG: "$${BUILDKITE_TAG#v}"
           YAML
 
+      - label: copy images to Amazon ECR
+        if: build.tag =~ /^v[0-9]+\.[0-9]+\.[0-9]+\$/
+        command: |
+          cat <<- YAML | buildkite-agent pipeline upload
+          steps:
+            - trigger: unified-release-copy-elastic-images-to-aws-ecr
+              build:
+                env:
+                  IMAGES_NAMES: "eck/eck-operator,eck/eck-operator-fips,eck/eck-operator-ubi,eck/eck-operator-ubi-fips"
+                  IMAGES_TAG: "$${BUILDKITE_TAG#v}"
+          YAML
+
       - label: ":buildkite: helm charts release"
         if: | # merge-main or tags
           ( build.branch == "main" && build.source != "schedule" )


### PR DESCRIPTION
This change adds copying of ECK images to Amazon ECR to the release pipeline by triggering the `unified-release-copy-elastic-images-to-aws-ecr` pipeline.

Test build :https://buildkite.com/elastic/cloud-on-k8s-operator/builds/9690 from branch [test-unified-release-copy-elastic-images-to-aws-ecr-pipeline](https://github.com/elastic/cloud-on-k8s/compare/test-unified-release-copy-elastic-images-to-aws-ecr-pipeline).

Similar to #6879.