### PR TITLE
add 9.0 to the release branch test matrix

### DIFF
--- a/.buildkite/e2e/release-branch-matrix.yaml
+++ b/.buildkite/e2e/release-branch-matrix.yaml
@@ -22,6 +22,7 @@
     - E2E_STACK_VERSION: "8.15.4"
     # current stack version 8.16.x is tested in all other tests no need to test it again
     - E2E_STACK_VERSION: "8.18.0-SNAPSHOT"
+    - E2E_STACK_VERSION: "9.0.0-SNAPSHOT"
 
 - label: kind
   fixed:


### PR DESCRIPTION
We should be testing the 9.0 SNAPSHOT release on the release branch
