### PR TITLE
update to go 1.24.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/cloud-on-k8s/v3
 
-go 1.24.2
+go 1.24.4
 
 require (
 	dario.cat/mergo v1.0.2

--- a/hack/config-extractor/go.mod
+++ b/hack/config-extractor/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/cloud-on-k8s/v3/hack/config-extractor
 
-go 1.24.2
+go 1.24.4
 
 require (
 	k8s.io/api v0.33.2

--- a/hack/helm/release/go.mod
+++ b/hack/helm/release/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/cloud-on-k8s/hack/helm/release
 
-go 1.24.2
+go 1.24.4
 
 require (
 	cloud.google.com/go/storage v1.55.0

--- a/hack/operatorhub/go.mod
+++ b/hack/operatorhub/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/cloud-on-k8s/v3/hack/operatorhub
 
-go 1.24.2
+go 1.24.4
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0

--- a/hack/upgrade-test-harness/go.mod
+++ b/hack/upgrade-test-harness/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/cloud-on-k8s/v3/hack/upgrade-test-harness
 
-go 1.24.2
+go 1.24.4
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -1,5 +1,5 @@
 # Docker image for the E2E tests runner
-FROM docker.io/library/golang:1.24.2
+FROM docker.io/library/golang:1.24.4
 
 ARG GO_TAGS
 


### PR DESCRIPTION
updating all components to require go 1.24.4. We are already using this version in our buildkite agents, so we are building with the operator with go 1.24.4