### PR TITLE
Move away from deprecated container input

### DIFF
--- a/test/e2e/beat/config_test.go
+++ b/test/e2e/beat/config_test.go
@@ -172,7 +172,10 @@ filebeat:
         default_config:
           paths:
           - /var/log/containers/*${data.kubernetes.container.id}.log
-          type: container
+          type: filestream
+		  parsers:
+		  - container:
+            stream: stdout
         enabled: true
       node: ${NODE_NAME}
       type: kubernetes

--- a/test/e2e/beat/config_test.go
+++ b/test/e2e/beat/config_test.go
@@ -173,8 +173,8 @@ filebeat:
           paths:
           - /var/log/containers/*${data.kubernetes.container.id}.log
           type: filestream
-		  parsers:
-		  - container:
+          parsers:
+          - container:
             stream: stdout
         enabled: true
       node: ${NODE_NAME}


### PR DESCRIPTION
Another test failure in stack 9.0

> 🐞 TestBeatSecureSettings/ES_data_should_pass_validations ~ stack-9-0-0-snap

My theory is that that we are using depracated input that makes this test fail. Testing it out with this PR.