### PR TITLE
update 2.x docs about support policy for ingress

### DIFF
--- a/docs/advanced-topics/traffic-splitting.asciidoc
+++ b/docs/advanced-topics/traffic-splitting.asciidoc
@@ -12,6 +12,15 @@ The default Kubernetes service created by ECK, named `<cluster_name>-es-http`, i
 
 As an alternative, you can use features provided by third-party software such as service meshes and ingress controllers to achieve more advanced traffic management configurations. Check the link:{eck_github}/tree/{eck_release_branch}/config/recipes[recipes directory] in the ECK source repository for a few examples. 
 
+[NOTE]
+================================
+**Support Scope for Ingress Controllers**
+
+link:https://kubernetes.io/docs/concepts/services-networking/ingress/[Ingress] is a standard Kubernetes concept. While ECK-managed workloads can be publicly exposed using ingress resources, and we provide link:https://github.com/elastic/cloud-on-k8s/tree/main/config/recipes/[example configurations], setting up an Ingress controller requires in-house Kubernetes expertise.
+
+If ingress configuration is challenging or unsupported in your environment, consider using standard LoadBalancer services as a simpler alternative.
+================================
+
 The service configurations shown in these sections are based on the following Elasticsearch cluster definition:
 
 [source,yaml,subs="attributes"]

--- a/docs/orchestrating-elastic-stack-applications/maps.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/maps.asciidoc
@@ -27,6 +27,15 @@ The following sections describe how to customize an {ems} deployment to suit you
 ** <<{p}-maps-http-disable-tls,Disable TLS>>
 ** <<{p}-maps-ingress>>
 
+[NOTE]
+================================
+**Support Scope for Ingress Controllers**
+
+link:https://kubernetes.io/docs/concepts/services-networking/ingress/[Ingress] is a standard Kubernetes concept. While ECK-managed workloads can be publicly exposed using ingress resources, and we provide link:https://github.com/elastic/cloud-on-k8s/tree/main/config/recipes/[example configurations], setting up an Ingress controller requires in-house Kubernetes expertise.
+
+If ingress configuration is challenging or unsupported in your environment, consider using standard LoadBalancer services as a simpler alternative.
+================================
+
 [id="{p}-maps-es"]
 == Deploy Elastic Maps Server
 
@@ -262,3 +271,12 @@ You can disable the generation of the self-signed certificate and hence disable 
 [id="{p}-maps-ingress"]
 ==== Ingress and Kibana configuration
 To use {ems} from your Kibana instances, you need to configure Kibana to fetch maps from your {ems} instance by using the link:https://www.elastic.co/guide/en/kibana/current/maps-connect-to-ems.html#elastic-maps-server-kibana[`map.emsUrl`] configuration key. The value of this setting needs to be the URL where the {ems} instance is reachable from your browser. The certificates presented by {ems} need to be trusted by the browser, and the URL must have the same origin as the URL where your Kibana is hosted to avoid cross origin resource issues. Check the link:{eck_github}/tree/{eck_release_branch}/config/recipes/[recipe section] for an example on how to set this up using an Ingress resource.
+
+[NOTE]
+================================
+**Support Scope for Ingress Controllers**
+
+link:https://kubernetes.io/docs/concepts/services-networking/ingress/[Ingress] is a standard Kubernetes concept. While ECK-managed workloads can be publicly exposed using ingress resources, and we provide link:https://github.com/elastic/cloud-on-k8s/tree/main/config/recipes/[example configurations], setting up an Ingress controller requires in-house Kubernetes expertise.
+
+If ingress configuration is challenging or unsupported in your environment, consider using standard LoadBalancer services as a simpler alternative.
+================================

--- a/docs/orchestrating-elastic-stack-applications/recipes.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/recipes.asciidoc
@@ -18,3 +18,12 @@ This section includes recipes that provide configuration examples for some commo
 * link:https://github.com/elastic/cloud-on-k8s/tree/main/config/recipes/autopilot[Deploy Elasticsearch, Kibana, Elastic Fleet Server and Elastic Agent within GKE Autopilot]
 
 WARNING: Compared to other configuration examples that are consistently tested, like <<{p}-elastic-agent-fleet-configuration-examples,fleet-managed Elastic Agent on ECK>>, <<{p}-elastic-agent-configuration-examples,standalone Elastic Agent on ECK>>, or <<{p}-beat-configuration-examples,Beats on ECK>>, the recipes in this section are not regularly tested by our automation system, and therefore should not be considered to be production-ready. 
+
+[NOTE]
+================================
+**Support Scope for Ingress Controllers**
+
+link:https://kubernetes.io/docs/concepts/services-networking/ingress/[Ingress] is a standard Kubernetes concept. While ECK-managed workloads can be publicly exposed using ingress resources, and we provide link:https://github.com/elastic/cloud-on-k8s/tree/main/config/recipes/[example configurations], setting up an Ingress controller requires in-house Kubernetes expertise.
+
+If ingress configuration is challenging or unsupported in your environment, consider using standard LoadBalancer services as a simpler alternative.
+================================

--- a/docs/orchestrating-elastic-stack-applications/stack-helm-chart.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/stack-helm-chart.asciidoc
@@ -124,6 +124,15 @@ helm install es-quickstart elastic/eck-elasticsearch -n elastic-stack --create-n
 [id="{p}-eck-stack-ingress"]
 === Adding Ingress to the Elastic stack using the Helm Charts
 
+[NOTE]
+================================
+**Support Scope for Ingress Controllers**
+
+link:https://kubernetes.io/docs/concepts/services-networking/ingress/[Ingress] is a standard Kubernetes concept. While ECK-managed workloads can be publicly exposed using ingress resources, and we provide link:https://github.com/elastic/cloud-on-k8s/tree/main/config/recipes/[example configurations], setting up an Ingress controller requires in-house Kubernetes expertise.
+
+If ingress configuration is challenging or unsupported in your environment, consider using standard LoadBalancer services as a simpler alternative.
+================================
+
 Both Elasticsearch and Kibana support Ingress, which can be enabled using the following options:
 
 [source,sh]


### PR DESCRIPTION

<!--
Thank you for your interest in contributing to Elastic Cloud on Kubernetes!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?  => Yes
- Have you followed the [contributor guidelines](https://github.com/elastic/cloud-on-k8s/tree/main/CONTRIBUTING.md)? => Yes
- If you submit code, is your pull request against main? We recommend pull requests against main. We will backport them as needed. => Not a code PR

## Description

- Pairing PR of https://github.com/elastic/docs-content/pull/908.
- Please backport this to 2.16. (Can also be backported to earlier versions, but if it takes time, it's fine to only do it in 2.16)


### Doc pages to update - ECK 2.x

- https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-recipes.html
- https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-traffic-splitting.html
- https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-maps.html
- https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-maps-http-configuration.html#k8s-maps-ingress
- https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-stack-helm-chart.html#k8s-eck-stack-ingress

### Reference pages (already updated) - ECK 3.x

Per https://github.com/elastic/docs-content/pull/908

- https://docs-v3-preview.elastic.dev/elastic/docs-content/tree/main/deploy-manage/deploy/cloud-on-k8s/recipes
- https://docs-v3-preview.elastic.dev/elastic/docs-content/tree/main/deploy-manage/deploy/cloud-on-k8s/requests-routing-to-elasticsearch-nodes
- https://docs-v3-preview.elastic.dev/elastic/docs-content/tree/main/deploy-manage/deploy/cloud-on-k8s/elastic-maps-server
- https://docs-v3-preview.elastic.dev/elastic/docs-content/tree/main/deploy-manage/deploy/cloud-on-k8s/http-configuration#k8s-maps-ingress
- https://docs-v3-preview.elastic.dev/elastic/docs-content/tree/main/deploy-manage/deploy/cloud-on-k8s/managing-deployments-using-helm-chart

### Docs preview

All the docs are added with the same piece of content. 

<img width="775" alt="image" src="https://github.com/user-attachments/assets/db7fa91e-2680-460f-a919-d225858b1406" />

