### PR TITLE
Update aks cluster

### DIFF
--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -69,7 +69,7 @@ plans:
   operation: create
   clusterName: ci
   provider: aks
-  kubernetesVersion: 1.29.2
+  kubernetesVersion: 1.30.10
   machineType: Standard_D8s_v3
   serviceAccount: true
   enforceSecurityPolicies: true
@@ -82,7 +82,7 @@ plans:
   operation: create
   clusterName: dev
   provider: aks
-  kubernetesVersion: 1.29.2
+  kubernetesVersion: 1.30.10
   machineType: Standard_D8s_v3
   serviceAccount: false
   enforceSecurityPolicies: true

--- a/hack/deployer/runner/aks.go
+++ b/hack/deployer/runner/aks.go
@@ -166,7 +166,7 @@ func (d *AKSDriver) create() error {
 		"--name", d.plan.ClusterName, "--location", d.plan.Aks.Location,
 		"--node-count", fmt.Sprintf("%d", d.plan.Aks.NodeCount), "--node-vm-size", d.plan.MachineType,
 		"--kubernetes-version", d.plan.KubernetesVersion,
-		"--node-osdisk-size", "120", "--enable-addons", "http_application_routing", "--output", "none", "--generate-ssh-keys",
+		"--node-osdisk-size", "120", "--output", "none", "--generate-ssh-keys",
 		"--zones", d.plan.Aks.Zones, servicePrincipal,
 		"--tags", strings.Join(toList(elasticTags), " "),
 	).Run()


### PR DESCRIPTION
This PR updates the AKS cluster version and disables the http_application_routing add-on (it's [deprecated](https://learn.microsoft.com/en-us/azure/aks/app-routing-migration) and I'm not sure we actually use it)