### PR TITLE
add pre-release flag to container push command in operatorhub

### DIFF
--- a/hack/operatorhub/cmd/container/container.go
+++ b/hack/operatorhub/cmd/container/container.go
@@ -68,6 +68,14 @@ func Command() *cobra.Command {
 		"force will force the attempted pushing of remote images, even when the exact version is found remotely. (OHUB_FORCE)",
 	)
 
+	cmd.PersistentFlags().BoolVarP(
+		&flags.PreRelease,
+		flags.PreReleaseFlag,
+		"P",
+		false,
+		"pre-release will pull eck images from the pre release repository (docker.elastic.co/eck-snapshots)",
+	)
+
 	publishCmd.Flags().DurationVarP(
 		&flags.ScanTimeout,
 		flags.ScanTimeoutFlag,
@@ -104,5 +112,6 @@ func commonConfig() container.CommonConfig {
 		ProjectID:           flags.ProjectID,
 		RedhatCatalogAPIKey: flags.APIKey,
 		RegistryPassword:    flags.RegistryPassword,
+		PreRelease:          flags.PreRelease,
 	}
 }

--- a/hack/operatorhub/cmd/flags/flags.go
+++ b/hack/operatorhub/cmd/flags/flags.go
@@ -35,6 +35,7 @@ const (
 	ProjectIDFlag        = "project-id"
 	ForceFlag            = "force"
 	ScanTimeoutFlag      = "scan-timeout"
+	PreReleaseFlag       = "pre-release"
 
 	// operatorhub command flags
 	YamlManifestFlag = "yaml-manifest"
@@ -57,6 +58,7 @@ var (
 	ProjectID        string
 	Force            bool
 	ScanTimeout      time.Duration
+	PreRelease       bool
 
 	// root command variables
 	ConfigPath        string

--- a/hack/operatorhub/internal/container/container.go
+++ b/hack/operatorhub/internal/container/container.go
@@ -22,6 +22,7 @@ import (
 
 const (
 	eckOperatorFormat              = "docker.elastic.co/eck/eck-operator-ubi:%s"
+	eckOperatorFormatPreRelease    = "docker.elastic.co/eck-snapshots/eck-operator-ubi:%s"
 	registryURL                    = "quay.io"
 	httpAcceptHeader               = "Accept"
 	httpContentTypeHeader          = "Content-Type"
@@ -49,6 +50,7 @@ type CommonConfig struct {
 	ProjectID           string
 	RedhatCatalogAPIKey string
 	RegistryPassword    string
+	PreRelease          bool
 }
 
 // PushImage will push an image to the Quay.io registry if it is determined
@@ -211,6 +213,9 @@ func pushImageToRegistry(c CommonConfig, tag string) error {
 	username := fmt.Sprintf(registryUserFormat, c.ProjectID)
 	formattedEckOperatorRedhatReference := fmt.Sprintf(eckOperatorRegistryReference, registryURL, c.ProjectID, tag)
 	imageToPull := fmt.Sprintf(eckOperatorFormat, tag)
+	if c.PreRelease {
+		imageToPull = fmt.Sprintf(eckOperatorFormatPreRelease, tag)
+	}
 
 	log.Printf("pulling image (%s) in preparation to push (%s) to quay.io registry: ", imageToPull, formattedEckOperatorRedhatReference)
 	// default credentials are used here, as the operator image which we use as a source is public.


### PR DESCRIPTION
For build candidates we now push the operator image to  `docker.elastic.co/eck-snapshots`. Adding an option in the `hack/operatorhub` tool to be able to pull images from that repo to test before a release
