### PR TITLE
Add command flag kubeconfig

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -7,6 +7,7 @@ package manager
 import (
 	"context"
 	"errors"
+	"flag"
 	"fmt"
 	"net/http"
 	"net/http/pprof"
@@ -143,6 +144,8 @@ func Command() *cobra.Command {
 		},
 		RunE: doRun,
 	}
+
+	cmd.Flags().AddGoFlagSet(flag.CommandLine)
 
 	cmd.Flags().Bool(
 		operator.AutoPortForwardFlag,


### PR DESCRIPTION
refer #https://github.com/kubernetes-sigs/controller-runtime/blob/v0.20.4/pkg/client/config/config.go#L56

add commond flag to run controller out-of-cluster