### PR TITLE
[E2E] Increase memory for non Fleet managed Agents also in TestGlobalCA

### DIFF
--- a/test/e2e/global_ca_test.go
+++ b/test/e2e/global_ca_test.go
@@ -60,7 +60,8 @@ func TestGlobalCA(t *testing.T) {
 	agent := elasticagent.NewBuilder(name).
 		WithElasticsearchRefs(elasticagent.ToOutput(es.Ref(), "default")).
 		WithDefaultESValidation(elasticagent.HasWorkingDataStream(elasticagent.LogsType, "elastic_agent", "default")).
-		WithOpenShiftRoles(test.UseSCCRole)
+		WithOpenShiftRoles(test.UseSCCRole).
+		MoreResourcesForIssue4730()
 	agent = elasticagent.ApplyYamls(t, agent, e2e_agent.E2EAgentSystemIntegrationConfig, e2e_agent.E2EAgentSystemIntegrationPodTemplate)
 	ls := logstash.NewBuilder(name).
 		WithRestrictedSecurityContext().


### PR DESCRIPTION
I missed this E2E test in https://github.com/elastic/cloud-on-k8s/pull/8692