### PR TITLE
Fix unresolved attribute in ECK Quickstart

### DIFF
--- a/docs/quickstart.asciidoc
+++ b/docs/quickstart.asciidoc
@@ -89,7 +89,7 @@ This completes the quickstart of the ECK operator. We recommend continuing to <<
 [id="{p}-deploy-elasticsearch"]
 == Deploy an {es} cluster
 
-To deploy a simple link:{ref}/getting-started.html[{es]}] cluster specification, with one {es} node:
+To deploy a simple link:{ref}/getting-started.html[{es}] cluster specification, with one {es} node:
 
 [source,yaml,subs="attributes,+macros"]
 ----


### PR DESCRIPTION
This fixes a small bug I noticed on the [Deploy an Elasticsearch cluster](https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-deploy-elasticsearch.html) page:


<img width="739" alt="Screenshot 2025-01-24 at 11 02 05 AM" src="https://github.com/user-attachments/assets/5e5b8466-ea8f-4a4c-a10b-909764d7d6dc" />
