### PR TITLE
Add automated workaround for 9.0.0 maps issue

### DIFF
--- a/pkg/controller/maps/pod.go
+++ b/pkg/controller/maps/pod.go
@@ -83,9 +83,19 @@ func newPodSpec(ems emsv1alpha1.ElasticMapsServer, configHash string) (corev1.Po
 		WithVolumeMounts(cfgVolume.VolumeMount(), logsVolume.VolumeMount()).
 		WithInitContainerDefaults()
 
-	// Add command override for versions 9.0.0 through 9.0.1 to fix OpenShift permission issue
+	// Add command override for affected versions to fix OpenShift permission issue
 	// See issue #8655: container create fails with "open executable: Operation not permitted"
-	if v.GTE(version.From(9, 0, 0)) && v.LTE(version.From(9, 0, 1)) {
+	// Known affected versions:
+	// - 7.17.28
+	// - 8.18.0
+	// - 8.18.1
+	// - 9.0.0
+	// - 9.0.1
+	affectedInVersion7 := v.EQ(version.From(7, 17, 28))
+	affectedInVersion8 := v.EQ(version.From(8, 18, 0)) || v.EQ(version.From(8, 18, 1))
+	affectedInVersion9 := v.EQ(version.From(9, 0, 0)) || v.EQ(version.From(9, 0, 1))
+
+	if affectedInVersion7 || affectedInVersion8 || affectedInVersion9 {
 		builder = builder.WithCommand([]string{"/bin/sh", "-c", "node app/index.js"})
 	}
 

--- a/pkg/controller/maps/pod_test.go
+++ b/pkg/controller/maps/pod_test.go
@@ -1,0 +1,106 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package maps
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	emsv1alpha1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/maps/v1alpha1"
+)
+
+func TestNewPodSpec(t *testing.T) {
+	tests := []struct {
+		name                string
+		ems                 emsv1alpha1.ElasticMapsServer
+		wantCommandOverride bool
+		expectedCommand     []string
+	}{
+		{
+			name: "version 8.9.0 - no command override",
+			ems: emsv1alpha1.ElasticMapsServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ems",
+					Namespace: "default",
+				},
+				Spec: emsv1alpha1.MapsSpec{
+					Version: "8.9.0",
+				},
+			},
+			wantCommandOverride: false,
+		},
+		{
+			name: "version 9.0.0 - should apply command override",
+			ems: emsv1alpha1.ElasticMapsServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ems",
+					Namespace: "default",
+				},
+				Spec: emsv1alpha1.MapsSpec{
+					Version: "9.0.0",
+				},
+			},
+			wantCommandOverride: true,
+			expectedCommand:     []string{"/bin/sh", "-c", "node app/index.js"},
+		},
+		{
+			name: "version 9.0.1 - should apply command override",
+			ems: emsv1alpha1.ElasticMapsServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ems",
+					Namespace: "default",
+				},
+				Spec: emsv1alpha1.MapsSpec{
+					Version: "9.0.1",
+				},
+			},
+			wantCommandOverride: true,
+			expectedCommand:     []string{"/bin/sh", "-c", "node app/index.js"},
+		},
+		{
+			name: "version 9.1.0 - no command override",
+			ems: emsv1alpha1.ElasticMapsServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ems",
+					Namespace: "default",
+				},
+				Spec: emsv1alpha1.MapsSpec{
+					Version: "9.1.0",
+				},
+			},
+			wantCommandOverride: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			podSpec, err := newPodSpec(tt.ems, "test-hash")
+			require.NoError(t, err)
+
+			// Find the main container
+			var mapsContainer *corev1.Container
+			for _, container := range podSpec.Spec.Containers {
+				if container.Name == emsv1alpha1.MapsContainerName {
+					mapsContainer = &container
+					break
+				}
+			}
+
+			require.NotNil(t, mapsContainer, "Maps container not found")
+
+			if tt.wantCommandOverride {
+				assert.Equal(t, tt.expectedCommand, mapsContainer.Command,
+					"Command override doesn't match expected value")
+			} else {
+				assert.Empty(t, mapsContainer.Command,
+					"Command should not be set for versions outside the override range")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Related to  #8655

Try to apply the workaround to explicitly set the command automatically. 

What I still need to figure out is whether earlier versions before 9.0.0 are also affected.