### PR TITLE
Re-enable 4.12 while Red Hat provides long term support

### DIFF
--- a/hack/operatorhub/config.yaml
+++ b/hack/operatorhub/config.yaml
@@ -41,6 +41,8 @@ packages:
   - outputPath: certified-operators
     packageName: elasticsearch-eck-operator-certified
     distributionChannel: certified-operators
+    # The minimum supported OpenShift version for ECK is 4.14 but we don't want to create unnecessary friction for users
+    # by excluding ECK from the 4.12 Operatorhub catalog as long as 4.12 is still within Red Hat extended maintenance.
     minSupportedOpenshiftVersion: v4.12
     operatorRepo: registry.connect.redhat.com/elastic/eck-operator
     ubiOnly: true

--- a/hack/operatorhub/config.yaml
+++ b/hack/operatorhub/config.yaml
@@ -41,7 +41,7 @@ packages:
   - outputPath: certified-operators
     packageName: elasticsearch-eck-operator-certified
     distributionChannel: certified-operators
-    minSupportedOpenshiftVersion: v4.14
+    minSupportedOpenshiftVersion: v4.12
     operatorRepo: registry.connect.redhat.com/elastic/eck-operator
     ubiOnly: true
     ## digestPinning should only be set to true for certified operator.


### PR DESCRIPTION
Based on https://access.redhat.com/support/policy/updates/openshift#ocp4 4.12 will receive security updates until 2026. While we do not support it anymore officially this changes the OLM config to avoid locking out users of this version from upgrading to 3.0. 

This is to break up a dependency chain where an upgarde to stack 9.0 would be predicated on an upgrade to ECK 3.0 which for users on 4.12 would first require a Kubernetes upgrade. While API compatibility is a concern as 1.25 is officially unsupported from [a Kubernetes point of view](https://kubernetes.io/releases/patch-releases/#non-active-branch-history) there are currently no known technical blockers that prevent ECK 3.0 from running on 1.25 at the users discretion. 

To be clear this does not change our official stance regarding the EOL state of OCP 4.12 it just removes the technical hurdle that would prevent users from running ECK 3.0 on that version. 