### PR TITLE
update to new monitoring index for kibana and logstash

### DIFF
--- a/test/e2e/test/kibana/builder.go
+++ b/test/e2e/test/kibana/builder.go
@@ -275,6 +275,9 @@ func (b Builder) WithEnv(envVar []corev1.EnvVar) Builder {
 
 func (b Builder) GetMetricsIndexPattern() string {
 	v := version.MustParse(test.Ctx().ElasticStackVersion)
+	if v.GTE(version.MinFor(9, 0, 0)) {
+		return ".monitoring-kibana-9-mb"
+	}
 	if v.GTE(version.MinFor(8, 3, 0)) {
 		return ".monitoring-kibana-8-mb"
 	}

--- a/test/e2e/test/logstash/builder.go
+++ b/test/e2e/test/logstash/builder.go
@@ -188,6 +188,10 @@ func (b Builder) WithLogsMonitoring(logsESRef ...commonv1.ObjectSelector) Builde
 }
 
 func (b Builder) GetMetricsIndexPattern() string {
+	v := version.MustParse(test.Ctx().ElasticStackVersion)
+	if v.GTE(version.MinFor(9, 0, 0)) {
+		return ".monitoring-logstash-9-mb"
+	}
 	return ".monitoring-logstash-8-mb"
 }
 


### PR DESCRIPTION
We have the e2e tests failing because the monitoring index was updated for 9.x release, updating this in our tests.
