### PR TITLE
Use MaxUnavailable for PDB

### DIFF
--- a/pkg/controller/elasticsearch/pdb/reconcile_test.go
+++ b/pkg/controller/elasticsearch/pdb/reconcile_test.go
@@ -40,13 +40,13 @@ func TestReconcile(t *testing.T) {
 				Labels:    map[string]string{label.ClusterNameLabelName: "cluster", commonv1.TypeLabelName: label.Type},
 			},
 			Spec: policyv1.PodDisruptionBudgetSpec{
-				MinAvailable: intStrPtr(intstr.FromInt(3)),
+				MaxUnavailable: intStrPtr(intstr.FromInt(0)),
 				Selector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						label.ClusterNameLabelName: "cluster",
 					},
 				},
-				MaxUnavailable: nil,
+				MinAvailable: nil,
 			},
 		}
 	}
@@ -79,7 +79,7 @@ func TestReconcile(t *testing.T) {
 			wantPDB: defaultPDB(),
 		},
 		{
-			name: "pdb needs a MinAvailable update",
+			name: "pdb doesn't need a MaxUnavailable update",
 			args: args{
 				initObjs:     []client.Object{defaultPDB()},
 				es:           defaultEs,
@@ -92,13 +92,13 @@ func TestReconcile(t *testing.T) {
 					Labels:    map[string]string{label.ClusterNameLabelName: "cluster", commonv1.TypeLabelName: label.Type},
 				},
 				Spec: policyv1.PodDisruptionBudgetSpec{
-					MinAvailable: intStrPtr(intstr.FromInt(5)),
+					MaxUnavailable: intStrPtr(intstr.FromInt(0)),
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
 							label.ClusterNameLabelName: "cluster",
 						},
 					},
-					MaxUnavailable: nil,
+					MinAvailable: nil,
 				},
 			},
 		},
@@ -196,13 +196,13 @@ func Test_expectedPDB(t *testing.T) {
 					Labels:    map[string]string{label.ClusterNameLabelName: "cluster", commonv1.TypeLabelName: label.Type},
 				},
 				Spec: policyv1.PodDisruptionBudgetSpec{
-					MinAvailable: intStrPtr(intstr.FromInt(3)),
+					MaxUnavailable: intStrPtr(intstr.FromInt(0)),
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
 							label.ClusterNameLabelName: "cluster",
 						},
 					},
-					MaxUnavailable: nil,
+					MinAvailable: nil,
 				},
 			},
 		},
@@ -227,13 +227,13 @@ func Test_expectedPDB(t *testing.T) {
 					Labels:    map[string]string{"a": "b", "c": "d", label.ClusterNameLabelName: "cluster", commonv1.TypeLabelName: label.Type},
 				},
 				Spec: policyv1.PodDisruptionBudgetSpec{
-					MinAvailable: intStrPtr(intstr.FromInt(3)),
+					MaxUnavailable: intStrPtr(intstr.FromInt(0)),
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
 							label.ClusterNameLabelName: "cluster",
 						},
 					},
-					MaxUnavailable: nil,
+					MinAvailable: nil,
 				},
 			},
 		},


### PR DESCRIPTION
We should use MaxUnavailable for simplicity.

```
// MaxUnavailable can only be used if the selector matches a builtin controller selector
// (eg. Deployments, StatefulSets, etc.). We cannot use it with our own cluster-name selector.
```

This comment was written by [this reason](https://github.com/elastic/cloud-on-k8s/issues/916#issuecomment-533135010).  According to this, maxUnavailable can be used only when selected pods are managed by only 1 StatefulSet. But it's not true. We can use maxUnavailable for the case multiple StatefulSets are managing selected pods. See [here](https://github.com/kubernetes/kubernetes/blob/v1.32.3/pkg/controller/disruption/disruption.go#L846-L850).

If this change is valid, I will change the document as well.

<!--
Thank you for your interest in contributing to Elastic Cloud on Kubernetes!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/cloud-on-k8s/tree/main/CONTRIBUTING.md)?
- If you submit code, is your pull request against main? We recommend pull requests against main. We will backport them as needed.-->
