### PR TITLE
[3.0] Update docs-build.yml to build version branches too (#8668)

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - '\d+.\d+'
   pull_request_target: ~
   merge_group: ~
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.0`:
 - [Update docs-build.yml to build version branches too (#8668)](https://github.com/elastic/cloud-on-k8s/pull/8668)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)