### PR TITLE
Set owner on service account Secret, update it when application is recreated

### DIFF
--- a/pkg/controller/association/reconciler.go
+++ b/pkg/controller/association/reconciler.go
@@ -381,8 +381,7 @@ func (r *Reconciler) reconcileAssociation(ctx context.Context, association commo
 			applicationSecretName,
 			UserKey(association, es.Namespace, r.ElasticsearchUserCreation.UserSecretSuffix),
 			serviceAccount,
-			association.GetName(),
-			association.GetUID(),
+			association.Associated(),
 		)
 		if err != nil {
 			return commonv1.AssociationFailed, err


### PR DESCRIPTION
This PR fixes the Service Account Secret ownership and also ensures that a new service account is created when an application is recreated.