### PR TITLE
UBI: Use micro image

### DIFF
--- a/build/Dockerfile-ubi
+++ b/build/Dockerfile-ubi
@@ -27,10 +27,7 @@ RUN --mount=type=cache,mode=0755,target=/go/pkg/mod \
 
 # ---------------------------------------------
 # Copy the operator binary into a lighter image
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1749489516
-
-# Update the base image packages to the latest versions
-RUN microdnf update --setopt=tsflags=nodocs --assumeyes && microdnf clean all
+FROM registry.access.redhat.com/ubi9/ubi-micro:9.6-1749632992
 
 ARG VERSION
 


### PR DESCRIPTION
Testing [UBI micro image](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html-single/building_running_and_managing_containers/index#con_understanding-the-ubi-micro-images_assembly_types-of-container-images):

> The ubi-micro is the smallest possible UBI image, obtained by excluding a package manager and all of its dependencies which are normally included in a container image. This minimizes the attack surface of container images based on the ubi-micro image and is suitable for minimal applications, even if you use UBI Standard, Minimal, or Init for other applications. The container image without the Linux distribution packaging is called a Distroless container image.