### PR TITLE
Remove ubi suffix for 9.x images

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -322,7 +322,7 @@ func Command() *cobra.Command {
 	cmd.Flags().Bool(
 		operator.UBIOnlyFlag,
 		false,
-		fmt.Sprintf("Use only UBI container images to deploy Elastic Stack applications. UBI images are only available from 7.10.0 onward. Cannot be combined with %s", operator.ContainerSuffixFlag),
+		fmt.Sprintf("Use only UBI container images to deploy Elastic Stack applications. UBI images are only available from 7.10.0 onward. Ignored from 9.x as default images are based on UBI. Cannot be combined with %s", operator.ContainerSuffixFlag),
 	)
 	cmd.Flags().Bool(
 		operator.ValidateStorageClassFlag,

--- a/pkg/controller/common/container/container.go
+++ b/pkg/controller/common/container/container.go
@@ -86,11 +86,9 @@ func ImageRepository(img Image, ver version.Version) string {
 	if useUBISuffix || isOlderMapsServerImg(img, ver) {
 		suffix = getUBISuffix(ver)
 	}
-	// Starting with 9.x ubi is the default for APM server, there's no -ubi image.
+	// Starting with 9.x ubi is the default for all stack images
 	if useUBISuffix && ver.Major >= 9 {
-		if img == APMServerImage {
-			suffix = ""
-		}
+		suffix = ""
 	}
 	// use the global container suffix in non-UBI mode
 	if !useUBISuffix {

--- a/pkg/controller/common/container/container_test.go
+++ b/pkg/controller/common/container/container_test.go
@@ -70,6 +70,14 @@ func TestImageRepository(t *testing.T) {
 			want:       testRegistry + "/elastic/elasticsearch-obi1:42.0.0",
 		},
 		{
+			name:       "Elasticsearch 9 image in ubi mode",
+			image:      ElasticsearchImage,
+			version:    "9.0.0",
+			repository: "elastic",
+			suffix:     "-ubi",
+			want:       testRegistry + "/elastic/elasticsearch:9.0.0",
+		},
+		{
 			name:       "Elasticsearch 8 image in ubi mode",
 			image:      ElasticsearchImage,
 			version:    "8.12.0",


### PR DESCRIPTION
With 9.x release all images should be based off of ubi, so we should no longer need the -ubi suffix