### PR TITLE
Add support for missing `remoteClusterServer` value in eck-elasticsea…

### DIFF
--- a/deploy/eck-stack/charts/eck-elasticsearch/templates/elasticsearch.yaml
+++ b/deploy/eck-stack/charts/eck-elasticsearch/templates/elasticsearch.yaml
@@ -40,6 +40,10 @@ spec:
   remoteClusters:
     {{- toYaml . | nindent 2 }}
   {{- end }}
+  {{- with .Values.remoteClusterServer }}
+  remoteClusterServer:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.volumeClaimDeletePolicy }}
   volumeClaimDeletePolicy:
     {{- if and (not (eq . "DeleteOnScaledownOnly")) (not (eq . "DeleteOnScaledownAndClusterDeletion")) }}

--- a/deploy/eck-stack/charts/eck-elasticsearch/templates/tests/elasticsearch_test.yaml
+++ b/deploy/eck-stack/charts/eck-elasticsearch/templates/tests/elasticsearch_test.yaml
@@ -97,6 +97,8 @@ tests:
       - name: cluster-two
         elasticsearchRef:
           name: cluster-two
+      remoteClusterServer:
+        enabled: false
     release:
       name: quickstart
     asserts:
@@ -161,6 +163,11 @@ tests:
           - name: cluster-two
             elasticsearchRef:
               name: cluster-two
+      - equal:
+          path: spec.remoteClusterServer
+          value:
+            enabled:
+              false
   - it: should render node roles properly
     values:
       - ../../examples/hot-warm-cold.yaml

--- a/deploy/eck-stack/charts/eck-elasticsearch/values.yaml
+++ b/deploy/eck-stack/charts/eck-elasticsearch/values.yaml
@@ -119,6 +119,11 @@ remoteClusters: {}
   #     name: cluster-two
   #     namespace: ns-two
 
+# RemoteClusterServer specifies if the remote cluster server should be enabled.
+# This must be enabled if this cluster is a remote cluster which is expected to be accessed using API key authentication.
+#
+remoteClusterServer: {}
+
 # VolumeClaimDeletePolicy sets the policy for handling deletion of PersistentVolumeClaims for all NodeSets.
 # Possible values are DeleteOnScaledownOnly and DeleteOnScaledownAndClusterDeletion.
 # By default, if not set or empty, the operator sets DeleteOnScaledownAndClusterDeletion.


### PR DESCRIPTION
This PR relates to https://github.com/elastic/cloud-on-k8s/pull/8089

While the operator can handle the `remoteClusterServer` value, it is not included in the Helm chart. This PR fixes that issue by adding support for that value in the chart.

<!--
Thank you for your interest in contributing to Elastic Cloud on Kubernetes!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/cloud-on-k8s/tree/main/CONTRIBUTING.md)?
- If you submit code, is your pull request against main? We recommend pull requests against main. We will backport them as needed.
