### PR TITLE
Remove remaining references to deprecated container input in Beats

### DIFF
--- a/config/e2e/monitoring.yaml
+++ b/config/e2e/monitoring.yaml
@@ -332,7 +332,7 @@ spec:
           - uptime
         period: 10s
     - name: container-log
-      type: container
+      type: container #TODO migrate to file stream?
       use_output: default
       meta:
         package:

--- a/config/recipes/beats/filebeat_autodiscover.yaml
+++ b/config/recipes/beats/filebeat_autodiscover.yaml
@@ -18,9 +18,17 @@ spec:
           hints:
             enabled: true
             default_config:
-              type: container
+              type: filestream
+              id: kubernetes-container-logs-${data.kubernetes.pod.name}-${data.kubernetes.container.id}
               paths:
               - /var/log/containers/*${data.kubernetes.container.id}.log
+              parsers:
+              - container: ~
+              prospector:
+                scanner:
+                  fingerprint.enabled: true
+                  symlinks: true
+              file_identity.fingerprint: ~
     processors:
     - add_cloud_metadata: {}
     - add_host_metadata: {}

--- a/config/recipes/beats/filebeat_autodiscover_by_metadata.yaml
+++ b/config/recipes/beats/filebeat_autodiscover_by_metadata.yaml
@@ -18,11 +18,27 @@ spec:
       - condition.equals.kubernetes.namespace: log-namespace
         config:
         - paths: ["/var/log/containers/*${data.kubernetes.container.id}.log"]
-          type: container
+          id: kubernetes-container-logs-${data.kubernetes.pod.name}-${data.kubernetes.container.id}
+          type: filestream
+          parsers:
+          - container: ~
+          prospector:
+            scanner:
+              fingerprint.enabled: true
+              symlinks: true
+          file_identity.fingerprint: ~
       - condition.equals.kubernetes.labels.log-label: "true"
         config:
         - paths: ["/var/log/containers/*${data.kubernetes.container.id}.log"]
-          type: container
+          id: kubernetes-container-logs-${data.kubernetes.pod.name}-${data.kubernetes.container.id}
+          type: filestream
+          parsers:
+          - container: ~
+          prospector:
+            scanner:
+              fingerprint.enabled: true
+              symlinks: true
+          file_identity.fingerprint: ~
     processors:
     - add_cloud_metadata: {}
     - add_host_metadata: {}

--- a/config/recipes/beats/filebeat_no_autodiscover.yaml
+++ b/config/recipes/beats/filebeat_no_autodiscover.yaml
@@ -11,9 +11,16 @@ spec:
     name: kibana
   config:
     filebeat.inputs:
-    - type: container
+    - type: filestream
       paths:
       - /var/log/containers/*.log
+      parsers:
+        - container: ~
+      prospector:
+        scanner:
+          fingerprint.enabled: true
+          symlinks: true
+      file_identity.fingerprint: ~
     processors:
     - add_host_metadata: {}
     - add_cloud_metadata: {}

--- a/config/recipes/beats/openshift_monitoring.yaml
+++ b/config/recipes/beats/openshift_monitoring.yaml
@@ -235,9 +235,17 @@ spec:
           hints:
             enabled: true
             default_config:
-              type: container
+              type: filestream
+              id: kubernetes-container-logs-${data.kubernetes.pod.name}-${data.kubernetes.container.id}
               paths:
               - /var/log/containers/*${data.kubernetes.container.id}.log
+              parsers:
+              - container: ~
+              prospector:
+                scanner:
+                  fingerprint.enabled: true
+                  symlinks: true
+              file_identity.fingerprint: ~
     processors:
     - add_cloud_metadata: {}
     - add_host_metadata: {}

--- a/config/recipes/beats/stack_monitoring.yaml
+++ b/config/recipes/beats/stack_monitoring.yaml
@@ -154,9 +154,17 @@ spec:
           hints:
             enabled: true
             default_config:
-              type: container
+              type: filestream
+              id: kubernetes-container-logs-${data.kubernetes.pod.name}-${data.kubernetes.container.id}
               paths:
               - /var/log/containers/*${data.kubernetes.container.id}.log
+              parsers:
+              - container: ~
+              prospector:
+                scanner:
+                  fingerprint.enabled: true
+                  symlinks: true
+              file_identity.fingerprint: ~
     processors:
     - add_cloud_metadata: {}
     - add_host_metadata: {}

--- a/deploy/eck-stack/charts/eck-beats/examples/filebeat_no_autodiscover.yaml
+++ b/deploy/eck-stack/charts/eck-beats/examples/filebeat_no_autodiscover.yaml
@@ -7,9 +7,16 @@ kibanaRef:
   name: eck-kibana
 config:
   filebeat.inputs:
-  - type: container
+  - type: filestream
     paths:
     - /var/log/containers/*.log
+    parsers:
+    - container: ~
+    prospector:
+      scanner:
+        fingerprint.enabled: true
+        symlinks: true
+    file_identity.fingerprint: ~
   processors:
   - add_host_metadata: {}
   - add_cloud_metadata: {}

--- a/deploy/eck-stack/charts/eck-beats/templates/tests/beats-filebeat-example_test.yaml
+++ b/deploy/eck-stack/charts/eck-beats/templates/tests/beats-filebeat-example_test.yaml
@@ -18,7 +18,7 @@ tests:
           value: eck-kibana
       - equal:
           path: spec.config.[filebeat.inputs][0].type
-          value: container
+          value: filestream
       - equal:
           path: spec.config.[filebeat.inputs][0].paths
           value:

--- a/docs/orchestrating-elastic-stack-applications/beat.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/beat.asciidoc
@@ -353,6 +353,7 @@ spec:
             enabled: true
             default_config:
               type: filestream
+              id: kubernetes-container-logs-${data.kubernetes.pod.name}-${data.kubernetes.container.id}
               paths:
               - /var/log/containers/*${data.kubernetes.container.id}.log
               parsers:

--- a/docs/orchestrating-elastic-stack-applications/beat.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/beat.asciidoc
@@ -34,9 +34,16 @@ spec:
     name: quickstart
   config:
     filebeat.inputs:
-    - type: container
+    - type: filestream
       paths:
       - /var/log/containers/*.log
+      parsers:
+        - container: ~
+      prospector:
+        scanner:
+          fingerprint.enabled: true
+          symlinks: true
+      file_identity.fingerprint: ~
   daemonSet:
     podTemplate:
       spec:
@@ -345,9 +352,16 @@ spec:
           hints:
             enabled: true
             default_config:
-              type: container
+              type: filestream
               paths:
               - /var/log/containers/*${data.kubernetes.container.id}.log
+              parsers:
+              - container: ~
+              prospector:
+                scanner:
+                  fingerprint.enabled: true
+                  symlinks: true
+              file_identity.fingerprint: ~
   daemonSet:
     podTemplate:
       spec:

--- a/pkg/apis/common/v1/common.go
+++ b/pkg/apis/common/v1/common.go
@@ -324,9 +324,16 @@ type ConfigSource struct {
 	// stringData:
 	//   beat.yml: |-
 	//     filebeat.inputs:
-	//     - type: container
+	//     - type: filestream
 	//       paths:
 	//       - /var/log/containers/*.log
+	//       parsers:
+	//         - container: ~
+	//       prospector:
+	//         scanner:
+	//           fingerprint.enabled: true
+	//           symlinks: true
+	//       file_identity.fingerprint: ~
 	//       processors:
 	//       - add_kubernetes_metadata:
 	//           node: ${NODE_NAME}

--- a/test/e2e/beat/config.go
+++ b/test/e2e/beat/config.go
@@ -15,9 +15,16 @@ var (
       hints:
         enabled: true
         default_config:
-          type: container
+          type: filestream
           paths:
           - /var/log/containers/*${data.kubernetes.container.id}.log
+        parsers:
+        - container: ~
+        prospector:
+          scanner:
+            fingerprint.enabled: true
+            symlinks: true
+        file_identity.fingerprint: ~
 processors:
 - add_cloud_metadata: {}
 - add_host_metadata: {}

--- a/test/e2e/beat/config.go
+++ b/test/e2e/beat/config.go
@@ -19,13 +19,13 @@ var (
           id: kubernetes-container-logs-${data.kubernetes.pod.name}-${data.kubernetes.container.id}
           paths:
           - /var/log/containers/*${data.kubernetes.container.id}.log
-        parsers:
-        - container: ~
-        prospector:
-          scanner:
-            fingerprint.enabled: true
-            symlinks: true
-        file_identity.fingerprint: ~
+          parsers:
+          - container: ~
+          prospector:
+            scanner:
+              fingerprint.enabled: true
+              symlinks: true
+          file_identity.fingerprint: ~
 processors:
 - add_cloud_metadata: {}
 - add_host_metadata: {}

--- a/test/e2e/beat/config.go
+++ b/test/e2e/beat/config.go
@@ -16,6 +16,7 @@ var (
         enabled: true
         default_config:
           type: filestream
+          id: kubernetes-container-logs-${data.kubernetes.pod.name}-${data.kubernetes.container.id}
           paths:
           - /var/log/containers/*${data.kubernetes.container.id}.log
         parsers:

--- a/test/e2e/beat/config_test.go
+++ b/test/e2e/beat/config_test.go
@@ -212,7 +212,8 @@ filebeat:
           paths:
           - /var/log/containers/*${data.kubernetes.container.id}.log
           type: filestream
-		  parsers:
+          id: kubernetes-container-logs-${data.kubernetes.pod.name}-${data.kubernetes.container.id}
+          parsers:
           - container: ~
           prospector:
             scanner:

--- a/test/e2e/beat/config_test.go
+++ b/test/e2e/beat/config_test.go
@@ -211,7 +211,14 @@ filebeat:
         default_config:
           paths:
           - /var/log/containers/*${data.kubernetes.container.id}.log
-          type: container
+          type: filestream
+		  parsers:
+          - container: ~
+          prospector:
+            scanner:
+              fingerprint.enabled: true
+              symlinks: true
+          file_identity.fingerprint: ~
         enabled: true
       host: ${NODE_NAME}
       type: kubernetes


### PR DESCRIPTION
Follow up to #8455 

Replaces all the references to the container input type with the new syntax based on filestream taken from https://github.com/elastic/beats/pull/36950

~There is one I was not sure about the syntax which is the one in e2e/monitoring which I will need to experiment with a bit.~
I will follow up on the monitoring config in a separate PR. Let's merge this one to get the tests to pass.