### PR TITLE
[E2E] Only override memory for non fleet managed Agents only

### DIFF
--- a/test/e2e/agent/config_test.go
+++ b/test/e2e/agent/config_test.go
@@ -48,7 +48,7 @@ func TestSystemIntegrationConfig(t *testing.T) {
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.socket_summary", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.uptime", "default"))
 
-	agentBuilder = agent.ApplyYamls(t, agentBuilder, E2EAgentSystemIntegrationConfig, E2EAgentSystemIntegrationPodTemplate)
+	agentBuilder = agent.ApplyYamls(t, agentBuilder, E2EAgentSystemIntegrationConfig, E2EAgentSystemIntegrationPodTemplate).MoreResourcesForIssue4730()
 
 	test.Sequence(nil, test.EmptySteps, esBuilder, agentBuilder, testPodBuilder).RunSequential(t)
 }
@@ -88,7 +88,7 @@ func TestAgentConfigRef(t *testing.T) {
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.socket_summary", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.uptime", "default"))
 
-	agentBuilder = agent.ApplyYamls(t, agentBuilder, "", E2EAgentSystemIntegrationPodTemplate)
+	agentBuilder = agent.ApplyYamls(t, agentBuilder, "", E2EAgentSystemIntegrationPodTemplate).MoreResourcesForIssue4730()
 
 	test.Sequence(nil, test.EmptySteps, esBuilder, agentBuilder).RunSequential(t)
 }
@@ -121,7 +121,7 @@ func TestMultipleOutputConfig(t *testing.T) {
 		WithESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.socket_summary", "default"), "default").
 		WithESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.uptime", "default"), "default")
 
-	agentBuilder = agent.ApplyYamls(t, agentBuilder, E2EAgentMultipleOutputConfig, E2EAgentSystemIntegrationPodTemplate)
+	agentBuilder = agent.ApplyYamls(t, agentBuilder, E2EAgentMultipleOutputConfig, E2EAgentSystemIntegrationPodTemplate).MoreResourcesForIssue4730()
 
 	test.Sequence(nil, test.EmptySteps, esBuilder1, esBuilder2, agentBuilder).RunSequential(t)
 }

--- a/test/e2e/metadata_propagation_test.go
+++ b/test/e2e/metadata_propagation_test.go
@@ -67,7 +67,8 @@ func TestMetadataPropagation(t *testing.T) {
 		WithLabel("my-label", "my-label-value").
 		WithAnnotation("eck.k8s.alpha.elastic.co/propagate-annotations", "*").
 		WithAnnotation("eck.k8s.alpha.elastic.co/propagate-labels", "*").
-		WithAnnotation("my-annotation", "my-annotation-value")
+		WithAnnotation("my-annotation", "my-annotation-value").
+		MoreResourcesForIssue4730()
 	agent = elasticagent.ApplyYamls(t, agent, e2e_agent.E2EAgentSystemIntegrationConfig, e2e_agent.E2EAgentSystemIntegrationPodTemplate)
 	ls := logstash.NewBuilder(name).
 		WithRestrictedSecurityContext().

--- a/test/e2e/test/agent/builder.go
+++ b/test/e2e/test/agent/builder.go
@@ -131,7 +131,7 @@ func NewBuilder(name string) Builder {
 		WithSuffix(suffix).
 		WithLabel(run.TestNameLabel, name).
 		WithDaemonSet()
-	return builder.MoreResourcesForIssue4730()
+	return builder
 }
 
 // MoreResourcesForIssue4730 adjusts Agent resource requirements to deal with https://github.com/elastic/elastic-agent/issues/4730.


### PR DESCRIPTION
My previous attempt to adjust the memory on non Fleet managed Agents was wrong, see https://github.com/elastic/cloud-on-k8s/pull/8688#discussion_r2152271412

In this PR I'm selectively adjusting the memory on `TestSystemIntegrationConfig`, `TestAgentConfigRef`, `TestMultipleOutputConfig` and `TestMetadataPropagation`