### PR TITLE
Adding a note about not using configured component templates from API-created index templates

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/stack-config-policy.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/stack-config-policy.asciidoc
@@ -11,6 +11,8 @@ CAUTION: {role_mappings_warning}
 
 NOTE: This requires a valid Enterprise license or Enterprise trial license. Check <<{p}-licensing,the license documentation>> for more details about managing licenses.
 
+NOTE: Component templates created in configuration policies cannot be referenced from index templates created through the Elasticsearch API currently.
+
 Starting from ECK `2.6.1` and Elasticsearch `8.6.1`, Elastic Stack configuration policies allow you to configure the following settings for Elasticsearch:
 
 - link:https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html#dynamic-cluster-setting[Cluster Settings]


### PR DESCRIPTION
Right now, Elasticsearch does not allow you to pull a component template created in a configuration policy into an index template created through the API. This has the potential to be dangerous to users, so I'm adding a note to the documentation. This will hopefully be fixed in https://github.com/elastic/elasticsearch/issues/118594, and at that point we can change this note to only refer to versions before that one.