### PR TITLE
Replace obsoleted SSL param in Logstash sample config.

### DIFF
--- a/config/samples/logstash/logstash_es.yaml
+++ b/config/samples/logstash/logstash_es.yaml
@@ -27,7 +27,7 @@ spec:
         output { 
           elasticsearch {
             hosts => [ "${PRODUCTION_ES_HOSTS}" ]
-            ssl => true
+            ssl_enabled => true
             ssl_certificate_authorities => "${PRODUCTION_ES_SSL_CERTIFICATE_AUTHORITY}"
             user => "${PRODUCTION_ES_USER}"
             password => "${PRODUCTION_ES_PASSWORD}"

--- a/config/samples/logstash/logstash_stackmonitor.yaml
+++ b/config/samples/logstash/logstash_stackmonitor.yaml
@@ -43,7 +43,7 @@ spec:
         output {
           elasticsearch {
             hosts => [ "${TEST_ES_HOSTS}" ]
-            ssl => true
+            ssl_enabled => true
             ssl_certificate_authorities => "${TEST_ES_SSL_CERTIFICATE_AUTHORITY}"
             user => "${TEST_ES_USER}"
             password => "${TEST_ES_PASSWORD}"

--- a/hack/upgrade-test-harness/testdata/upcoming/stack.yaml
+++ b/hack/upgrade-test-harness/testdata/upcoming/stack.yaml
@@ -91,7 +91,7 @@ spec:
         output { 
           elasticsearch {
             hosts => [ "${PRODUCTION_ES_HOSTS}" ]
-            ssl => true
+            ssl_enabled => true
             ssl_certificate_authorities => "${PRODUCTION_ES_SSL_CERTIFICATE_AUTHORITY}"
             user => "${PRODUCTION_ES_USER}"
             password => "${PRODUCTION_ES_PASSWORD}"


### PR DESCRIPTION
Replaces obsoleted `ssl` option with `ssl_enabled`  in Logstash sample config.

Fixes: https://github.com/elastic/cloud-on-k8s/issues/8463