### PR TITLE
Update supported versions

### DIFF
--- a/.buildkite/e2e/nightly-main-matrix.yaml
+++ b/.buildkite/e2e/nightly-main-matrix.yaml
@@ -21,14 +21,14 @@
   fixed:
     E2E_PROVIDER: kind
   mixed:
-    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.28.13@sha256:45d319897776e11167e4698f6b14938eb4d52eb381d9e3d7a9086c16c69a8110
-    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.29.8@sha256:d46b7aa29567e93b27f7531d258c372e829d7224b25e3fc6ffdefed12476d3aa
-    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.30.4@sha256:976ea815844d5fa93be213437e3ff5754cd599b040946b5cca43ca45c2047114
-    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.31.1@sha256:cd224d8da58d50907d1dd41d476587643dad2ffd9f6a4d96caf530fb3b9a5956
+    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.29.14@sha256:8703bd94ee24e51b778d5556ae310c6c0fa67d761fae6379c8e0bb480e6fea29
+    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.30.13@sha256:397209b3d947d154f6641f2d0ce8d473732bd91c87d9575ade99049aa33cd648
+    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.31.9@sha256:b94a3a6c06198d17f59cca8c6f486236fa05e2fb359cbd75dabbfc348a10b211
+    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.32.5@sha256:e3b2327e3a5ab8c76f5ece68936e4cafaa82edf58486b769727ab0b3b97a5b0d
     # The latest version of kind/k8s needs to be listed twice at the end of this list
     # as it's tested in both ipv4 and ipv6 mode.
-    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027
-    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027
+    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.33.1@sha256:050072256b9a903bd914c0b2866828150cb229cea0efe5892e2b644d5dd3b34f
+    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.33.1@sha256:050072256b9a903bd914c0b2866828150cb229cea0efe5892e2b644d5dd3b34f
       DEPLOYER_KIND_IP_FAMILY: ipv6
 
 - label: gke

--- a/.buildkite/e2e/release-branch-matrix.yaml
+++ b/.buildkite/e2e/release-branch-matrix.yaml
@@ -31,14 +31,14 @@
   fixed:
     E2E_PROVIDER: kind
   mixed:
-    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.28.13@sha256:45d319897776e11167e4698f6b14938eb4d52eb381d9e3d7a9086c16c69a8110
-    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.29.8@sha256:d46b7aa29567e93b27f7531d258c372e829d7224b25e3fc6ffdefed12476d3aa
-    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.30.4@sha256:976ea815844d5fa93be213437e3ff5754cd599b040946b5cca43ca45c2047114
-    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.31.1@sha256:cd224d8da58d50907d1dd41d476587643dad2ffd9f6a4d96caf530fb3b9a5956
+    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.29.14@sha256:8703bd94ee24e51b778d5556ae310c6c0fa67d761fae6379c8e0bb480e6fea29
+    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.30.13@sha256:397209b3d947d154f6641f2d0ce8d473732bd91c87d9575ade99049aa33cd648
+    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.31.9@sha256:b94a3a6c06198d17f59cca8c6f486236fa05e2fb359cbd75dabbfc348a10b211
+    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.32.5@sha256:e3b2327e3a5ab8c76f5ece68936e4cafaa82edf58486b769727ab0b3b97a5b0d
     # The latest version of kind/k8s needs to be listed twice at the end of this list
     # as it's tested in both ipv4 and ipv6 mode.
-    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027
-    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027
+    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.33.1@sha256:050072256b9a903bd914c0b2866828150cb229cea0efe5892e2b644d5dd3b34f
+    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.33.1@sha256:050072256b9a903bd914c0b2866828150cb229cea0efe5892e2b644d5dd3b34f
       DEPLOYER_KIND_IP_FAMILY: ipv6
 
 - label: gke
@@ -59,7 +59,7 @@
   fixed:
     E2E_PROVIDER: ocp
   mixed:
-    - DEPLOYER_CLIENT_VERSION: "4.18.1"
+    - DEPLOYER_CLIENT_VERSION: "4.19.0"
 
 - label: eks-arm
   fixed:

--- a/.buildkite/e2e/release-branch-matrix.yaml
+++ b/.buildkite/e2e/release-branch-matrix.yaml
@@ -59,7 +59,7 @@
   fixed:
     E2E_PROVIDER: ocp
   mixed:
-    - DEPLOYER_CLIENT_VERSION: "4.19.0"
+    - DEPLOYER_CLIENT_VERSION: "4.19.2"
 
 - label: eks-arm
   fixed:

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Current features:
 
 Supported versions:
 
-*  Kubernetes 1.28-1.32
-*  OpenShift 4.14-4.18
+*  Kubernetes 1.29-1.33
+*  OpenShift 4.15-4.19
 *  Elasticsearch, Kibana, APM Server: 7.17+, 8+, 9+
 *  Enterprise Search: 7.7+, 8+
 *  Beats: 7.17+, 8+, 9+

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -93,7 +93,7 @@ plans:
 - id: ocp-ci
   operation: create
   clusterName: ci
-  clientVersion: 4.19.0
+  clientVersion: 4.19.2
   provider: ocp
   machineType: n1-standard-8
   serviceAccount: true
@@ -103,7 +103,7 @@ plans:
 - id: ocp-dev
   operation: create
   clusterName: dev
-  clientVersion: 4.19.0
+  clientVersion: 4.19.2
   provider: ocp
   machineType: n1-standard-8
   serviceAccount: true

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -3,7 +3,7 @@ plans:
   operation: create
   clusterName: ci
   provider: gke
-  kubernetesVersion: 1.31
+  kubernetesVersion: 1.32
   machineType: n1-standard-8
   serviceAccount: true
   enforceSecurityPolicies: true
@@ -18,7 +18,7 @@ plans:
   operation: create
   clusterName: ci-autopilot
   provider: gke
-  kubernetesVersion: 1.31
+  kubernetesVersion: 1.32
   serviceAccount: true
   enforceSecurityPolicies: true
   # this is disabled in autopilot: container provisioner is privileged; not allowed in Autopilot
@@ -31,7 +31,7 @@ plans:
   operation: create
   clusterName: dev
   provider: gke
-  kubernetesVersion: 1.31
+  kubernetesVersion: 1.32
   machineType: n1-standard-8
   serviceAccount: false
   enforceSecurityPolicies: true
@@ -58,7 +58,7 @@ plans:
   operation: create
   clusterName: dev-autopilot
   provider: gke
-  kubernetesVersion: 1.31
+  kubernetesVersion: 1.32
   serviceAccount: false
   enforceSecurityPolicies: true
   gke:
@@ -69,7 +69,7 @@ plans:
   operation: create
   clusterName: ci
   provider: aks
-  kubernetesVersion: 1.30.10
+  kubernetesVersion: 1.31.8
   machineType: Standard_D8s_v3
   serviceAccount: true
   enforceSecurityPolicies: true
@@ -82,7 +82,7 @@ plans:
   operation: create
   clusterName: dev
   provider: aks
-  kubernetesVersion: 1.30.10
+  kubernetesVersion: 1.31.8
   machineType: Standard_D8s_v3
   serviceAccount: false
   enforceSecurityPolicies: true
@@ -93,7 +93,7 @@ plans:
 - id: ocp-ci
   operation: create
   clusterName: ci
-  clientVersion: 4.18.1
+  clientVersion: 4.19.0
   provider: ocp
   machineType: n1-standard-8
   serviceAccount: true
@@ -103,7 +103,7 @@ plans:
 - id: ocp-dev
   operation: create
   clusterName: dev
-  clientVersion: 4.18.1
+  clientVersion: 4.19.0
   provider: ocp
   machineType: n1-standard-8
   serviceAccount: true
@@ -117,7 +117,7 @@ plans:
   machineType: c5d.2xlarge
   serviceAccount: false
   enforceSecurityPolicies: true
-  kubernetesVersion: 1.29
+  kubernetesVersion: 1.33
   diskSetup: kubectl apply -f hack/deployer/config/local-disks/ssd-provisioner.yaml
   eks:
     region: ap-northeast-3
@@ -130,7 +130,7 @@ plans:
   machineType: m6gd.2xlarge
   serviceAccount: false
   enforceSecurityPolicies: true
-  kubernetesVersion: 1.29
+  kubernetesVersion: 1.33
   diskSetup: kubectl apply -f hack/deployer/config/local-disks/ssd-provisioner.yaml
   eks:
     region: eu-west-1
@@ -142,7 +142,7 @@ plans:
   provider: eks
   machineType: c5d.2xlarge
   serviceAccount: false
-  kubernetesVersion: 1.29
+  kubernetesVersion: 1.33
   enforceSecurityPolicies: true
   eks:
     region: eu-west-2
@@ -151,22 +151,22 @@ plans:
 - id: kind-dev
   operation: create
   clusterName: eck
-  clientVersion: 0.24.0
+  clientVersion: 0.29.0
   provider: kind
   kubernetesVersion: 1.31.1
   enforceSecurityPolicies: true
   kind:
     nodeCount: 3
-    nodeImage: kindest/node:v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027
+    nodeImage: kindest/node:v1.33.1@sha256:050072256b9a903bd914c0b2866828150cb229cea0efe5892e2b644d5dd3b34f
     ipFamily: ipv4
 - id: kind-ci
   operation: create
   clusterName: kind-ci
-  clientVersion: 0.24.0
+  clientVersion: 0.29.0
   provider: kind
-  kubernetesVersion: 1.31.1
+  kubernetesVersion: 1.33.1
   enforceSecurityPolicies: true
   kind:
     nodeCount: 3
-    nodeImage: kindest/node:v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027
+    nodeImage: kindest/node:v1.33.1@sha256:050072256b9a903bd914c0b2866828150cb229cea0efe5892e2b644d5dd3b34f
     ipFamily: ipv4

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -3,7 +3,7 @@ plans:
   operation: create
   clusterName: ci
   provider: gke
-  kubernetesVersion: 1.32
+  kubernetesVersion: 1.33
   machineType: n1-standard-8
   serviceAccount: true
   enforceSecurityPolicies: true
@@ -18,7 +18,7 @@ plans:
   operation: create
   clusterName: ci-autopilot
   provider: gke
-  kubernetesVersion: 1.32
+  kubernetesVersion: 1.33
   serviceAccount: true
   enforceSecurityPolicies: true
   # this is disabled in autopilot: container provisioner is privileged; not allowed in Autopilot
@@ -31,7 +31,7 @@ plans:
   operation: create
   clusterName: dev
   provider: gke
-  kubernetesVersion: 1.32
+  kubernetesVersion: 1.33
   machineType: n1-standard-8
   serviceAccount: false
   enforceSecurityPolicies: true
@@ -58,7 +58,7 @@ plans:
   operation: create
   clusterName: dev-autopilot
   provider: gke
-  kubernetesVersion: 1.32
+  kubernetesVersion: 1.33
   serviceAccount: false
   enforceSecurityPolicies: true
   gke:
@@ -69,7 +69,7 @@ plans:
   operation: create
   clusterName: ci
   provider: aks
-  kubernetesVersion: 1.31.8
+  kubernetesVersion: 1.32.4
   machineType: Standard_D8s_v3
   serviceAccount: true
   enforceSecurityPolicies: true
@@ -82,7 +82,7 @@ plans:
   operation: create
   clusterName: dev
   provider: aks
-  kubernetesVersion: 1.31.8
+  kubernetesVersion: 1.32.4
   machineType: Standard_D8s_v3
   serviceAccount: false
   enforceSecurityPolicies: true

--- a/hack/operatorhub/templates/csv.tpl
+++ b/hack/operatorhub/templates/csv.tpl
@@ -284,9 +284,9 @@ spec:
     Supported versions:
 
 
-    * Kubernetes 1.28-1.32
+    * Kubernetes 1.29-1.33
 
-    * OpenShift 4.14-4.18
+    * OpenShift 4.15-4.19
 
     * Google Kubernetes Engine (GKE), Azure Kubernetes Service (AKS), and Amazon Elastic Kubernetes Service (EKS)
 


### PR DESCRIPTION
This PR updates the supported versions of Kubernetes and OpenShift.

Versions in this PR are either:
* Last available Kind images
* Last _default_ versions for each CSPs

This PR also updates Kind to `0.29.0`, I did a quick test locally with `kindest/node:v1.29.14` and it's working as expected.