### PR TITLE
Logstash: cacert is now ssl_certificate_authorities

### DIFF
--- a/config/samples/logstash/logstash_es.yaml
+++ b/config/samples/logstash/logstash_es.yaml
@@ -28,7 +28,7 @@ spec:
           elasticsearch {
             hosts => [ "${PRODUCTION_ES_HOSTS}" ]
             ssl => true
-            cacert => "${PRODUCTION_ES_SSL_CERTIFICATE_AUTHORITY}"
+            ssl_certificate_authorities => "${PRODUCTION_ES_SSL_CERTIFICATE_AUTHORITY}"
             user => "${PRODUCTION_ES_USER}"
             password => "${PRODUCTION_ES_PASSWORD}"
           } 

--- a/config/samples/logstash/logstash_stackmonitor.yaml
+++ b/config/samples/logstash/logstash_stackmonitor.yaml
@@ -44,7 +44,7 @@ spec:
           elasticsearch {
             hosts => [ "${TEST_ES_HOSTS}" ]
             ssl => true
-            cacert => "${TEST_ES_SSL_CERTIFICATE_AUTHORITY}"
+            ssl_certificate_authorities => "${TEST_ES_SSL_CERTIFICATE_AUTHORITY}"
             user => "${TEST_ES_USER}"
             password => "${TEST_ES_PASSWORD}"
           }

--- a/hack/upgrade-test-harness/testdata/upcoming/stack.yaml
+++ b/hack/upgrade-test-harness/testdata/upcoming/stack.yaml
@@ -92,7 +92,7 @@ spec:
           elasticsearch {
             hosts => [ "${PRODUCTION_ES_HOSTS}" ]
             ssl => true
-            cacert => "${PRODUCTION_ES_SSL_CERTIFICATE_AUTHORITY}"
+            ssl_certificate_authorities => "${PRODUCTION_ES_SSL_CERTIFICATE_AUTHORITY}"
             user => "${PRODUCTION_ES_USER}"
             password => "${PRODUCTION_ES_PASSWORD}"
           } 

--- a/test/e2e/logstash/es_output_test.go
+++ b/test/e2e/logstash/es_output_test.go
@@ -36,7 +36,7 @@ output {
   elasticsearch {
 	hosts => [ "${PRODUCTION_ES_HOSTS}" ]
 	ssl_enabled => true
-	cacert => "${PRODUCTION_ES_SSL_CERTIFICATE_AUTHORITY}"
+	ssl_certificate_authorities => "${PRODUCTION_ES_SSL_CERTIFICATE_AUTHORITY}"
 	user => "${PRODUCTION_ES_USER}"
 	password => "${PRODUCTION_ES_PASSWORD}"
   } 


### PR DESCRIPTION
Follow up to #8460 (I forgot to retest 😞 )

`cacert` has been renamed to `ssl_certificate_authorities` (and it is a list now)