### PR TITLE
Update docs-build.yml to build version branches too

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - '\d+.\d+'
   pull_request_target: ~
   merge_group: ~
 


### PR DESCRIPTION
This should be back-ported to `3.0` if the intend is to publish the `3.0` branch to elastic.co/docs instead of `main`.

After this is backported and our workflows ran on the respective branches we can switch the documentation configuration over to use `3.0` as the source for production builds.
