### PR TITLE
chore(deps): update registry.access.redhat.com/ubi9/ubi-minimal docker tag to v9.5-1741850109 (#8544)

### DIFF
--- a/build/Dockerfile-ubi
+++ b/build/Dockerfile-ubi
@@ -27,7 +27,7 @@ RUN --mount=type=cache,mode=0755,target=/go/pkg/mod \
 
 # ---------------------------------------------
 # Copy the operator binary into a lighter image
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1741599792
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1741850109
 
 # Update the base image packages to the latest versions
 RUN microdnf update --setopt=tsflags=nodocs --assumeyes && microdnf clean all

--- a/hack/deployer/clients/ocp/Dockerfile
+++ b/hack/deployer/clients/ocp/Dockerfile
@@ -12,6 +12,6 @@ RUN curl -fsSLO https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${CLIE
     mv oc /usr/local/bin/oc && \
     rm openshift-client-linux-${CLIENT_VERSION}.tar.gz
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1741599792
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1741850109
 COPY --from=builder /usr/local/bin/openshift-install .
 COPY --from=builder /usr/local/bin/oc .


### PR DESCRIPTION
Backport of #8544 into 3.0

See https://github.com/elastic/cloud-on-k8s/pull/8544#issuecomment-2748598060