### PR TITLE
Revert "fix: enable image signing (#8737)"

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -75,7 +75,7 @@ steps:
           DRIVAH_BUILD_PATH: "build"
           DRIVAH_AMD_AGENT_MEMORY: "5G"
           RECURSIVE: true
-          SIGN_IMAGES: true
+          SIGN_IMAGES: false
 
   - group: build e2e-tests
     key: "e2e-tests-image-build"


### PR DESCRIPTION
This reverts commit 56edeed82568abc7d420a5d838c38b6e84a80035 from https://github.com/elastic/cloud-on-k8s/pull/8737

Refer to https://github.com/elastic/cloud-on-k8s/issues/8736#issuecomment-3078204826 for additional context.