### PR TITLE
Logstash e2e: ssl => ssl_enabled and fix supported versions listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Supported versions:
 *  Beats: 7.0+, 8+
 *  Elastic Agent: 7.10+ (standalone), 7.14+, 8+ (Fleet)
 *  Elastic Maps Server: 7.11+, 8+
-*  Logstash 8.7+
+*  Logstash 8.12+
 
 Check the [Quickstart](https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-quickstart.html) to deploy your first cluster with ECK.
 

--- a/docs/supported-versions.asciidoc
+++ b/docs/supported-versions.asciidoc
@@ -9,7 +9,7 @@ ECK is compatible with:
 * Beats: 7.0+, 8+
 * Elastic Agent: 7.10+ (standalone), 7.14+ (Fleet), 8+
 * Elastic Maps Server: 7.11+, 8+
-* Logstash: 8.7+
+* Logstash: 8.12+
 
 ECK should work with all conformant installers as listed in these link:https://github.com/cncf/k8s-conformance/blob/master/faq.md#what-is-a-distribution-hosted-platform-and-an-installer[FAQs]. Distributions include source patches and so may not work as-is with ECK.
 

--- a/hack/operatorhub/templates/csv.tpl
+++ b/hack/operatorhub/templates/csv.tpl
@@ -300,7 +300,7 @@ spec:
 
     * Elastic Maps Server: 7.11+, 8+
 
-    * Logstash 8.7+
+    * Logstash 8.12+
 
 
     ECK should work with all conformant installers as listed in these [FAQs](https://github.com/cncf/k8s-conformance/blob/master/faq.md#what-is-a-distribution-hosted-platform-and-an-installer). Distributions include source patches and so may not work as-is with ECK.

--- a/test/e2e/logstash/es_output_test.go
+++ b/test/e2e/logstash/es_output_test.go
@@ -35,7 +35,6 @@ input { exec { command => 'uptime' interval => 10 } }
 output { 
   elasticsearch {
 	hosts => [ "${PRODUCTION_ES_HOSTS}" ]
-	ssl => true
 	cacert => "${PRODUCTION_ES_SSL_CERTIFICATE_AUTHORITY}"
 	user => "${PRODUCTION_ES_USER}"
 	password => "${PRODUCTION_ES_PASSWORD}"

--- a/test/e2e/logstash/es_output_test.go
+++ b/test/e2e/logstash/es_output_test.go
@@ -35,6 +35,7 @@ input { exec { command => 'uptime' interval => 10 } }
 output { 
   elasticsearch {
 	hosts => [ "${PRODUCTION_ES_HOSTS}" ]
+	ssl_enabled => true
 	cacert => "${PRODUCTION_ES_SSL_CERTIFICATE_AUTHORITY}"
 	user => "${PRODUCTION_ES_USER}"
 	password => "${PRODUCTION_ES_PASSWORD}"


### PR DESCRIPTION
Between 8.7 and 8.8 `ssl` has been renamed to `ssl_enabled` as of 9.0.0 `ssl` is not longer allowed. ~This removes the attribute from the test config as it is implied by the `https` scheme in the hosts URL.~

This updates the property to `ssl_enabled`. Also we do incorrectly state that we support Logstash 8.7+ while in code we exclude anything before 8.12! https://github.com/elastic/cloud-on-k8s/blob/0548959d68de23b7086a56a98bfa8a3876a62a55/pkg/controller/common/version/version.go#L36