### PR TITLE
Fix Helm ingress in GKE for Elasticsearch and Kibana

### DIFF
--- a/deploy/eck-stack/charts/eck-elasticsearch/templates/ingress.yaml
+++ b/deploy/eck-stack/charts/eck-elasticsearch/templates/ingress.yaml
@@ -45,4 +45,4 @@ spec:
             port:
               number: 9200
   {{- end }}
-{{- end }}
+{{ end }}

--- a/deploy/eck-stack/charts/eck-kibana/templates/ingress.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/templates/ingress.yaml
@@ -45,4 +45,4 @@ spec:
             port:
               number: 5601
   {{- end }}
-{{- end }}
+{{ end }}


### PR DESCRIPTION
## What is this change?

While testing some backlog issues related to eck-stack Helm + Ingress, I noted that my ingress tests in GKE were not coming online properly (the Loadbalancer wasn't being created) because of the following error:

```
28m         Warning   Translate                           ingress/kibana                                                        Translation failed: invalid ingress spec: error getting BackendConfig for port "&ServiceBackendPort{Name:,Number:5601,}" on service "elastic/kibana-kb-http", err: no BackendConfig for service port exists.
```

This was directly from using our [example](deploy/eck-stack/examples/kibana/ingress/kibana-gke.yaml) manifest.

~~Upon debugging, the only path I could get this functional was to add the `BackendConfig` object, which I've updated the Helm templates to automatically do if GKE is detected using the service annotations.~~

~~I'm unsure if this is a new requirement, as I tested GKE when ingress was originally added to the helm charts, but it certainly doesn't appear to be working now.~~

@kvalliyurnatt pointed out it was the annotation that was causing this. I've removed it.

### Testing

Upon making these changes, and updating the helm dependencies to be local, I tested in this manner:

```
❯ helm upgrade -i eck-stack . -n elastic -f ./cloud-on-k8s/deploy/eck-stack/examples/kibana/ingress/kibana-gke.yaml
❯ kc get ingress -n elastic
NAME            CLASS    HOSTS                       ADDRESS       PORTS     AGE
elasticsearch   <none>   elasticsearch.company.dev   34.8.xx.xxx   80, 443   7m47s
kibana          <none>   kibana.company.dev          34.8.xx.xxx   80, 443   18m
```

I was both able to login to Kibana, and query Elasticsearch's health endpoint via the loadbalancer with an `/etc/hosts` entry.
