### PR TITLE
Disable Renovate on docs/release-notes/index.md

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -38,6 +38,13 @@
         "docs/design/0005-configurable-operator.md"
       ],
       "enabled": false
+    },
+    {
+      "description": "Docker images in the release notes should not be updated",
+      "matchFileNames": [
+        "docs/release-notes/index.md"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
This PR excludes `docs/release-notes/index.md` from renovate updates.

See https://github.com/elastic/cloud-on-k8s/pull/8636#pullrequestreview-2815026828