### PR TITLE
Refactor container command override for APM server into minimal args

### DIFF
--- a/pkg/controller/apmserver/deployment_test.go
+++ b/pkg/controller/apmserver/deployment_test.go
@@ -154,10 +154,7 @@ func expectedDeploymentParams() testParams {
 						},
 						Name:  apmv1.ApmServerContainerName,
 						Image: "docker.elastic.co/apm/apm-server:1.0.0",
-						Command: []string{
-							"apm-server",
-							"run",
-							"-e",
+						Args: []string{
 							"-c",
 							"config/config-secret/apm-server.yml",
 						},

--- a/pkg/controller/apmserver/pod.go
+++ b/pkg/controller/apmserver/pod.go
@@ -67,10 +67,8 @@ func readinessProbe(tls bool) corev1.Probe {
 	}
 }
 
-var command = []string{
-	"apm-server",
-	"run",
-	"-e", // log to stderr
+var args = []string{
+	// -e flag is implicit in containerised versions of APM server as they start the binary with the --environment=container flag.
 	"-c", "config/config-secret/apm-server.yml",
 }
 
@@ -143,7 +141,7 @@ func newPodSpec(c k8s.Client, as *apmv1.ApmServer, p PodSpecParams) (corev1.PodT
 		WithDockerImage(p.CustomImageName, container.ImageRepository(container.APMServerImage, v)).
 		WithReadinessProbe(readinessProbe(as.Spec.HTTP.TLS.Enabled())).
 		WithPorts(ports).
-		WithCommand(command).
+		WithArgs(args...).
 		WithEnv(env...).
 		WithVolumes(volumes...).
 		WithVolumeMounts(volumeMounts...).

--- a/pkg/controller/apmserver/pod_test.go
+++ b/pkg/controller/apmserver/pod_test.go
@@ -131,7 +131,7 @@ func TestNewPodSpec(t *testing.T) {
 							},
 							ReadinessProbe: &probe,
 							Ports:          []corev1.ContainerPort{{Name: "https", ContainerPort: int32(HTTPPort), Protocol: corev1.ProtocolTCP}},
-							Command:        command,
+							Args:           args,
 							VolumeMounts: []corev1.VolumeMount{
 								configSecretVol.VolumeMount(), configVolume.VolumeMount(), httpCertsSecretVol.VolumeMount(),
 							},


### PR DESCRIPTION
Fixes #8447

We should not need to overide the entrypoint/command for the container. All we need is to configure our custom configuration file. We also do not need the `-e` argument it is implict when `--environment=container`

TODO: 
- [ ] test this with the oldest supported stack version 
- [x] test this with 8.17
- [x] test this with 9.0.0-SNAPSHOT