### PR TITLE
Avoid registering `log-verbosity` twice

### DIFF
--- a/pkg/utils/log/log.go
+++ b/pkg/utils/log/log.go
@@ -33,6 +33,7 @@ const (
 )
 
 var Log = crlog.Log
+var verbosity *int
 
 func init() {
 	// Introduced mainly as a workaround for a controller-runtime bug.
@@ -41,9 +42,15 @@ func init() {
 	if logLevel, err := strconv.Atoi(os.Getenv(testLogLevelEnvVar)); err == nil {
 		setLogger(&logLevel)
 	}
-}
 
-var verbosity = flag.Int(FlagName, 0, "Verbosity level of logs (-2=Error, -1=Warn, 0=Info, >0=Debug)")
+	if flag.Lookup(FlagName) == nil {
+		// Register the log-verbosity flag with a default value of 0 (Info level).
+		verbosity = flag.Int(FlagName, 0, "Verbosity level of logs (-2=Error, -1=Warn, 0=Info, >0=Debug)")
+	} else {
+		// If previously registered, use the existing flag. (from https://stackoverflow.com/a/49195212)
+		verbosity = flag.Lookup(FlagName).Value.(flag.Getter).Get().(*int)
+	}
+}
 
 // BindFlags attaches logging flags to the given flag set.
 func BindFlags(flags *pflag.FlagSet) {


### PR DESCRIPTION
When updating this library in `kibana-controller`, we're getting the following errors:

```
panic: /var/folders/ns/qvpd0vj129l9yb4d0kvwc1tw0000gn/T/go-build188310518/b1167/certificates.test flag redefined: log-verbosity
```

It looks like `k8s-arch-commons` depends on v2, which is registering the same flag `log-verbosity`.

We need to make sure to register the flag once.