### PR TITLE
add a beats configuration pre 8.10 tests

### DIFF
--- a/test/e2e/beat/config.go
+++ b/test/e2e/beat/config.go
@@ -403,7 +403,7 @@ spec:
 
 // Stack versions 8.0.X to 8.9.X do not support fingerprint identity type
 // Versions 7.17.X and 8.10.X and above support fingerprint identity type
-func supportsFingerprintIdentiy(stackVersion version.Version) bool {
+func supportsFingerprintIdentity(stackVersion version.Version) bool {
 	if stackVersion.LT(version.MinFor(8, 10, 0)) && stackVersion.GTE(version.MinFor(8, 0, 0)) {
 		return false
 	}

--- a/test/e2e/beat/config.go
+++ b/test/e2e/beat/config.go
@@ -403,7 +403,7 @@ spec:
 
 // Stack versions 8.0.X to 8.9.X do not support fingerprint identity type
 // Versions 7.17.X and 8.10.X and above support fingerprint identity type
-func supportsFingerprintIdentity(stackVersion version.Version) bool {
+func SupportsFingerprintIdentity(stackVersion version.Version) bool {
 	if stackVersion.LT(version.MinFor(8, 10, 0)) && stackVersion.GTE(version.MinFor(8, 0, 0)) {
 		return false
 	}

--- a/test/e2e/beat/config.go
+++ b/test/e2e/beat/config.go
@@ -6,6 +6,10 @@
 
 package beat
 
+import (
+	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/version"
+)
+
 var (
 	E2EFilebeatConfig = `filebeat:
   autodiscover:
@@ -396,3 +400,12 @@ spec:
     name: machine-id
 `
 )
+
+// Stack versions 8.0.X to 8.9.X do not support fingerprint identity type
+// Versions 7.17.X and 8.10.X and above support fingerprint identity type
+func supportsFingerprintIdentiy(stackVersion version.Version) bool {
+	if stackVersion.LT(version.MinFor(8, 10, 0)) && stackVersion.GTE(version.MinFor(8, 0, 0)) {
+		return false
+	}
+	return true
+}

--- a/test/e2e/beat/config.go
+++ b/test/e2e/beat/config.go
@@ -30,6 +30,21 @@ processors:
 - add_cloud_metadata: {}
 - add_host_metadata: {}
 `
+	E2EFilebeatConfigPRE810 = `filebeat:
+  autodiscover:
+    providers:
+    - type: kubernetes
+      node: ${NODE_NAME}
+      hints:
+        enabled: true
+        default_config:
+          type: container
+          paths:
+          - /var/log/containers/*${data.kubernetes.container.id}.log
+processors:
+- add_cloud_metadata: {}
+- add_host_metadata: {}
+`
 
 	E2EFilebeatPodTemplate = `spec:
   automountServiceAccountToken: true # some older Beat versions are depending on this settings presence in k8s context

--- a/test/e2e/beat/config_test.go
+++ b/test/e2e/beat/config_test.go
@@ -51,7 +51,7 @@ func TestFilebeatDefaultConfig(t *testing.T) {
 	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
 	// Stack versions 8.0.X to 8.9.X do not support fingerprint identity type
 	// Versions 7.17.X and 8.10.X and above support fingerprint identity type
-	if !supportsFingerprintIdentity(stackVersion) {
+	if !SupportsFingerprintIdentity(stackVersion) {
 		fileBeatConfig = E2EFilebeatConfigPRE810
 	}
 	fbBuilder = beat.ApplyYamls(t, fbBuilder, fileBeatConfig, E2EFilebeatPodTemplate)
@@ -200,7 +200,7 @@ processors:
 	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
 	// Stack versions 8.0.X to 8.9.X do not support fingerprint identity type
 	// Versions 7.17.X and 8.10.X and above support fingerprint identity type
-	if !supportsFingerprintIdentity(stackVersion) {
+	if !SupportsFingerprintIdentity(stackVersion) {
 		config = `
 name: ${AGENT_NAME_VAR}
 filebeat:
@@ -262,7 +262,7 @@ processors:
 	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
 	// Stack versions 8.0.X to 8.9.X do not support fingerprint identity type
 	// Versions 7.17.X and 8.10.X and above support fingerprint identity type
-	if !supportsFingerprintIdentity(stackVersion) {
+	if !SupportsFingerprintIdentity(stackVersion) {
 		config = fmt.Sprintf(`
 name: %s
 filebeat:

--- a/test/e2e/beat/config_test.go
+++ b/test/e2e/beat/config_test.go
@@ -49,8 +49,9 @@ func TestFilebeatDefaultConfig(t *testing.T) {
 	fileBeatConfig := E2EFilebeatConfig
 
 	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
-	// Versions older than 8.10 do not have support for fingerprint file identity type
-	if stackVersion.LT(version.MinFor(8, 10, 0)) && stackVersion.GTE(version.MinFor(8, 0, 0)) {
+	// Stack versions 8.0.X to 8.9.X do not support fingerprint identity type
+	// Versions 7.17.X and 8.10.X and above support fingerprint identity type
+	if !supportsFingerprintIdentiy(stackVersion) {
 		fileBeatConfig = E2EFilebeatConfigPRE810
 	}
 	fbBuilder = beat.ApplyYamls(t, fbBuilder, fileBeatConfig, E2EFilebeatPodTemplate)
@@ -197,8 +198,9 @@ processors:
 `
 
 	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
-	// Versions older than 8.10 do not have support for fingerprint file identity type
-	if stackVersion.LT(version.MinFor(8, 10, 0)) && stackVersion.GTE(version.MinFor(8, 0, 0)) {
+	// Stack versions 8.0.X to 8.9.X do not support fingerprint identity type
+	// Versions 7.17.X and 8.10.X and above support fingerprint identity type
+	if !supportsFingerprintIdentiy(stackVersion) {
 		config = `
 name: ${AGENT_NAME_VAR}
 filebeat:
@@ -258,8 +260,9 @@ processors:
 `, agentName)
 
 	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
-	// Versions older than 8.10 do not have support for fingerprint file identity type
-	if stackVersion.LT(version.MinFor(8, 10, 0)) && stackVersion.GTE(version.MinFor(8, 0, 0)) {
+	// Stack versions 8.0.X to 8.9.X do not support fingerprint identity type
+	// Versions 7.17.X and 8.10.X and above support fingerprint identity type
+	if !supportsFingerprintIdentiy(stackVersion) {
 		config = fmt.Sprintf(`
 name: %s
 filebeat:

--- a/test/e2e/beat/config_test.go
+++ b/test/e2e/beat/config_test.go
@@ -51,7 +51,7 @@ func TestFilebeatDefaultConfig(t *testing.T) {
 	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
 	// Stack versions 8.0.X to 8.9.X do not support fingerprint identity type
 	// Versions 7.17.X and 8.10.X and above support fingerprint identity type
-	if !supportsFingerprintIdentiy(stackVersion) {
+	if !supportsFingerprintIdentity(stackVersion) {
 		fileBeatConfig = E2EFilebeatConfigPRE810
 	}
 	fbBuilder = beat.ApplyYamls(t, fbBuilder, fileBeatConfig, E2EFilebeatPodTemplate)
@@ -200,7 +200,7 @@ processors:
 	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
 	// Stack versions 8.0.X to 8.9.X do not support fingerprint identity type
 	// Versions 7.17.X and 8.10.X and above support fingerprint identity type
-	if !supportsFingerprintIdentiy(stackVersion) {
+	if !supportsFingerprintIdentity(stackVersion) {
 		config = `
 name: ${AGENT_NAME_VAR}
 filebeat:
@@ -262,7 +262,7 @@ processors:
 	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
 	// Stack versions 8.0.X to 8.9.X do not support fingerprint identity type
 	// Versions 7.17.X and 8.10.X and above support fingerprint identity type
-	if !supportsFingerprintIdentiy(stackVersion) {
+	if !supportsFingerprintIdentity(stackVersion) {
 		config = fmt.Sprintf(`
 name: %s
 filebeat:

--- a/test/e2e/beat/setup_test.go
+++ b/test/e2e/beat/setup_test.go
@@ -56,7 +56,7 @@ func TestBeatKibanaRefWithTLSDisabled(t *testing.T) {
 	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
 	// Stack versions 8.0.X to 8.9.X do not support fingerprint identity type
 	// Versions 7.17.X and 8.10.X and above support fingerprint identity type
-	if !supportsFingerprintIdentity(version) {
+	if !SupportsFingerprintIdentity(stackVersion) {
 		fileBeatConfig = E2EFilebeatConfigPRE810
 	}
 
@@ -94,7 +94,7 @@ func TestBeatKibanaRef(t *testing.T) {
 	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
 	// Stack versions 8.0.X to 8.9.X do not support fingerprint identity type
 	// Versions 7.17.X and 8.10.X and above support fingerprint identity type
-	if !supportsFingerprintIdentity(version) {
+	if !SupportsFingerprintIdentity(stackVersion) {
 		fileBeatConfig = E2EFilebeatConfigPRE810
 	}
 

--- a/test/e2e/beat/setup_test.go
+++ b/test/e2e/beat/setup_test.go
@@ -55,7 +55,7 @@ func TestBeatKibanaRefWithTLSDisabled(t *testing.T) {
 
 	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
 	// Versions older than 8.10 do not have support for fingerprint file identity type
-	if stackVersion.LT(version.MinFor(8, 10, 0)) && stackVersion.GTE(version.MinFor(8, 0, 0)) {
+	if !supportsFingerprintIdentity(version) {
 		fileBeatConfig = E2EFilebeatConfigPRE810
 	}
 
@@ -92,7 +92,7 @@ func TestBeatKibanaRef(t *testing.T) {
 
 	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
 	// Versions older than 8.10 do not have support for fingerprint file identity type
-	if stackVersion.LT(version.MinFor(8, 10, 0)) && stackVersion.GTE(version.MinFor(8, 0, 0)) {
+	if !supportsFingerprintIdentity(version) {
 		fileBeatConfig = E2EFilebeatConfigPRE810
 	}
 

--- a/test/e2e/beat/setup_test.go
+++ b/test/e2e/beat/setup_test.go
@@ -54,7 +54,8 @@ func TestBeatKibanaRefWithTLSDisabled(t *testing.T) {
 	fileBeatConfig := E2EFilebeatConfig
 
 	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
-	// Versions older than 8.10 do not have support for fingerprint file identity type
+	// Stack versions 8.0.X to 8.9.X do not support fingerprint identity type
+	// Versions 7.17.X and 8.10.X and above support fingerprint identity type
 	if !supportsFingerprintIdentity(version) {
 		fileBeatConfig = E2EFilebeatConfigPRE810
 	}
@@ -91,7 +92,8 @@ func TestBeatKibanaRef(t *testing.T) {
 	fileBeatConfig := E2EFilebeatConfig
 
 	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
-	// Versions older than 8.10 do not have support for fingerprint file identity type
+	// Stack versions 8.0.X to 8.9.X do not support fingerprint identity type
+	// Versions 7.17.X and 8.10.X and above support fingerprint identity type
 	if !supportsFingerprintIdentity(version) {
 		fileBeatConfig = E2EFilebeatConfigPRE810
 	}

--- a/test/e2e/beat/setup_test.go
+++ b/test/e2e/beat/setup_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/beat/filebeat"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/beat/heartbeat"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/beat/metricbeat"
+	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/v2/test/e2e/test"
 	"github.com/elastic/cloud-on-k8s/v2/test/e2e/test/beat"
 	"github.com/elastic/cloud-on-k8s/v2/test/e2e/test/elasticsearch"
@@ -50,7 +51,15 @@ func TestBeatKibanaRefWithTLSDisabled(t *testing.T) {
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithKibanaRef(kbBuilder.Ref())
 
-	fbBuilder = beat.ApplyYamls(t, fbBuilder, E2EFilebeatConfig, E2EFilebeatPodTemplate)
+	fileBeatConfig := E2EFilebeatConfig
+
+	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
+	// Versions older than 8.10 do not have support for fingerprint file identity type
+	if stackVersion.LT(version.MinFor(8, 10, 0)) && stackVersion.GTE(version.MinFor(8, 0, 0)) {
+		fileBeatConfig = E2EFilebeatConfigPRE810
+	}
+
+	fbBuilder = beat.ApplyYamls(t, fbBuilder, fileBeatConfig, E2EFilebeatPodTemplate)
 
 	dashboardCheck := getDashboardCheck(
 		esBuilder,
@@ -79,7 +88,15 @@ func TestBeatKibanaRef(t *testing.T) {
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithKibanaRef(kbBuilder.Ref())
 
-	fbBuilder = beat.ApplyYamls(t, fbBuilder, E2EFilebeatConfig, E2EFilebeatPodTemplate)
+	fileBeatConfig := E2EFilebeatConfig
+
+	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
+	// Versions older than 8.10 do not have support for fingerprint file identity type
+	if stackVersion.LT(version.MinFor(8, 10, 0)) && stackVersion.GTE(version.MinFor(8, 0, 0)) {
+		fileBeatConfig = E2EFilebeatConfigPRE810
+	}
+
+	fbBuilder = beat.ApplyYamls(t, fbBuilder, fileBeatConfig, E2EFilebeatPodTemplate)
 
 	mbBuilder := beat.NewBuilder(name).
 		WithType(metricbeat.Type).

--- a/test/e2e/stack_test.go
+++ b/test/e2e/stack_test.go
@@ -73,7 +73,7 @@ func initialBuildersToUpgrade(t *testing.T, initialVersion string) ([]test.Build
 
 	stackVersion := version.MustParse(initialVersion)
 	beatsConfig := beattests.E2EFilebeatConfig
-	if stackVersion.LT(version.MustParse("8.10.0")) && stackVersion.GTE(version.MustParse("8.0.0")) {
+	if !supportsFingerprintIdentity(version) {
 		beatsConfig = beattests.E2EFilebeatConfigPRE810
 	}
 	fb = beat.ApplyYamls(t, fb, beatsConfig, beattests.E2EFilebeatPodTemplate)

--- a/test/e2e/stack_test.go
+++ b/test/e2e/stack_test.go
@@ -73,7 +73,7 @@ func initialBuildersToUpgrade(t *testing.T, initialVersion string) ([]test.Build
 
 	stackVersion := version.MustParse(initialVersion)
 	beatsConfig := beattests.E2EFilebeatConfig
-	if !supportsFingerprintIdentity(version) {
+	if !beattests.SupportsFingerprintIdentity(stackVersion) {
 		beatsConfig = beattests.E2EFilebeatConfigPRE810
 	}
 	fb = beat.ApplyYamls(t, fb, beatsConfig, beattests.E2EFilebeatPodTemplate)

--- a/test/e2e/stack_test.go
+++ b/test/e2e/stack_test.go
@@ -60,7 +60,7 @@ func initialBuildersToUpgrade(t *testing.T, initialVersion string) ([]test.Build
 	ent := enterprisesearch.NewBuilder("ent").
 		WithNodeCount(1).
 		WithVersion(initialVersion). // pre 8.x doesn't require any config, but we change the version after calling
-		WithoutConfig(). // NewBuilder which relies on the version from test.Ctx(), so removing config here
+		WithoutConfig().             // NewBuilder which relies on the version from test.Ctx(), so removing config here
 		WithElasticsearchRef(esRef).
 		WithRestrictedSecurityContext()
 	fb := beat.NewBuilder("fb").
@@ -70,7 +70,13 @@ func initialBuildersToUpgrade(t *testing.T, initialVersion string) ([]test.Build
 		WithVersion(initialVersion).
 		WithElasticsearchRef(esRef).
 		WithKibanaRef(kbRef)
-	fb = beat.ApplyYamls(t, fb, beattests.E2EFilebeatConfig, beattests.E2EFilebeatPodTemplate)
+
+	stackVersion := version.MustParse(initialVersion)
+	beatsConfig := beattests.E2EFilebeatConfig
+	if stackVersion.LT(version.MustParse("8.10.0")) && stackVersion.GTE(version.MustParse("8.0.0")) {
+		beatsConfig = beattests.E2EFilebeatConfigPRE810
+	}
+	fb = beat.ApplyYamls(t, fb, beatsConfig, beattests.E2EFilebeatPodTemplate)
 
 	esUpdated := es.WithVersion(test.LatestReleasedVersion8x)
 	kbUpdated := kb.WithVersion(test.LatestReleasedVersion8x)


### PR DESCRIPTION
fingerprint type was only introduced in 8.10, so have a seperate beats configuration for tests prior to that stack version
