### PR TITLE
[3.0] add a beats configuration for pre 8.10 tests (#8541)

### DIFF
--- a/test/e2e/beat/config.go
+++ b/test/e2e/beat/config.go
@@ -6,6 +6,10 @@
 
 package beat
 
+import (
+	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/version"
+)
+
 var (
 	E2EFilebeatConfig = `filebeat:
   autodiscover:
@@ -26,6 +30,21 @@ var (
               fingerprint.enabled: true
               symlinks: true
           file_identity.fingerprint: ~
+processors:
+- add_cloud_metadata: {}
+- add_host_metadata: {}
+`
+	E2EFilebeatConfigPRE810 = `filebeat:
+  autodiscover:
+    providers:
+    - type: kubernetes
+      node: ${NODE_NAME}
+      hints:
+        enabled: true
+        default_config:
+          type: container
+          paths:
+          - /var/log/containers/*${data.kubernetes.container.id}.log
 processors:
 - add_cloud_metadata: {}
 - add_host_metadata: {}
@@ -381,3 +400,12 @@ spec:
     name: machine-id
 `
 )
+
+// Stack versions 8.0.X to 8.9.X do not support fingerprint identity type
+// Versions 7.17.X and 8.10.X and above support fingerprint identity type
+func SupportsFingerprintIdentity(stackVersion version.Version) bool {
+	if stackVersion.LT(version.MinFor(8, 10, 0)) && stackVersion.GTE(version.MinFor(8, 0, 0)) {
+		return false
+	}
+	return true
+}

--- a/test/e2e/beat/config_test.go
+++ b/test/e2e/beat/config_test.go
@@ -46,7 +46,15 @@ func TestFilebeatDefaultConfig(t *testing.T) {
 			beat.HasEventFromPod(testPodBuilder.Pod.Name),
 			beat.HasMessageContaining(testPodBuilder.Logged))
 
-	fbBuilder = beat.ApplyYamls(t, fbBuilder, E2EFilebeatConfig, E2EFilebeatPodTemplate)
+	fileBeatConfig := E2EFilebeatConfig
+
+	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
+	// Stack versions 8.0.X to 8.9.X do not support fingerprint identity type
+	// Versions 7.17.X and 8.10.X and above support fingerprint identity type
+	if !SupportsFingerprintIdentity(stackVersion) {
+		fileBeatConfig = E2EFilebeatConfigPRE810
+	}
+	fbBuilder = beat.ApplyYamls(t, fbBuilder, fileBeatConfig, E2EFilebeatPodTemplate)
 
 	test.Sequence(nil, test.EmptySteps, esBuilder, fbBuilder, testPodBuilder).RunSequential(t)
 }
@@ -189,6 +197,29 @@ processors:
 - add_host_metadata: {}
 `
 
+	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
+	// Stack versions 8.0.X to 8.9.X do not support fingerprint identity type
+	// Versions 7.17.X and 8.10.X and above support fingerprint identity type
+	if !SupportsFingerprintIdentity(stackVersion) {
+		config = `
+name: ${AGENT_NAME_VAR}
+filebeat:
+  autodiscover:
+    providers:
+    - hints:
+        default_config:
+          paths:
+          - /var/log/containers/*${data.kubernetes.container.id}.log
+          type: container
+        enabled: true
+      node: ${NODE_NAME}
+      type: kubernetes
+processors:
+- add_cloud_metadata: {}
+- add_host_metadata: {}
+`
+	}
+
 	fbBuilder = beat.ApplyYamls(t, fbBuilder, config, E2EFilebeatPodTemplate)
 
 	test.Sequence(nil, test.EmptySteps, esBuilder, fbBuilder, testPodBuilder).RunSequential(t)
@@ -227,6 +258,29 @@ processors:
 - add_cloud_metadata: {}
 - add_host_metadata: {}
 `, agentName)
+
+	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
+	// Stack versions 8.0.X to 8.9.X do not support fingerprint identity type
+	// Versions 7.17.X and 8.10.X and above support fingerprint identity type
+	if !SupportsFingerprintIdentity(stackVersion) {
+		config = fmt.Sprintf(`
+name: %s
+filebeat:
+  autodiscover:
+    providers:
+    - hints:
+        default_config:
+          paths:
+          - /var/log/containers/*${data.kubernetes.container.id}.log
+          type: container
+        enabled: true
+      host: ${NODE_NAME}
+      type: kubernetes
+processors:
+- add_cloud_metadata: {}
+- add_host_metadata: {}
+`, agentName)
+	}
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/beat/setup_test.go
+++ b/test/e2e/beat/setup_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/beat/filebeat"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/beat/heartbeat"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/beat/metricbeat"
+	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/v2/test/e2e/test"
 	"github.com/elastic/cloud-on-k8s/v2/test/e2e/test/beat"
 	"github.com/elastic/cloud-on-k8s/v2/test/e2e/test/elasticsearch"
@@ -50,7 +51,16 @@ func TestBeatKibanaRefWithTLSDisabled(t *testing.T) {
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithKibanaRef(kbBuilder.Ref())
 
-	fbBuilder = beat.ApplyYamls(t, fbBuilder, E2EFilebeatConfig, E2EFilebeatPodTemplate)
+	fileBeatConfig := E2EFilebeatConfig
+
+	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
+	// Stack versions 8.0.X to 8.9.X do not support fingerprint identity type
+	// Versions 7.17.X and 8.10.X and above support fingerprint identity type
+	if !SupportsFingerprintIdentity(stackVersion) {
+		fileBeatConfig = E2EFilebeatConfigPRE810
+	}
+
+	fbBuilder = beat.ApplyYamls(t, fbBuilder, fileBeatConfig, E2EFilebeatPodTemplate)
 
 	dashboardCheck := getDashboardCheck(
 		esBuilder,
@@ -79,7 +89,16 @@ func TestBeatKibanaRef(t *testing.T) {
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithKibanaRef(kbBuilder.Ref())
 
-	fbBuilder = beat.ApplyYamls(t, fbBuilder, E2EFilebeatConfig, E2EFilebeatPodTemplate)
+	fileBeatConfig := E2EFilebeatConfig
+
+	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
+	// Stack versions 8.0.X to 8.9.X do not support fingerprint identity type
+	// Versions 7.17.X and 8.10.X and above support fingerprint identity type
+	if !SupportsFingerprintIdentity(stackVersion) {
+		fileBeatConfig = E2EFilebeatConfigPRE810
+	}
+
+	fbBuilder = beat.ApplyYamls(t, fbBuilder, fileBeatConfig, E2EFilebeatPodTemplate)
 
 	mbBuilder := beat.NewBuilder(name).
 		WithType(metricbeat.Type).


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.0`:
 - [add a beats configuration for pre 8.10 tests (#8541)](https://github.com/elastic/cloud-on-k8s/pull/8541)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)