### PR TITLE
Fix enterprise search version in chart and other stack versions in readme and operator hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ Supported versions:
 
 *  Kubernetes 1.28-1.32
 *  OpenShift 4.14-4.18
-*  Elasticsearch, Kibana, APM Server: 7.17+, 8+
+*  Elasticsearch, Kibana, APM Server: 7.17+, 8+, 9+
 *  Enterprise Search: 7.7+, 8+
-*  Beats: 7.17+, 8+
-*  Elastic Agent: 7.17+ (standalone), 7.17+, 8+ (Fleet)
-*  Elastic Maps Server: 7.17+, 8+
-*  Logstash 8.12+
+*  Beats: 7.17+, 8+, 9+
+*  Elastic Agent: 7.17+ (standalone), 7.17+, 8+, 9+ (Fleet)
+*  Elastic Maps Server: 7.17+, 8+, 9+
+*  Logstash 8.12+, 9+
 
 Check the [Quickstart](https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-quickstart.html) to deploy your first cluster with ECK.
 

--- a/deploy/eck-stack/charts/eck-enterprise-search/templates/tests/entsearch_test.yaml
+++ b/deploy/eck-stack/charts/eck-enterprise-search/templates/tests/entsearch_test.yaml
@@ -16,7 +16,7 @@ tests:
           value: quickstart-eck-enterprise-search
       - equal:
           path: spec.version
-          value: 9.1.0-SNAPSHOT
+          value: 8.19.0-SNAPSHOT
   - it: name override should work properly
     set:
       nameOverride: override
@@ -84,7 +84,7 @@ tests:
           value: quickstart-eck-enterprise-search
       - equal:
           path: spec.version
-          value: 9.1.0-SNAPSHOT
+          value: 8.19.0-SNAPSHOT
       - equal:
           path: spec.count
           value: 1

--- a/deploy/eck-stack/charts/eck-enterprise-search/values.yaml
+++ b/deploy/eck-stack/charts/eck-enterprise-search/values.yaml
@@ -18,7 +18,7 @@
 
 # Version of Enterprise Search.
 #
-version: 9.1.0-SNAPSHOT
+version: 8.19.0-SNAPSHOT
 
 # Enterprise Search Docker image to deploy
 #

--- a/hack/operatorhub/templates/csv.tpl
+++ b/hack/operatorhub/templates/csv.tpl
@@ -286,21 +286,21 @@ spec:
 
     * Kubernetes 1.28-1.32
 
-    * OpenShift 4.13-4.18
+    * OpenShift 4.14-4.18
 
     * Google Kubernetes Engine (GKE), Azure Kubernetes Service (AKS), and Amazon Elastic Kubernetes Service (EKS)
 
-    * Elasticsearch, Kibana, APM Server: 7.17+, 8+
+    * Elasticsearch, Kibana, APM Server: 7.17+, 8+, 9+
 
     * Enterprise Search: 7.17+, 8+
 
-    * Beats: 7.17+, 8+
+    * Beats: 7.17+, 8+, 9+
 
-    * Elastic Agent: 7.17+, 8+
+    * Elastic Agent: 7.17+, 8+, 9+
 
-    * Elastic Maps Server: 7.17+, 8+
+    * Elastic Maps Server: 7.17+, 8+, 9+
 
-    * Logstash 8.12+
+    * Logstash 8.12+, 9+
 
 
     ECK should work with all conformant installers as listed in these [FAQs](https://github.com/cncf/k8s-conformance/blob/master/faq.md#what-is-a-distribution-hosted-platform-and-an-installer). Distributions include source patches and so may not work as-is with ECK.


### PR DESCRIPTION
Enterprise search  does not have a 9.X version, updating charts and also fixing README to add the correct supported versions
