### PR TITLE
Revert "fix: enable image signing (#8737)" (#8755)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -75,7 +75,7 @@ steps:
           DRIVAH_BUILD_PATH: "build"
           DRIVAH_AMD_AGENT_MEMORY: "5G"
           RECURSIVE: true
-          SIGN_IMAGES: true
+          SIGN_IMAGES: false
 
   - group: build e2e-tests
     key: "e2e-tests-image-build"


### PR DESCRIPTION
Backport https://github.com/elastic/cloud-on-k8s/pull/8755 into `3.1`