### PR TITLE
Remove policyID validation

### DIFF
--- a/pkg/apis/agent/v1alpha1/validations.go
+++ b/pkg/apis/agent/v1alpha1/validations.go
@@ -18,7 +18,6 @@ import (
 
 var (
 	defaultChecks = []func(*Agent) field.ErrorList{
-		checkPolicyID,
 		checkNoUnknownFields,
 		checkNameLength,
 		checkSupportedVersion,
@@ -60,20 +59,6 @@ func checkSupportedVersion(a *Agent) field.ErrorList {
 	}
 
 	return commonv1.CheckSupportedStackVersion(a.Spec.Version, version.SupportedAgentVersions)
-}
-
-func checkPolicyID(a *Agent) field.ErrorList {
-	v, err := commonv1.ParseVersion(a.Spec.Version)
-	if err != nil {
-		return err
-	}
-	if v.GTE(MandatoryPolicyIDVersion) && len(a.Spec.PolicyID) == 0 {
-		msg := "Agent policyID is mandatory"
-		return field.ErrorList{
-			field.Required(field.NewPath("spec").Child("policyID"), msg),
-		}
-	}
-	return nil
 }
 
 func checkAtMostOneDeploymentOption(a *Agent) field.ErrorList {

--- a/pkg/apis/agent/v1alpha1/validations_test.go
+++ b/pkg/apis/agent/v1alpha1/validations_test.go
@@ -66,66 +66,6 @@ func Test_checkSupportedVersion(t *testing.T) {
 	}
 }
 
-func Test_checkPolicyID(t *testing.T) {
-	expectedError := field.ErrorList{
-		&field.Error{
-			Type:     field.ErrorTypeRequired,
-			Field:    "spec.policyID",
-			BadValue: "",
-			Detail:   "Agent policyID is mandatory",
-		}}
-	tests := []struct {
-		name    string
-		beat    Agent
-		wantErr field.ErrorList
-	}{
-		{
-			name: "no policyID required for 8.x",
-			beat: Agent{
-				Spec: AgentSpec{
-					Version: "8.5.99",
-				},
-			},
-			wantErr: nil,
-		},
-		{
-			name: "policyID required for 9.x",
-			beat: Agent{
-				Spec: AgentSpec{
-					Version: "9.0.0",
-				},
-			},
-			wantErr: expectedError,
-		},
-		{
-			name: "policyID required for 9.0.0-SNAPSHOT",
-			beat: Agent{
-				Spec: AgentSpec{
-					Version: "9.0.0-SNAPSHOT",
-				},
-			},
-			wantErr: expectedError,
-		},
-		{
-			name: "policyID set for 9.x",
-			beat: Agent{
-				Spec: AgentSpec{
-					Version:  "9.0.0",
-					PolicyID: "foo",
-				},
-			},
-			wantErr: nil,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := checkPolicyID(&tc.beat)
-			assert.Equal(t, tc.wantErr, got)
-		})
-	}
-}
-
 func Test_checkAtMostOneDeploymentOption(t *testing.T) {
 	type args struct {
 		a *Agent


### PR DESCRIPTION
It looks like the removal of the default policy in the Kibana Fleet settings did not make the cut for the 9.0 release https://www.elastic.co/guide/en/kibana/master/fleet-settings-kb.html 

This removes the validation we added and fixes https://github.com/elastic/cloud-on-k8s/issues/8446