### PR TITLE
[3.0] Re-enable 4.12 while Red Hat provides long term support (#8552)

### DIFF
--- a/hack/operatorhub/config.yaml
+++ b/hack/operatorhub/config.yaml
@@ -41,7 +41,9 @@ packages:
   - outputPath: certified-operators
     packageName: elasticsearch-eck-operator-certified
     distributionChannel: certified-operators
-    minSupportedOpenshiftVersion: v4.14
+    # The minimum supported OpenShift version for ECK is 4.14 but we don't want to create unnecessary friction for users
+    # by excluding ECK from the 4.12 Operatorhub catalog as long as 4.12 is still within Red Hat extended maintenance.
+    minSupportedOpenshiftVersion: v4.12
     operatorRepo: registry.connect.redhat.com/elastic/eck-operator
     ubiOnly: true
     ## digestPinning should only be set to true for certified operator.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.0`:
 - [Re-enable 4.12 while Red Hat provides long term support (#8552)](https://github.com/elastic/cloud-on-k8s/pull/8552)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)