### PR TITLE
[3.0] Validate updates to 9.0 go through 8.18 (#8559)

### DIFF
--- a/pkg/controller/elasticsearch/validation/webhook_test.go
+++ b/pkg/controller/elasticsearch/validation/webhook_test.go
@@ -146,6 +146,54 @@ func Test_validatingWebhook_Handle(t *testing.T) {
 			want: admission.Denied(noDowngradesMsg),
 		},
 		{
+			name: "reject invalid update (from 8.9.0 to 9.0.0))",
+			fields: fields{
+				client: k8s.NewFakeClient(),
+			},
+			args: args{
+				req: admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Update,
+					OldObject: runtime.RawExtension{
+						Raw: asJSON(&esv1.Elasticsearch{
+							ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "name"},
+							Spec:       esv1.ElasticsearchSpec{Version: "8.9.1", NodeSets: []esv1.NodeSet{{Name: "set1", Count: 3}}},
+						}),
+					},
+					Object: runtime.RawExtension{
+						Raw: asJSON(&esv1.Elasticsearch{
+							ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "name"},
+							Spec:       esv1.ElasticsearchSpec{Version: "9.0.0", NodeSets: []esv1.NodeSet{{Name: "set1", Count: 3}}},
+						}),
+					},
+				}},
+			},
+			want: admission.Denied(unsupportedUpgradeMsg),
+		},
+		{
+			name: "accept valid update (from 8.18.0 to 9.0.0))",
+			fields: fields{
+				client: k8s.NewFakeClient(),
+			},
+			args: args{
+				req: admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Update,
+					OldObject: runtime.RawExtension{
+						Raw: asJSON(&esv1.Elasticsearch{
+							ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "name"},
+							Spec:       esv1.ElasticsearchSpec{Version: "8.18.0", NodeSets: []esv1.NodeSet{{Name: "set1", Count: 3}}},
+						}),
+					},
+					Object: runtime.RawExtension{
+						Raw: asJSON(&esv1.Elasticsearch{
+							ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "name"},
+							Spec:       esv1.ElasticsearchSpec{Version: "9.0.0", NodeSets: []esv1.NodeSet{{Name: "set1", Count: 3}}},
+						}),
+					},
+				}},
+			},
+			want: admission.Allowed(""),
+		},
+		{
 			name: "accept valid creation with warnings due to deprecated version",
 			fields: fields{
 				client: k8s.NewFakeClient(),

--- a/pkg/controller/elasticsearch/version/supported_versions.go
+++ b/pkg/controller/elasticsearch/version/supported_versions.go
@@ -35,8 +35,8 @@ func technicallySupportedVersions(v version.Version) *version.MinMaxVersion {
 		}
 	case 9:
 		return &version.MinMaxVersion{
-			// 8.16.0 is the lowest version that offers a direct upgrade path to 9.0
-			Min: version.MinFor(8, 16, 0), // allow snapshot builds here for testing
+			// 8.18.0 is the lowest version that offers a direct upgrade path to 9.0
+			Min: version.MinFor(8, 18, 0), // allow snapshot builds here for testing
 			Max: version.MustParse("9.99.99"),
 		}
 	default:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.0`:
 - [Validate updates to 9.0 go through 8.18 (#8559)](https://github.com/elastic/cloud-on-k8s/pull/8559)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)