### PR TITLE
Add logs volume for file/metricbeat when stack monitoring is enabled with readOnlyRootFilesystem.

### DIFF
--- a/pkg/controller/elasticsearch/nodespec/podspec.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec.go
@@ -134,7 +134,7 @@ func BuildPodTemplateSpec(
 		WithContainersSecurityContext(securitycontext.For(ver, enableReadOnlyRootFilesystem)).
 		WithPreStopHook(*NewPreStopHook())
 
-	builder, err = stackmon.WithMonitoring(ctx, client, builder, es)
+	builder, err = stackmon.WithMonitoring(ctx, client, builder, es, enableReadOnlyRootFilesystem)
 	if err != nil {
 		return corev1.PodTemplateSpec{}, err
 	}

--- a/pkg/controller/elasticsearch/stackmon/__snapshots__/sidecar_test.snap
+++ b/pkg/controller/elasticsearch/stackmon/__snapshots__/sidecar_test.snap
@@ -903,3 +903,240 @@ setup.template.settings:
  }
 }
 ---
+
+[TestWithMonitoring/with_metrics_and_logs_monitoring_and_read_only_root_filesystem - 1]
+{
+ "metadata": {
+  "annotations": {
+   "elasticsearch.k8s.elastic.co/monitoring-config-hash": "1805099278"
+  },
+  "creationTimestamp": null
+ },
+ "spec": {
+  "automountServiceAccountToken": false,
+  "containers": [
+   {
+    "env": [
+     {
+      "name": "ES_LOG_STYLE",
+      "value": "file"
+     }
+    ],
+    "name": "elasticsearch",
+    "resources": {}
+   },
+   {
+    "args": [
+     "-c",
+     "/etc/metricbeat-config/metricbeat.yml",
+     "-e"
+    ],
+    "env": [
+     {
+      "name": "POD_IP",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "status.podIP"
+       }
+      }
+     },
+     {
+      "name": "POD_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.name"
+       }
+      }
+     },
+     {
+      "name": "NODE_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "spec.nodeName"
+       }
+      }
+     },
+     {
+      "name": "NAMESPACE",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.namespace"
+       }
+      }
+     }
+    ],
+    "image": "docker.elastic.co/beats/metricbeat:7.14.0",
+    "name": "metricbeat",
+    "resources": {},
+    "securityContext": {
+     "allowPrivilegeEscalation": false,
+     "capabilities": {
+      "drop": [
+       "ALL"
+      ]
+     },
+     "privileged": false,
+     "readOnlyRootFilesystem": true
+    },
+    "volumeMounts": [
+     {
+      "mountPath": "/etc/metricbeat-config",
+      "name": "sample-metricbeat-config",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/mnt/elastic-internal/es-monitoring-association/observability/monitoring/certs",
+      "name": "es-monitoring-03f555-ca",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/mnt/elastic-internal/es-monitoring/aerospace/sample/certs",
+      "name": "es-monitoring-local-ca",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/usr/share/metricbeat/data",
+      "name": "metricbeat-data"
+     },
+     {
+      "mountPath": "/usr/share/metricbeat/logs",
+      "name": "metricbeat-logs"
+     }
+    ]
+   },
+   {
+    "args": [
+     "-c",
+     "/etc/filebeat-config/filebeat.yml",
+     "-e"
+    ],
+    "env": [
+     {
+      "name": "POD_IP",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "status.podIP"
+       }
+      }
+     },
+     {
+      "name": "POD_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.name"
+       }
+      }
+     },
+     {
+      "name": "NODE_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "spec.nodeName"
+       }
+      }
+     },
+     {
+      "name": "NAMESPACE",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.namespace"
+       }
+      }
+     }
+    ],
+    "image": "docker.elastic.co/beats/filebeat:7.14.0",
+    "name": "filebeat",
+    "resources": {},
+    "securityContext": {
+     "allowPrivilegeEscalation": false,
+     "capabilities": {
+      "drop": [
+       "ALL"
+      ]
+     },
+     "privileged": false,
+     "readOnlyRootFilesystem": true
+    },
+    "volumeMounts": [
+     {
+      "mountPath": "/etc/filebeat-config",
+      "name": "sample-filebeat-config",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/mnt/elastic-internal/es-monitoring-association/observability/monitoring/certs",
+      "name": "es-monitoring-03f555-ca",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/usr/share/filebeat/data",
+      "name": "filebeat-data"
+     },
+     {
+      "mountPath": "/usr/share/filebeat/logs",
+      "name": "filebeat-logs"
+     },
+     {
+      "mountPath": "/usr/share/elasticsearch/logs",
+      "name": "elasticsearch-logs"
+     }
+    ]
+   }
+  ],
+  "volumes": [
+   {
+    "name": "es-monitoring-03f555-ca",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-es-logs-observability-monitoring-ca"
+    }
+   },
+   {
+    "name": "es-monitoring-local-ca",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-es-http-certs-public"
+    }
+   },
+   {
+    "emptyDir": {},
+    "name": "filebeat-data"
+   },
+   {
+    "emptyDir": {},
+    "name": "filebeat-logs"
+   },
+   {
+    "emptyDir": {},
+    "name": "metricbeat-data"
+   },
+   {
+    "emptyDir": {},
+    "name": "metricbeat-logs"
+   },
+   {
+    "name": "sample-filebeat-config",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-es-monitoring-filebeat-config"
+    }
+   },
+   {
+    "name": "sample-metricbeat-config",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-es-monitoring-metricbeat-config"
+    }
+   }
+  ]
+ }
+}
+---

--- a/pkg/controller/kibana/pod.go
+++ b/pkg/controller/kibana/pod.go
@@ -166,7 +166,7 @@ func NewPodTemplateSpec(
 			WithInitContainers(keystore.InitContainer)
 	}
 
-	builder, err = stackmon.WithMonitoring(ctx, client, builder, kb, basePath)
+	builder, err = stackmon.WithMonitoring(ctx, client, builder, kb, basePath, canEnableSecurityContext)
 	if err != nil {
 		return corev1.PodTemplateSpec{}, err
 	}

--- a/pkg/controller/kibana/stackmon/__snapshots__/sidecar_test.snap
+++ b/pkg/controller/kibana/stackmon/__snapshots__/sidecar_test.snap
@@ -807,3 +807,231 @@ processors:
     - add_host_metadata: null
 
 ---
+
+[TestWithMonitoring/with_metrics_and_logs_monitoring_and_read_only_root_filesystem - 1]
+{
+ "metadata": {
+  "annotations": {
+   "kibana.k8s.elastic.co/monitoring-config-hash": "1902028541"
+  },
+  "creationTimestamp": null
+ },
+ "spec": {
+  "automountServiceAccountToken": false,
+  "containers": [
+   {
+    "name": "kibana",
+    "resources": {},
+    "volumeMounts": [
+     {
+      "mountPath": "/usr/share/kibana/logs",
+      "name": "kibana-logs"
+     }
+    ]
+   },
+   {
+    "args": [
+     "-c",
+     "/etc/metricbeat-config/metricbeat.yml",
+     "-e"
+    ],
+    "env": [
+     {
+      "name": "POD_IP",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "status.podIP"
+       }
+      }
+     },
+     {
+      "name": "POD_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.name"
+       }
+      }
+     },
+     {
+      "name": "NODE_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "spec.nodeName"
+       }
+      }
+     },
+     {
+      "name": "NAMESPACE",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.namespace"
+       }
+      }
+     }
+    ],
+    "image": "docker.elastic.co/beats/metricbeat:7.14.0",
+    "name": "metricbeat",
+    "resources": {},
+    "volumeMounts": [
+     {
+      "mountPath": "/etc/metricbeat-config",
+      "name": "sample-metricbeat-config",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/mnt/elastic-internal/kb-monitoring-association/observability/monitoring/certs",
+      "name": "kb-monitoring-03f555-ca",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/mnt/elastic-internal/kb-monitoring/aerospace/sample/certs",
+      "name": "kb-monitoring-local-ca",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/usr/share/metricbeat/data",
+      "name": "metricbeat-data"
+     },
+     {
+      "mountPath": "/usr/share/metricbeat/logs",
+      "name": "metricbeat-logs"
+     }
+    ]
+   },
+   {
+    "args": [
+     "-c",
+     "/etc/filebeat-config/filebeat.yml",
+     "-e"
+    ],
+    "env": [
+     {
+      "name": "POD_IP",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "status.podIP"
+       }
+      }
+     },
+     {
+      "name": "POD_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.name"
+       }
+      }
+     },
+     {
+      "name": "NODE_NAME",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "spec.nodeName"
+       }
+      }
+     },
+     {
+      "name": "NAMESPACE",
+      "valueFrom": {
+       "fieldRef": {
+        "apiVersion": "v1",
+        "fieldPath": "metadata.namespace"
+       }
+      }
+     }
+    ],
+    "image": "docker.elastic.co/beats/filebeat:7.14.0",
+    "name": "filebeat",
+    "resources": {},
+    "volumeMounts": [
+     {
+      "mountPath": "/etc/filebeat-config",
+      "name": "sample-filebeat-config",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/mnt/elastic-internal/kb-monitoring-association/observability/logs/certs",
+      "name": "kb-monitoring-584a4d-ca",
+      "readOnly": true
+     },
+     {
+      "mountPath": "/usr/share/filebeat/data",
+      "name": "filebeat-data"
+     },
+     {
+      "mountPath": "/usr/share/filebeat/logs",
+      "name": "filebeat-logs"
+     },
+     {
+      "mountPath": "/usr/share/kibana/logs",
+      "name": "kibana-logs"
+     }
+    ]
+   }
+  ],
+  "volumes": [
+   {
+    "emptyDir": {},
+    "name": "filebeat-data"
+   },
+   {
+    "emptyDir": {},
+    "name": "filebeat-logs"
+   },
+   {
+    "name": "kb-monitoring-03f555-ca",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-es-monitoring-observability-monitoring-ca"
+    }
+   },
+   {
+    "name": "kb-monitoring-584a4d-ca",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-es-logs-observability-monitoring-ca"
+    }
+   },
+   {
+    "name": "kb-monitoring-local-ca",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-kb-http-certs-public"
+    }
+   },
+   {
+    "emptyDir": {},
+    "name": "kibana-logs"
+   },
+   {
+    "emptyDir": {},
+    "name": "metricbeat-data"
+   },
+   {
+    "emptyDir": {},
+    "name": "metricbeat-logs"
+   },
+   {
+    "name": "sample-filebeat-config",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-kb-monitoring-filebeat-config"
+    }
+   },
+   {
+    "name": "sample-metricbeat-config",
+    "secret": {
+     "optional": false,
+     "secretName": "sample-kb-monitoring-metricbeat-config"
+    }
+   }
+  ]
+ }
+}
+---

--- a/pkg/controller/kibana/stackmon/sidecar_test.go
+++ b/pkg/controller/kibana/stackmon/sidecar_test.go
@@ -93,26 +93,30 @@ var (
 
 func TestWithMonitoring(t *testing.T) {
 	tests := []struct {
-		name string
-		kb   func() kbv1.Kibana
+		name                   string
+		kb                     func() kbv1.Kibana
+		readOnlyRootFilesystem bool
 	}{
 		{
 			name: "without monitoring",
 			kb: func() kbv1.Kibana {
 				return sampleKb
 			},
+			readOnlyRootFilesystem: false,
 		},
 		{
 			name: "with metrics monitoring",
 			kb: func() kbv1.Kibana {
 				return kbFixtureWithMetricsMonitoring(sampleKb, monitoringEsRef, monitoringAssocConf)
 			},
+			readOnlyRootFilesystem: false,
 		},
 		{
 			name: "with logs monitoring",
 			kb: func() kbv1.Kibana {
 				return kbFixtureWithLogsMonitoring(sampleKb, monitoringEsRef, monitoringAssocConf)
 			},
+			readOnlyRootFilesystem: false,
 		},
 		{
 			name: "with metrics and logs monitoring",
@@ -126,6 +130,7 @@ func TestWithMonitoring(t *testing.T) {
 					logsAssocConf,
 				)
 			},
+			readOnlyRootFilesystem: false,
 		},
 		{
 			name: "with metrics and logs monitoring with different es ref",
@@ -139,6 +144,21 @@ func TestWithMonitoring(t *testing.T) {
 					logsAssocConf,
 				)
 			},
+			readOnlyRootFilesystem: false,
+		},
+		{
+			name: "with metrics and logs monitoring and read only root filesystem",
+			kb: func() kbv1.Kibana {
+				return kbFixtureWithLogsMonitoring(
+					kbFixtureWithMetricsMonitoring(
+						sampleKb,
+						monitoringEsRef,
+						monitoringAssocConf),
+					logsEsRef,
+					logsAssocConf,
+				)
+			},
+			readOnlyRootFilesystem: true,
 		},
 	}
 
@@ -146,7 +166,7 @@ func TestWithMonitoring(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			kb := tc.kb()
 			builder := defaults.NewPodTemplateBuilder(corev1.PodTemplateSpec{}, kbv1.KibanaContainerName)
-			_, err := WithMonitoring(context.Background(), fakeClient, builder, kb, "")
+			_, err := WithMonitoring(context.Background(), fakeClient, builder, kb, "", tc.readOnlyRootFilesystem)
 			assert.NoError(t, err)
 
 			actual, err := json.MarshalIndent(builder.PodTemplate, " ", "")


### PR DESCRIPTION
resolves #8605

When `readOnlyRootFilesystem` is enabled for Elasticsearch or Kibana and stack monitoring is enabled both filebeat and metricbeat need an `emptyDir` volume to write logs otherwise they receive an error when attempting to write any logs to their logs directory as can happen when indexing errors occur, and a new event file is attempted to be written.

