### PR TITLE
[E2E] Increase Agent memory from 756Mi -> 884Mi

### DIFF
--- a/test/e2e/test/agent/builder.go
+++ b/test/e2e/test/agent/builder.go
@@ -179,11 +179,11 @@ func (b Builder) MoreResourcesForIssue4730() Builder {
 	return b.WithResources(
 		corev1.ResourceRequirements{
 			Limits: map[corev1.ResourceName]resource.Quantity{
-				corev1.ResourceMemory: resource.MustParse("756Mi"),
+				corev1.ResourceMemory: resource.MustParse("884Mi"),
 				corev1.ResourceCPU:    resource.MustParse("200m"),
 			},
 			Requests: map[corev1.ResourceName]resource.Quantity{
-				corev1.ResourceMemory: resource.MustParse("756Mi"),
+				corev1.ResourceMemory: resource.MustParse("884Mi"),
 				corev1.ResourceCPU:    resource.MustParse("200m"),
 			},
 		},


### PR DESCRIPTION
Resolves: #8686 
Follow up of: #8337 which previously increased from `756Mi`.

