### PR TITLE
Avoid vault initialisation on local kind runs

### DIFF
--- a/hack/deployer/runner/kind.go
+++ b/hack/deployer/runner/kind.go
@@ -70,20 +70,16 @@ type KindDriverFactory struct{}
 var _ DriverFactory = &KindDriverFactory{}
 
 func (k KindDriverFactory) Create(plan Plan) (Driver, error) {
-	c, err := vault.NewClient()
-	if err != nil {
-		return nil, err
-	}
 	return &KindDriver{
 		plan:        plan,
-		vaultClient: c,
+		vaultClient: vault.NewClientProvider(),
 	}, nil
 }
 
 type KindDriver struct {
 	plan        Plan
 	clientImage string
-	vaultClient vault.Client
+	vaultClient vault.ClientProvider
 }
 
 func (k *KindDriver) Execute() error {

--- a/hack/deployer/runner/ocp.go
+++ b/hack/deployer/runner/ocp.go
@@ -231,7 +231,7 @@ func (d *OCPDriver) setupDisks() error {
 }
 
 func (d *OCPDriver) ensureClientImage() error {
-	image, err := ensureClientImage(OCPDriverID, d.vaultClient, d.plan.ClientVersion, d.plan.ClientBuildDefDir)
+	image, err := ensureClientImage(OCPDriverID, vault.Provide(d.vaultClient), d.plan.ClientVersion, d.plan.ClientBuildDefDir)
 	if err != nil {
 		return err
 	}

--- a/pkg/utils/vault/client.go
+++ b/pkg/utils/vault/client.go
@@ -42,6 +42,14 @@ func NewClientProvider() func() (Client, error) {
 	}
 }
 
+// Provide returns a client provider for the given client.
+// Convenience function to avoid a lambda function when you already have a client.
+func Provide(c Client) ClientProvider {
+	return func() (Client, error) {
+		return c, nil
+	}
+}
+
 func NewClient() (Client, error) {
 	client, err := api.NewClient(api.DefaultConfig())
 	if err != nil {


### PR DESCRIPTION
When running kind locally for testing, vault access is not needed. However because deployer eagerly initialises the client we always create the client and VPN etc is needed. 

This lazily initialises the client to make local testing somewhat more convenient.