### PR TITLE
Fix: Remove empty newline in front of labels (eck-operator)

### DIFF
--- a/deploy/eck-operator/templates/_helpers.tpl
+++ b/deploy/eck-operator/templates/_helpers.tpl
@@ -50,7 +50,7 @@ Selector labels
 {{- define "eck-operator.selectorLabels" -}}
 {{- if .Values.global.manifestGen }}
 control-plane: elastic-operator
-{{- else }}
+{{- else -}}
 app.kubernetes.io/name: {{ include "eck-operator.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to Elastic Cloud on Kubernetes!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? Yes
- Have you followed the [contributor guidelines](https://github.com/elastic/cloud-on-k8s/tree/main/CONTRIBUTING.md)? I hope so
- If you submit code, is your pull request against main? We recommend pull requests against main. We will backport them as needed. Yes


This PR addresses removing extra newline in labels when doing `helm template`:

Before:

```
apiVersion: v1
kind: ServiceAccount
automountServiceAccountToken: true
metadata:
  name: elastic-operator
  namespace: elastic-operator
  labels:

    app.kubernetes.io/name: elastic-operator
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "2.17.0-SNAPSHOT"
    helm.sh/chart: eck-operator-2.17.0-SNAPSHOT
    app.kubernetes.io/managed-by: Helm
```

After my change:

```
apiVersion: v1
kind: ServiceAccount
automountServiceAccountToken: true
metadata:
  name: elastic-operator
  namespace: elastic-operator
  labels:
    app.kubernetes.io/name: elastic-operator
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "2.17.0-SNAPSHOT"
    helm.sh/chart: eck-operator-2.17.0-SNAPSHOT
    app.kubernetes.io/managed-by: Helm
```
