### PR TITLE
Use the port 8080 health check instead of enabling anonymous access

### DIFF
--- a/config/recipes/gclb/01-elastic-stack.yaml
+++ b/config/recipes/gclb/01-elastic-stack.yaml
@@ -23,11 +23,6 @@ spec:
     count: 3
     config:
       node.store.allow_mmap: false
-      # Enable anonymous access to allow GCLB health probes to succeed
-      xpack.security.authc:
-        anonymous:
-          username: anon
-          roles: monitoring_user
     podTemplate:
       spec:
         containers:

--- a/config/recipes/gclb/02-ingress.yaml
+++ b/config/recipes/gclb/02-ingress.yaml
@@ -37,3 +37,18 @@ spec:
                 name: hulk-kb-http
                 port:
                   name: https
+---
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: es-lb-healthcheck
+spec:
+  default:
+    config:
+      tcpHealthCheck:
+        port: 8080
+      type: TCP
+  targetRef:
+    group: ''
+    kind: Service
+    name: hulk-es-http


### PR DESCRIPTION
For more information on TCP health checks, see the GCP documentation https://cloud.google.com/load-balancing/docs/health-check-concepts#method

<!--
Thank you for your interest in contributing to Elastic Cloud on Kubernetes!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/cloud-on-k8s/tree/main/CONTRIBUTING.md)?
- If you submit code, is your pull request against main? We recommend pull requests against main. We will backport them as needed.
