### PR TITLE
Check EntSearch version within range

### DIFF
--- a/test/e2e/test/enterprisesearch/builder.go
+++ b/test/e2e/test/enterprisesearch/builder.go
@@ -47,7 +47,7 @@ func (b Builder) DeepCopy() *Builder {
 
 var _ test.Builder = Builder{}
 
-// SkipTest returns true if the version is not  in supported range, or if the version is incompatible with Openshift.
+// SkipTest returns true if the version is not in the supported range, or if the version is incompatible with Openshift.
 func (b Builder) SkipTest() bool {
 	v := version.MustParse(b.EnterpriseSearch.Spec.Version)
 	return version.SupportedEnterpriseSearchVersions.WithinRange(v) != nil ||

--- a/test/e2e/test/enterprisesearch/builder.go
+++ b/test/e2e/test/enterprisesearch/builder.go
@@ -21,7 +21,6 @@ import (
 )
 
 var (
-	minVersion = version.MustParse("7.7.0")
 	// Enterprise Search 7.9 and 7.10 are incompatible with Openshift default SCC due to file permission errors.
 	// See https://github.com/elastic/cloud-on-k8s/issues/3656.
 	ocpIncompatibleVersions = semver.MustParseRange(">=7.9.0 <7.11.0")
@@ -48,11 +47,10 @@ func (b Builder) DeepCopy() *Builder {
 
 var _ test.Builder = Builder{}
 
-// SkipTest returns true if the version is not at least 7.7.0, or if the version is incompatible with Openshift.
+// SkipTest returns true if the version is not  in supported range, or if the version is incompatible with Openshift.
 func (b Builder) SkipTest() bool {
 	v := version.MustParse(b.EnterpriseSearch.Spec.Version)
-	// skip if not at least 7.0
-	return !v.GTE(minVersion) ||
+	return version.SupportedEnterpriseSearchVersions.WithinRange(v) != nil ||
 		// or if incompatible with Openshift
 		isIncompatibleWithOcp(v)
 }


### PR DESCRIPTION
Recent test failures made me realise that the Enterprise search tests should not run at all against 9.0.0 

> 🐞 TestEntSearchAssociation/Creating_Enterprise_Search_should_succeed ~ stack-9-0-0-snap
> 🐞 TestEnterpriseSearchConfigUpdate/Creating_Enterprise_Search_should_succeed ~ stack-9-0-0-snap
> 🐞 TestEnterpriseSearchCrossNSAssociation/Creating_Enterprise_Search_should_succeed ~ stack-9-0-0- snap