### PR TITLE
Remove unused MandatoryPolicyIDVersion const

### DIFF
--- a/pkg/apis/agent/v1alpha1/agent_types.go
+++ b/pkg/apis/agent/v1alpha1/agent_types.go
@@ -24,10 +24,6 @@ const (
 	FleetServerServiceAccount commonv1.ServiceAccountName = "fleet-server"
 )
 
-var (
-	MandatoryPolicyIDVersion = version.MustParse("9.0.0-SNAPSHOT")
-)
-
 // AgentSpec defines the desired state of the Agent
 type AgentSpec struct {
 	// Version of the Agent.


### PR DESCRIPTION
I missed this in https://github.com/elastic/cloud-on-k8s/pull/8449