### PR TITLE
Fix broken links in 8.19 docs version bump (2.15)

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/readiness.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/readiness.asciidoc
@@ -47,4 +47,4 @@ Note that this requires restarting the Pods.
 
 == Elasticsearch versions 8.2.0 and later
 
-We do not recommend overriding the default readiness probe on Elasticsearch 8.2.0 and later. ECK configures a socket based readiness probe using the Elasticsearch link:https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html#tcp-readiness-port[readiness port feature] which is not influenced by the load on the Elasticsearch cluster.
+We do not recommend overriding the default readiness probe on Elasticsearch 8.2.0 and later. ECK configures a socket based readiness probe using the Elasticsearch link:https://www.elastic.co/guide/en/elasticsearch/reference/8.19/modules-network.html#readiness-tcp-port[readiness port feature] which is not influenced by the load on the Elasticsearch cluster.

--- a/docs/release-notes/highlights-2.14.0.asciidoc
+++ b/docs/release-notes/highlights-2.14.0.asciidoc
@@ -35,7 +35,7 @@ Starting with ECK 2.14.0 it becomes possible to fully delegate the transport cer
 [id="{p}-2140-advanced-readiness-probe"]
 === Advanced readiness probe
 
-The Elasticsearch containers are now configured to use the link:https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html#tcp-readiness-port[Elasticsearch TCP readiness port]. This change also improves cluster upgrade stability by fixing a bug in the upgrade process.
+The Elasticsearch containers are now configured to use the link:https://www.elastic.co/guide/en/elasticsearch/reference/8.19/modules-network.html#readiness-tcp-port[Elasticsearch TCP readiness port]. This change also improves cluster upgrade stability by fixing a bug in the upgrade process.
 
 [float]
 [id="{p}-2140-connect-resources-to-serverless"]


### PR DESCRIPTION
Duplicate of https://github.com/elastic/cloud-on-k8s/pull/8764 for v2.15.