### PR TITLE
Support new agent image path as of 9.0

### DIFF
--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -181,7 +181,7 @@ func buildPodTemplate(params Params, fleetCerts *certificates.CertificatesSecret
 	builder = builder.
 		WithLabels(agentLabels).
 		WithAnnotations(annotations).
-		WithDockerImage(spec.Image, container.ImageRepository(container.AgentImage, v)).
+		WithDockerImage(spec.Image, container.ImageRepository(container.AgentImageFor(v), v)).
 		WithAutomountServiceAccountToken().
 		WithVolumeLikes(vols...).
 		WithEnv(

--- a/pkg/controller/common/container/container.go
+++ b/pkg/controller/common/container/container.go
@@ -62,12 +62,20 @@ const (
 	AuditbeatImage        Image = "beats/auditbeat"
 	JournalbeatImage      Image = "beats/journalbeat"
 	PacketbeatImage       Image = "beats/packetbeat"
-	AgentImage            Image = "beats/elastic-agent"
+	AgentImagePre9        Image = "beats/elastic-agent"
+	AgentImage            Image = "elastic-agent/elastic-agent"
 	MapsImage             Image = "elastic-maps-service/elastic-maps-server"
 	LogstashImage         Image = "logstash/logstash"
 )
 
 var MinMapsVersionOnARM = version.MinFor(8, 16, 0)
+
+func AgentImageFor(version version.Version) Image {
+	if version.Major < 9 {
+		return AgentImagePre9
+	}
+	return AgentImage
+}
 
 // ImageRepository returns the full container image name by concatenating the current container registry and the image path with the given version.
 // A UBI suffix (-ubi8 or -ubi suffix depending on the version) is appended to the image name for the maps image,

--- a/pkg/controller/common/container/container_test.go
+++ b/pkg/controller/common/container/container_test.go
@@ -197,3 +197,36 @@ func TestImageRepository(t *testing.T) {
 		})
 	}
 }
+
+func TestAgentImageFor(t *testing.T) {
+	type args struct {
+		version version.Version
+	}
+	tests := []struct {
+		name string
+		args args
+		want Image
+	}{
+		{
+			name: "New default elastic-agent/elastic-agent ",
+			args: args{
+				version: version.MustParse("9.5.0"),
+			},
+			want: "elastic-agent/elastic-agent",
+		},
+		{
+			name: "Legacy image in beats namespace priot to 9.0",
+			args: args{
+				version: version.MustParse("8.0.0"),
+			},
+			want: "beats/elastic-agent",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := AgentImageFor(tt.args.version); got != tt.want {
+				t.Errorf("AgentImageFor() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Takes the agent image part from https://github.com/elastic/cloud-on-k8s/pull/8480. We need this for 3.0/9.0 before the feature freeze. 

Starting with version 9.0 the agent image will be available in its own path in the Elastic container registry and no longer share it with Beats.