### PR TITLE
[3.0] Add support for defining dnsPolicy and dnsConfig options for ECK operator statefulset (#7999)

### DIFF
--- a/deploy/eck-operator/templates/statefulset.yaml
+++ b/deploy/eck-operator/templates/statefulset.yaml
@@ -138,7 +138,15 @@ spec:
         {{- end }}
       {{- if .Values.hostNetwork }}
       hostNetwork: true
+      {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
+      {{- else if .Values.hostNetwork }}
       dnsPolicy: ClusterFirstWithHostNet
+      {{- end }}
+      {{- with .Values.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/deploy/eck-operator/templates/tests/statefulset_test.yaml
+++ b/deploy/eck-operator/templates/tests/statefulset_test.yaml
@@ -100,3 +100,46 @@ tests:
         equal:
           path: spec.template.spec.containers[0].env[2].value
           value: my-webhook-server-cert
+  - it: should set dnsPolicy to ClusterFirstWithHostNet when hostNetwork is enabled
+    set:
+      hostNetwork: true
+    asserts:
+      - template: statefulset.yaml
+        equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+      - template: statefulset.yaml
+        equal:
+          path: spec.template.spec.dnsPolicy
+          value: "ClusterFirstWithHostNet"
+  - it: should render dnsPolicy properly when hostNetwork is enabled
+    set:
+      hostNetwork: true
+      dnsPolicy: ClusterFirst
+    asserts:
+      - template: statefulset.yaml
+        equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+      - template: statefulset.yaml
+        equal:
+          path: spec.template.spec.dnsPolicy
+          value: "ClusterFirst"
+  - it: should render dnsPolicy and dnsConfig properly
+    set:
+      dnsPolicy: ClusterFirst
+      dnsConfig:
+        nameservers: "1.2.3.4"
+    asserts:
+      - template: statefulset.yaml
+        equal:
+          path: spec.template.spec.hostNetwork
+          value: null
+      - template: statefulset.yaml
+        equal:
+          path: spec.template.spec.dnsPolicy
+          value: "ClusterFirst"
+      - template: statefulset.yaml
+        equal:
+          path: spec.template.spec.dnsConfig.nameservers
+          value: "1.2.3.4"

--- a/deploy/eck-operator/values.yaml
+++ b/deploy/eck-operator/values.yaml
@@ -148,8 +148,25 @@ webhook:
 
 # hostNetwork allows a Pod to use the Node network namespace.
 # This is required to allow for communication with the kube API when using some alternate CNIs in conjunction with webhook enabled.
+# If hostNetwork is enabled, dnsPolicy defaults to ClusterFirstWithHostNet unless explicitly set.
 # CAUTION: Proceed at your own risk. This setting has security concerns such as allowing malicious users to access workloads running on the host.
 hostNetwork: false
+
+# dnsPolicy defines the DNS policy for the operator pod.
+# Check https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy for more details.
+dnsPolicy: ""
+
+# dnsConfig defines the DNS configuration for the operator pod.
+# Check https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config for more details.
+# dnsConfig:
+#   nameservers:
+#     - 169.254.20.10
+#   searches:
+#     - svc.cluster.local
+#   options:
+#     - name: ndots
+#       value: "2"
+dnsConfig: {}
 
 softMultiTenancy:
   # enabled determines whether the operator is installed with soft multi-tenancy extensions.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.0`:
 - [Add support for defining dnsPolicy and dnsConfig options for ECK operator statefulset (#7999)](https://github.com/elastic/cloud-on-k8s/pull/7999)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)