### PR TITLE
Tolerate mutation checks failures in TestMutationResizeMemory* tests

### DIFF
--- a/test/e2e/es/mutation_test.go
+++ b/test/e2e/es/mutation_test.go
@@ -108,7 +108,11 @@ func TestMutationResizeMemoryUp(t *testing.T) {
 				corev1.ResourceMemory: resource.MustParse("4Gi"),
 				corev1.ResourceCPU:    resource.MustParse("2"),
 			},
-		}).TolerateMutationChecksFailures()
+		}).
+		// Tolerate mutation check failures as the upgrade can briefly turn the cluster RED
+		// if a node shuts down before a newly created replica completes its initialization.
+		// See https://github.com/elastic/cloud-on-k8s/issues/8267.
+		TolerateMutationChecksFailures()
 
 	RunESMutation(t, b, mutated)
 }
@@ -132,7 +136,11 @@ func TestMutationResizeMemoryDown(t *testing.T) {
 				corev1.ResourceMemory: resource.MustParse("2Gi"),
 				corev1.ResourceCPU:    resource.MustParse("2"),
 			},
-		}).TolerateMutationChecksFailures()
+		}).
+		// Tolerate mutation check failures as the upgrade can briefly turn the cluster RED
+		// if a node shuts down before a newly created replica completes its initialization.
+		// See https://github.com/elastic/cloud-on-k8s/issues/8267.
+		TolerateMutationChecksFailures()
 
 	RunESMutation(t, b, mutated)
 }

--- a/test/e2e/es/mutation_test.go
+++ b/test/e2e/es/mutation_test.go
@@ -108,7 +108,7 @@ func TestMutationResizeMemoryUp(t *testing.T) {
 				corev1.ResourceMemory: resource.MustParse("4Gi"),
 				corev1.ResourceCPU:    resource.MustParse("2"),
 			},
-		})
+		}).TolerateMutationChecksFailures()
 
 	RunESMutation(t, b, mutated)
 }
@@ -132,7 +132,7 @@ func TestMutationResizeMemoryDown(t *testing.T) {
 				corev1.ResourceMemory: resource.MustParse("2Gi"),
 				corev1.ResourceCPU:    resource.MustParse("2"),
 			},
-		})
+		}).TolerateMutationChecksFailures()
 
 	RunESMutation(t, b, mutated)
 }


### PR DESCRIPTION
This allows `TestMutationResizeMemoryUp` and `TestMutationResizeMemoryDown` tests to tolerate 15 (the default value) continuous health checks failures during their mutation, as the upgrade can briefly turn the cluster RED if a node shuts down before a newly created replica completes its initialization.

Relates to https://github.com/elastic/cloud-on-k8s/issues/8267.