### PR TITLE
Update eksctl ClusterConfig to create K8s 1.33 clusters

### DIFF
--- a/.buildkite/Makefile
+++ b/.buildkite/Makefile
@@ -4,7 +4,7 @@
 
 # This Makefile is used to run the buildkite agent in virtual machines when Docker access is required.
 
-CI_IMAGE               ?= docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4c9da1f3
+CI_IMAGE               ?= docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:79fd3a55
 ROOT_DIR               := $(CURDIR)/..
 GO_MOUNT_PATH          ?= /go/src/github.com/elastic/cloud-on-k8s
 export VAULT_ROOT_PATH = secret/ci/elastic-cloud-on-k8s

--- a/.buildkite/e2e/pipeline-gen/pipeline.tpl.yaml
+++ b/.buildkite/e2e/pipeline-gen/pipeline.tpl.yaml
@@ -34,7 +34,7 @@ steps:
       machineType: "{{ .KindAgentsMachineType }}"
       {{- end }}
       {{- else }}
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4c9da1f3
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:79fd3a55
       memory: "5G"
       {{- end }}
 
@@ -86,7 +86,7 @@ steps:
       diskSizeGb: 150
       {{- end }}
       {{- else }}
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4c9da1f3
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:79fd3a55
       memory: "4G"
       {{- end }}
 
@@ -122,7 +122,7 @@ steps:
         {{- if not $test.Dind }}
           - make run-deployer
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4c9da1f3
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:79fd3a55
           memory: "4G"
         {{- else }}
           - make -C .buildkite TARGET="run-deployer" ci
@@ -145,5 +145,5 @@ steps:
       - ".buildkite/e2e/reporter/*.md"
       - ".buildkite/e2e/reporter/*.yml"
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4c9da1f3
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:79fd3a55
       memory: "2G"

--- a/.buildkite/e2e/reporter/templates/notify-failures.tpl.yml
+++ b/.buildkite/e2e/reporter/templates/notify-failures.tpl.yml
@@ -4,7 +4,7 @@ steps:
   - label: "{{ .ShortFailuresCount }} failure(s)"
     command: exit {{ .ShortFailuresCount }}
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4c9da1f3
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:79fd3a55
       memory: "2G"
 
   # notify e2e tests failures for the main branch and tags
@@ -13,7 +13,7 @@ steps:
     if: build.branch == "main" || build.tag != null
     command: echo "notify"
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4c9da1f3
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:79fd3a55
       memory: "2G"
 
     notify:

--- a/.buildkite/pipeline-e2e-clusters-cleanup.yml
+++ b/.buildkite/pipeline-e2e-clusters-cleanup.yml
@@ -10,7 +10,7 @@ steps:
       - make build-deployer
       - buildkite-agent artifact upload hack/deployer/deployer
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4c9da1f3
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:79fd3a55
       memory: 2G
 
   - label: ":broom: e2e test cluster cleanup gke"
@@ -26,7 +26,7 @@ steps:
       - chmod u+x /usr/local/hack/deployer/deployer
       - /usr/local/hack/deployer/deployer cleanup --plans-file hack/deployer/config/plans.yml --cluster-prefix $${E2E_TEST_CLUSTER_PREFIX} --config-file deployer-config.yml
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4c9da1f3
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:79fd3a55
       memory: 2G
 
   - label: ":broom: e2e test cluster cleanup aks"
@@ -55,7 +55,7 @@ steps:
       - chmod u+x /usr/local/hack/deployer/deployer
       - /usr/local/hack/deployer/deployer cleanup --plans-file hack/deployer/config/plans.yml --cluster-prefix $${E2E_TEST_CLUSTER_PREFIX} --config-file deployer-config.yml
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4c9da1f3
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:79fd3a55
       memory: 2G
 
   - label: ":broom: e2e test cluster cleanup eks-arm"
@@ -71,7 +71,7 @@ steps:
       - chmod u+x /usr/local/hack/deployer/deployer
       - /usr/local/hack/deployer/deployer cleanup --plans-file hack/deployer/config/plans.yml --cluster-prefix $${E2E_TEST_CLUSTER_PREFIX} --config-file deployer-config.yml
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4c9da1f3
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:79fd3a55
       memory: 2G
 
   - label: ":broom: e2e test cluster cleanup ocp"

--- a/.buildkite/pipeline-e2e-tests.yml
+++ b/.buildkite/pipeline-e2e-tests.yml
@@ -17,7 +17,7 @@ steps:
               E2E_PROVIDER: gke
           DEF
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4c9da1f3
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:79fd3a55
           memory: "2G"
 
       # for nightly builds from main
@@ -30,7 +30,7 @@ steps:
           cd .buildkite/e2e/pipeline-gen && go build -o pipeline-gen
           cat ../nightly-main-matrix.yaml | ./pipeline-gen | buildkite-agent pipeline upload
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4c9da1f3
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:79fd3a55
           memory: "2G"
 
       # for all tags
@@ -41,5 +41,5 @@ steps:
           cd .buildkite/e2e/pipeline-gen && go build -o pipeline-gen
           cat ../release-branch-matrix.yaml | ./pipeline-gen | buildkite-agent pipeline upload
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4c9da1f3
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:79fd3a55
           memory: "2G"

--- a/.buildkite/pipeline-release-helm.yml
+++ b/.buildkite/pipeline-release-helm.yml
@@ -10,7 +10,7 @@ steps:
       - make build
       - buildkite-agent artifact upload bin/releaser
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4c9da1f3
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:79fd3a55
       memory: "2G"
 
   - label: "operator dev helm chart"
@@ -29,7 +29,7 @@ steps:
       - chmod u+x /usr/local/bin/releaser
       - releaser --env=dev --charts-dir=deploy/eck-operator
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4c9da1f3
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:79fd3a55
       memory: "2G"
 
   - wait
@@ -50,7 +50,7 @@ steps:
       - chmod u+x /usr/local/bin/releaser
       - releaser --env=dev --charts-dir=deploy/eck-stack
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4c9da1f3
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:79fd3a55
       memory: "2G"
 
   - wait
@@ -68,7 +68,7 @@ steps:
       - chmod u+x /usr/local/bin/releaser
       - releaser --env=prod --charts-dir=deploy/eck-operator
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4c9da1f3
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:79fd3a55
       memory: "2G"
 
   - wait
@@ -86,5 +86,5 @@ steps:
       - chmod u+x /usr/local/bin/releaser
       - releaser --env=prod --charts-dir=deploy/eck-stack
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4c9da1f3
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:79fd3a55
       memory: "2G"

--- a/.buildkite/pipeline-release-redhat.yml
+++ b/.buildkite/pipeline-release-redhat.yml
@@ -7,7 +7,7 @@ steps:
       - make build
       - buildkite-agent artifact upload bin/operatorhub
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4c9da1f3
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:79fd3a55
       memory: "2G"
 
   - label: ":docker: push container"
@@ -20,7 +20,7 @@ steps:
         cd hack/operatorhub
         operatorhub container push
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4c9da1f3
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:79fd3a55
       memory: "2G"
 
   - label: ":docker: preflight container check"
@@ -32,7 +32,7 @@ steps:
     commands:
       - .buildkite/scripts/release/redhat-preflight.sh
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4c9da1f3
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:79fd3a55
       memory: "2G"
 
   - label: ":docker: publish container"
@@ -47,7 +47,7 @@ steps:
         cd hack/operatorhub
         operatorhub container publish
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4c9da1f3
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:79fd3a55
       memory: "2G"
 
   - label: ":redhat: generate and create-pr"
@@ -62,5 +62,5 @@ steps:
         operatorhub generate-manifests
         operatorhub bundle create-pr
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4c9da1f3
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:79fd3a55
       memory: "2G"

--- a/.buildkite/pipeline-release.yml
+++ b/.buildkite/pipeline-release.yml
@@ -10,7 +10,7 @@ steps:
         commands:
           - .buildkite/scripts/release/k8s-manifests.sh
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4c9da1f3
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:79fd3a55
           memory: "2G"
 
       - label: "copy images to dockerhub"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,14 +9,14 @@ steps:
       - label: ":go: lint"
         command: "make lint check-local-changes"
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4c9da1f3
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:79fd3a55
           cpu: "6"
           memory: "7G"
 
       - label: ":go: generate"
         command: "make generate check-local-changes"
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4c9da1f3
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:79fd3a55
           cpu: "4"
           memory: "4G"
 
@@ -25,7 +25,7 @@ steps:
           - "make check-license-header check-predicates shellcheck reattach-pv"
           - "make -C hack/helm/release build"
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4c9da1f3
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:79fd3a55
           cpu: "4"
           memory: "4G"
 
@@ -35,28 +35,28 @@ steps:
       - label: ":go: unit-tests"
         command: "make unit-xml"
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4c9da1f3
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:79fd3a55
           cpu: "4"
           memory: "4G"
 
       - label: ":go: integration-tests"
         command: "make integration-xml"
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4c9da1f3
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:79fd3a55
           cpu: "4"
           memory: "4G"
 
       - label: ":go: manifest-gen-tests"
         command: "make manifest-gen-test"
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4c9da1f3
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:79fd3a55
           cpu: "4"
           memory: "2G"
 
       - label: ":go: helm-tests"
         command: "make helm-test"
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4c9da1f3
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:79fd3a55
           cpu: "4"
           memory: "2G"
 
@@ -112,7 +112,7 @@ steps:
           E2E_SKIP_CLEANUP: true
       DEF
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4c9da1f3
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:79fd3a55
       memory: "2G"
 
   # for PR comment
@@ -125,14 +125,14 @@ steps:
       $$(echo ./pipeline-gen $$GITHUB_PR_COMMENT_VAR_ARGS) \
         | buildkite-agent pipeline upload
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4c9da1f3
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:79fd3a55
       memory: "2G"
 
   # for the main branch (merge and nightly) and tags
   - label: ":buildkite:"
     command: buildkite-agent pipeline upload .buildkite/pipeline-e2e-tests.yml
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4c9da1f3
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:79fd3a55
       memory: "2G"
 
   # ----------
@@ -165,7 +165,7 @@ steps:
         done
       ) | buildkite-agent pipeline upload
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4c9da1f3
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:79fd3a55
       memory: "256Mi"
 
   - label: ":buildkite:"
@@ -173,5 +173,5 @@ steps:
       - "operator-image-build"
     command: buildkite-agent pipeline upload .buildkite/pipeline-release.yml
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4c9da1f3
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:79fd3a55
       memory: "2G"

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -143,6 +143,7 @@ plans:
   machineType: c5d.2xlarge
   serviceAccount: false
   kubernetesVersion: 1.33
+  diskSetup: kubectl apply -f hack/deployer/config/local-disks/ssd-provisioner.yaml
   enforceSecurityPolicies: true
   eks:
     region: eu-west-2

--- a/hack/deployer/runner/eks.go
+++ b/hack/deployer/runner/eks.go
@@ -39,15 +39,10 @@ metadata:
     {{- end }}
 nodeGroups:
   - name: ng-1
-    amiFamily: AmazonLinux2
+    amiFamily: AmazonLinux2023
     instanceType: {{.MachineType}}
     desiredCapacity: {{.NodeCount}}
     ami: {{.NodeAMI}}
-    overrideBootstrapCommand: |
-      #!/bin/bash
-      source /var/lib/cloud/scripts/eksctl/bootstrap.helper.sh
-
-      /etc/eks/bootstrap.sh {{.ClusterName}} --container-runtime containerd --kubelet-extra-args "--node-labels=${NODE_LABELS}"
     iam:
       instanceProfileARN: {{.InstanceProfileARN}}
       instanceRoleARN: {{.InstanceRoleARN}}


### PR DESCRIPTION
This PR updates `eksctl` `ClusterConfig` so we can create K8s 1.33 clusters in AWS.

It works as expected locally:

```
> k get nodes
NAME                                                STATUS   ROLES    AGE     VERSION
ip-xxx.ap-northeast-3.compute.internal   Ready    <none>   8m39s   v1.33.0-eks-802817d
ip-xxx.ap-northeast-3.compute.internal   Ready    <none>   8m38s   v1.33.0-eks-802817d
ip-xxx.ap-northeast-3.compute.internal   Ready    <none>   8m38s   v1.33.0-eks-802817d
```

```
NAME                                                              HEALTH   NODES   VERSION   PHASE   AGE
elasticsearch.elasticsearch.k8s.elastic.co/elasticsearch-sample   green    3       9.0.0     Ready   3m25s

NAME                                    READY   STATUS    RESTARTS   AGE
pod/elasticsearch-sample-es-default-0   1/1     Running   0          3m24s
pod/elasticsearch-sample-es-default-1   1/1     Running   0          3m24s
pod/elasticsearch-sample-es-default-2   1/1     Running   0          3m24s

NAME                                                                         STATUS   VOLUME              CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
persistentvolumeclaim/elasticsearch-data-elasticsearch-sample-es-default-0   Bound    local-pv-26c2ebe1   182Gi      RWO            e2e-default    <unset>                 85s
persistentvolumeclaim/elasticsearch-data-elasticsearch-sample-es-default-1   Bound    local-pv-143c8daf   182Gi      RWO            e2e-default    <unset>                 3m24s
persistentvolumeclaim/elasticsearch-data-elasticsearch-sample-es-default-2   Bound    local-pv-6d0cd6a3   182Gi      RWO            e2e-default    <unset>                 3m24s
```

Note that it requires to install **`eksctl` `0.210.0`** before being able to run a test, I'm going to update our CI image in a bit.