### PR TITLE
Add Elastic renovate bot to allow list for buildkite

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -5,7 +5,7 @@
       "pipeline_slug": "cloud-on-k8s-operator",
       "allow_org_users": true,
       "allowed_repo_permissions": ["admin", "write"],
-      "allowed_list": ["renovate[bot]"],
+      "allowed_list": ["renovate[bot]", "elastic-renovate-prod[bot]"],
       "build_on_commit": true,
       "build_on_comment": true,
       "trigger_comment_regex": "^(?:(?:buildkite\\s+)?(?:build|test)\\s+(?:this|it))\\s*(?<args>.*)",


### PR DESCRIPTION
Adding the Elastic renovate bot to the allowed list for buildkite so that renovate PRs can have buildkite builds kicked off automatically.
