### PR TITLE
Bump e2e test memory to 5G

### DIFF
--- a/.buildkite/e2e/pipeline-gen/pipeline.tpl.yaml
+++ b/.buildkite/e2e/pipeline-gen/pipeline.tpl.yaml
@@ -35,7 +35,7 @@ steps:
       {{- end }}
       {{- else }}
       image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:18bfe327
-      memory: "4G"
+      memory: "5G"
       {{- end }}
 
   {{- end }}


### PR DESCRIPTION
In light of recent build failures this PR bumps the memory for the e2e test job to 5G