### PR TITLE
Check Close() errors to detect precondition failures during index.yaml upload

### DIFF
--- a/hack/helm/release/internal/helm/helm.go
+++ b/hack/helm/release/internal/helm/helm.go
@@ -299,7 +299,9 @@ func updateIndex(ctx context.Context, conf ReleaseConfig, tempDir string) error 
 	if _, err = io.Copy(newIndexObjWriter, newIndexFile); err != nil {
 		return fmt.Errorf("while copying new index.yaml to bucket: %w", err)
 	}
-	defer newIndexObjWriter.Close()
+	if err := newIndexObjWriter.Close(); err != nil {
+		return fmt.Errorf("while finalizing upload of index.yaml: %w", err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
This replaces the deferred `Close()` with an explicit one so we can detect cases where the upload fails due to the GenerationMatch precondition (e.g., another release updated the file). This helps avoid silent race-condition issues.

