### PR TITLE
[DOCS] Updates release notes title

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -1,5 +1,5 @@
 ---
-navigation_title: "Release Notes"
+navigation_title: "Elastic Cloud on Kubernetes"
 mapped_pages:
   - https://www.elastic.co/guide/en/cloud-on-k8s/current/release-highlights.html
   - https://www.elastic.co/guide/en/cloud-on-k8s/current/eck-release-notes.html


### PR DESCRIPTION
Changes `Release Notes` to `Elastic Cloud on Kubernetes` to match the other release notes pages: https://staging-website.elastic.co/docs/release-notes
