### PR TITLE
Improving the default PDB implementation.

### DIFF
--- a/pkg/controller/common/license/check.go
+++ b/pkg/controller/common/license/check.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"time"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -100,23 +99,24 @@ func (lc *checker) EnterpriseFeaturesEnabled(ctx context.Context) (bool, error) 
 
 // Valid returns true if the given Enterprise license is valid or an error if any.
 func (lc *checker) Valid(ctx context.Context, l EnterpriseLicense) (bool, error) {
-	pk, err := lc.publicKeyFor(l)
-	if err != nil {
-		return false, errors.Wrap(err, "while loading signature secret")
-	}
-	if len(pk) == 0 {
-		ulog.FromContext(ctx).Info("This is an unlicensed development build of ECK. License management and Enterprise features are disabled")
-		return false, nil
-	}
-	verifier, err := NewVerifier(pk)
-	if err != nil {
-		return false, err
-	}
-	status := verifier.Valid(ctx, l, time.Now())
-	if status == LicenseStatusValid {
-		return true, nil
-	}
-	return false, nil
+	return true, nil
+	// pk, err := lc.publicKeyFor(l)
+	// if err != nil {
+	// 	return false, errors.Wrap(err, "while loading signature secret")
+	// }
+	// if len(pk) == 0 {
+	// 	ulog.FromContext(ctx).Info("This is an unlicensed development build of ECK. License management and Enterprise features are disabled")
+	// 	return false, nil
+	// }
+	// verifier, err := NewVerifier(pk)
+	// if err != nil {
+	// 	return false, err
+	// }
+	// status := verifier.Valid(ctx, l, time.Now())
+	// if status == LicenseStatusValid {
+	// 	return true, nil
+	// }
+	// return false, nil
 }
 
 // ValidOperatorLicenseKeyType returns true if the current operator license key is valid

--- a/pkg/controller/common/license/check.go
+++ b/pkg/controller/common/license/check.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -99,24 +100,23 @@ func (lc *checker) EnterpriseFeaturesEnabled(ctx context.Context) (bool, error) 
 
 // Valid returns true if the given Enterprise license is valid or an error if any.
 func (lc *checker) Valid(ctx context.Context, l EnterpriseLicense) (bool, error) {
-	return true, nil
-	// pk, err := lc.publicKeyFor(l)
-	// if err != nil {
-	// 	return false, errors.Wrap(err, "while loading signature secret")
-	// }
-	// if len(pk) == 0 {
-	// 	ulog.FromContext(ctx).Info("This is an unlicensed development build of ECK. License management and Enterprise features are disabled")
-	// 	return false, nil
-	// }
-	// verifier, err := NewVerifier(pk)
-	// if err != nil {
-	// 	return false, err
-	// }
-	// status := verifier.Valid(ctx, l, time.Now())
-	// if status == LicenseStatusValid {
-	// 	return true, nil
-	// }
-	// return false, nil
+	pk, err := lc.publicKeyFor(l)
+	if err != nil {
+		return false, errors.Wrap(err, "while loading signature secret")
+	}
+	if len(pk) == 0 {
+		ulog.FromContext(ctx).Info("This is an unlicensed development build of ECK. License management and Enterprise features are disabled")
+		return false, nil
+	}
+	verifier, err := NewVerifier(pk)
+	if err != nil {
+		return false, err
+	}
+	status := verifier.Valid(ctx, l, time.Now())
+	if status == LicenseStatusValid {
+		return true, nil
+	}
+	return false, nil
 }
 
 // ValidOperatorLicenseKeyType returns true if the current operator license key is valid

--- a/pkg/controller/common/statefulset/fixtures.go
+++ b/pkg/controller/common/statefulset/fixtures.go
@@ -24,6 +24,14 @@ type TestSset struct {
 	Master          bool
 	Data            bool
 	Ingest          bool
+	ML              bool
+	Transform       bool
+	RemoteClusterClient bool
+	DataHot         bool
+	DataWarm        bool
+	DataCold        bool
+	DataContent     bool
+	DataFrozen      bool
 	Status          appsv1.StatefulSetStatus
 	ResourceVersion string
 }
@@ -54,6 +62,14 @@ func (t TestSset) Build() appsv1.StatefulSet {
 	label.NodeTypesMasterLabelName.Set(t.Master, labels)
 	label.NodeTypesDataLabelName.Set(t.Data, labels)
 	label.NodeTypesIngestLabelName.Set(t.Ingest, labels)
+	label.NodeTypesMLLabelName.Set(t.ML, labels)
+	label.NodeTypesTransformLabelName.Set(t.Transform, labels)
+	label.NodeTypesRemoteClusterClientLabelName.Set(t.RemoteClusterClient, labels)
+	label.NodeTypesDataHotLabelName.Set(t.DataHot, labels)
+	label.NodeTypesDataWarmLabelName.Set(t.DataWarm, labels)
+	label.NodeTypesDataColdLabelName.Set(t.DataCold, labels)
+	label.NodeTypesDataContentLabelName.Set(t.DataContent, labels)
+	label.NodeTypesDataFrozenLabelName.Set(t.DataFrozen, labels)
 	statefulSet := appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      t.Name,
@@ -95,6 +111,14 @@ type TestPod struct {
 	Master          bool
 	Data            bool
 	Ingest          bool
+	ML              bool
+	Transform       bool
+	RemoteClusterClient bool
+	DataHot         bool
+	DataWarm        bool
+	DataCold        bool
+	DataContent     bool
+	DataFrozen      bool
 	Ready           bool
 	RestartCount    int32
 	Phase           corev1.PodPhase
@@ -111,6 +135,14 @@ func (t TestPod) Build() corev1.Pod {
 	label.NodeTypesMasterLabelName.Set(t.Master, labels)
 	label.NodeTypesDataLabelName.Set(t.Data, labels)
 	label.NodeTypesIngestLabelName.Set(t.Ingest, labels)
+	label.NodeTypesMLLabelName.Set(t.ML, labels)
+	label.NodeTypesTransformLabelName.Set(t.Transform, labels)
+	label.NodeTypesRemoteClusterClientLabelName.Set(t.RemoteClusterClient, labels)
+	label.NodeTypesDataHotLabelName.Set(t.DataHot, labels)
+	label.NodeTypesDataWarmLabelName.Set(t.DataWarm, labels)
+	label.NodeTypesDataColdLabelName.Set(t.DataCold, labels)
+	label.NodeTypesDataContentLabelName.Set(t.DataContent, labels)
+	label.NodeTypesDataFrozenLabelName.Set(t.DataFrozen, labels)
 
 	status := corev1.PodStatus{
 		// assume Running by default

--- a/pkg/controller/elasticsearch/pdb/dfs.go
+++ b/pkg/controller/elasticsearch/pdb/dfs.go
@@ -5,12 +5,59 @@
 package pdb
 
 import (
+	"slices"
+
 	appsv1 "k8s.io/api/apps/v1"
 
+	esv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/sset"
 )
 
-// groupBySharedRoles groups StatefulSets that share at least one role using DFS.
+var (
+	dataRoles = []string{
+		string(esv1.DataRole),
+		string(esv1.DataHotRole),
+		string(esv1.DataWarmRole),
+		string(esv1.DataColdRole),
+		string(esv1.DataContentRole),
+		// Note: DataFrozenRole is excluded as it has different disruption rules (yellow+ health)
+	}
+)
+
+// normalizeRole returns the normalized form of a role where any data role
+// is normalized to the same data role.
+func normalizeRole(role string) string {
+	if slices.Contains(dataRoles, role) {
+		return string(esv1.DataRole)
+	}
+	return role
+}
+
+// groupBySharedRoles groups StatefulSets that share at least one role by first building an adjacency list based
+// on shared roles and then using a depth-first search (DFS) to find connected components.
+//
+// Why an adjacency list?
+// 1. It's a simple way to represent connected components.
+//
+// Example:
+// With the following StatefulSets:
+// - StatefulSet A (idx 0) with roles ["master", "data"]
+// - StatefulSet B (idx 1) with roles ["data_cold"]
+// - StatefulSet C (idx 2) with roles ["data"]
+// - StatefulSet D (idx 3) with roles ["coordinating"]
+//
+// The adjacency list would be:
+// [
+//	[1, 2] # sts idx 0 is connected to sts idx 1 and 2
+//	[0, 2] # sts idx 1 is connected to sts idx 0 and 2
+//	[0, 1] # sts idx 2 is connected to sts idx 0 and 1
+//	[]     # sts idx 3 is not connected to any other sts'
+// ]
+//
+// Why DFS?
+//  1. It's a well known, simple algorithm for traversing or searching tree or graph data structures.
+//  2. It's efficient enough for exploring all connected components in a graph.
+//     (I believe "union-find" is slightly more efficient, but at this data size it doesn't matter.)
 func groupBySharedRoles(statefulSets sset.StatefulSetList) [][]appsv1.StatefulSet {
 	n := len(statefulSets)
 	if n == 0 {
@@ -30,24 +77,19 @@ func groupBySharedRoles(statefulSets sset.StatefulSetList) [][]appsv1.StatefulSe
 			continue
 		}
 		for _, role := range roles {
-			roleToIndices[string(role)] = append(roleToIndices[string(role)], i)
+			normalizedRole := normalizeRole(string(role))
+			roleToIndices[normalizedRole] = append(roleToIndices[normalizedRole], i)
 		}
 	}
 
-	// Create edges between StatefulSets that share any role
+	// Populate the adjacency list with each StatefulSet index, and the slice of StatefulSet
+	// indices which share roles.
 	for _, indices := range roleToIndices {
 		for i := 1; i < len(indices); i++ {
 			// Connect each StatefulSet to the first StatefulSet with the same role
 			// This ensures all StatefulSets with the role are in the same component
 			adjList[indices[0]] = append(adjList[indices[0]], indices[i])
 			adjList[indices[i]] = append(adjList[indices[i]], indices[0])
-			// Optionally, connect all pairs for a fully connected component
-			for j := 1; j < len(indices); j++ {
-				if indices[i] != indices[j] {
-					adjList[indices[i]] = append(adjList[indices[i]], indices[j])
-					adjList[indices[j]] = append(adjList[indices[j]], indices[i])
-				}
-			}
 		}
 	}
 
@@ -64,27 +106,28 @@ func groupBySharedRoles(statefulSets sset.StatefulSetList) [][]appsv1.StatefulSe
 		stack := []int{i}
 
 		for len(stack) > 0 {
-			// Pop the top node from the stack
-			node := stack[len(stack)-1]
+			// Retrieve the top node from the stack
+			stsIdx := stack[len(stack)-1]
+			// Remove the top node from the stack
 			stack = stack[:len(stack)-1]
 
-			if visited[node] {
+			if visited[stsIdx] {
 				continue
 			}
 
-			// Mark node as visited and add to group
-			visited[node] = true
-			group = append(group, statefulSets[node])
+			// Mark statefulSet as visited and add to group
+			visited[stsIdx] = true
+			group = append(group, statefulSets[stsIdx])
 
-			// Push all unvisited neighbors onto the stack
-			for _, neighbor := range adjList[node] {
+			// Using the adjacency list previously built, push all unvisited statefulSets onto the stack
+			// so they are visited on the next iteration.
+			for _, neighbor := range adjList[stsIdx] {
 				if !visited[neighbor] {
 					stack = append(stack, neighbor)
 				}
 			}
 		}
 
-		// Add the group to the result
 		result = append(result, group)
 	}
 

--- a/pkg/controller/elasticsearch/pdb/dfs.go
+++ b/pkg/controller/elasticsearch/pdb/dfs.go
@@ -48,10 +48,12 @@ func normalizeRole(role string) string {
 //
 // The adjacency list would be:
 // [
+//
 //	[1, 2] # sts idx 0 is connected to sts idx 1 and 2
 //	[0, 2] # sts idx 1 is connected to sts idx 0 and 2
 //	[0, 1] # sts idx 2 is connected to sts idx 0 and 1
 //	[]     # sts idx 3 is not connected to any other sts'
+//
 // ]
 //
 // Why DFS?
@@ -64,7 +66,6 @@ func groupBySharedRoles(statefulSets sset.StatefulSetList) [][]appsv1.StatefulSe
 		return [][]appsv1.StatefulSet{}
 	}
 
-	// Build adjacency list based on shared roles
 	adjList := make([][]int, n)
 	roleToIndices := make(map[string][]int)
 

--- a/pkg/controller/elasticsearch/pdb/dfs.go
+++ b/pkg/controller/elasticsearch/pdb/dfs.go
@@ -73,7 +73,6 @@ func groupBySharedRoles(statefulSets sset.StatefulSetList) [][]appsv1.StatefulSe
 
 // buildConnectedStatefulSets uses iterative DFS (avoiding recursion) to find connected statefulSets.
 func buildConnectedStatefulSets(statefulSets sset.StatefulSetList, adjList [][]int, size int) [][]appsv1.StatefulSet {
-	// Use iterative DFS (avoiding recursion) to find connected statefulsets.
 	var result [][]appsv1.StatefulSet
 	visited := make([]bool, size)
 

--- a/pkg/controller/elasticsearch/pdb/dfs.go
+++ b/pkg/controller/elasticsearch/pdb/dfs.go
@@ -1,0 +1,92 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package pdb
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/sset"
+)
+
+// groupBySharedRoles groups StatefulSets that share at least one role using DFS.
+func groupBySharedRoles(statefulSets sset.StatefulSetList) [][]appsv1.StatefulSet {
+	n := len(statefulSets)
+	if n == 0 {
+		return [][]appsv1.StatefulSet{}
+	}
+
+	// Build adjacency list based on shared roles
+	adjList := make([][]int, n)
+	roleToIndices := make(map[string][]int)
+
+	// Map roles to StatefulSet indices
+	for i, sset := range statefulSets {
+		roles := getRolesFromStatefulSetPodTemplate(sset)
+		if len(roles) == 0 {
+			// StatefulSets with no roles are coordinating nodes - group them together
+			roleToIndices["coordinating"] = append(roleToIndices["coordinating"], i)
+			continue
+		}
+		for _, role := range roles {
+			roleToIndices[string(role)] = append(roleToIndices[string(role)], i)
+		}
+	}
+
+	// Create edges between StatefulSets that share any role
+	for _, indices := range roleToIndices {
+		for i := 1; i < len(indices); i++ {
+			// Connect each StatefulSet to the first StatefulSet with the same role
+			// This ensures all StatefulSets with the role are in the same component
+			adjList[indices[0]] = append(adjList[indices[0]], indices[i])
+			adjList[indices[i]] = append(adjList[indices[i]], indices[0])
+			// Optionally, connect all pairs for a fully connected component
+			for j := 1; j < len(indices); j++ {
+				if indices[i] != indices[j] {
+					adjList[indices[i]] = append(adjList[indices[i]], indices[j])
+					adjList[indices[j]] = append(adjList[indices[j]], indices[i])
+				}
+			}
+		}
+	}
+
+	// use iterative DFS (avoiding recursion) to find connected components
+	var result [][]appsv1.StatefulSet
+	visited := make([]bool, n)
+
+	for i := range statefulSets {
+		if visited[i] {
+			continue
+		}
+
+		group := []appsv1.StatefulSet{}
+		stack := []int{i}
+
+		for len(stack) > 0 {
+			// Pop the top node from the stack
+			node := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+
+			if visited[node] {
+				continue
+			}
+
+			// Mark node as visited and add to group
+			visited[node] = true
+			group = append(group, statefulSets[node])
+
+			// Push all unvisited neighbors onto the stack
+			for _, neighbor := range adjList[node] {
+				if !visited[neighbor] {
+					stack = append(stack, neighbor)
+				}
+			}
+		}
+
+		// Add the group to the result
+		result = append(result, group)
+	}
+
+	return result
+}

--- a/pkg/controller/elasticsearch/pdb/dfs.go
+++ b/pkg/controller/elasticsearch/pdb/dfs.go
@@ -100,9 +100,9 @@ func buildConnectedStatefulSets(statefulSets sset.StatefulSetList, adjList [][]i
 
 			// Using the adjacency list previously built, push all unvisited statefulSets onto the stack
 			// so they are visited on the next iteration.
-			for _, neighbor := range adjList[stsIdx] {
-				if !visited[neighbor] {
-					stack = append(stack, neighbor)
+			for _, sts := range adjList[stsIdx] {
+				if !visited[sts] {
+					stack = append(stack, sts)
 				}
 			}
 		}

--- a/pkg/controller/elasticsearch/pdb/dfs_test.go
+++ b/pkg/controller/elasticsearch/pdb/dfs_test.go
@@ -1,0 +1,219 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package pdb
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+
+	ssetfixtures "github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/statefulset"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/sset"
+)
+
+func TestGroupBySharedRoles(t *testing.T) {
+	tests := []struct {
+		name         string
+		statefulSets sset.StatefulSetList
+		want         [][]appsv1.StatefulSet
+	}{
+		{
+			name:         "empty statefulsets",
+			statefulSets: sset.StatefulSetList{},
+			want:         [][]appsv1.StatefulSet{},
+		},
+		{
+			name: "single statefulset with no roles",
+			statefulSets: sset.StatefulSetList{
+				ssetfixtures.TestSset{Name: "coordinating"}.Build(),
+			},
+			want: [][]appsv1.StatefulSet{
+				{
+					ssetfixtures.TestSset{Name: "coordinating"}.Build(),
+				},
+			},
+		},
+		{
+			name: "all statefulsets with different roles",
+			statefulSets: sset.StatefulSetList{
+				ssetfixtures.TestSset{Name: "master", Master: true}.Build(),
+				ssetfixtures.TestSset{Name: "ingest", Ingest: true}.Build(),
+			},
+			want: [][]appsv1.StatefulSet{
+				{
+					ssetfixtures.TestSset{Name: "master", Master: true}.Build(),
+				},
+				{
+					ssetfixtures.TestSset{Name: "ingest", Ingest: true}.Build(),
+				},
+			},
+		},
+		{
+			name: "statefulsets with shared roles are grouped properly",
+			statefulSets: sset.StatefulSetList{
+				ssetfixtures.TestSset{Name: "master", Master: true, Data: true}.Build(),
+				ssetfixtures.TestSset{Name: "data", Data: true}.Build(),
+				ssetfixtures.TestSset{Name: "ingest", Ingest: true}.Build(),
+			},
+			want: [][]appsv1.StatefulSet{
+				{
+					ssetfixtures.TestSset{Name: "master", Master: true, Data: true}.Build(),
+					ssetfixtures.TestSset{Name: "data", Data: true}.Build(),
+				},
+				{
+					ssetfixtures.TestSset{Name: "ingest", Ingest: true}.Build(),
+				},
+			},
+		},
+		{
+			name: "statefulsets with multiple shared roles in multiple groups, and data* roles are grouped properly",
+			statefulSets: sset.StatefulSetList{
+				ssetfixtures.TestSset{Name: "master", Master: true, Data: true}.Build(),
+				ssetfixtures.TestSset{Name: "data", Data: true}.Build(),
+				ssetfixtures.TestSset{Name: "data_hot", DataHot: true}.Build(),
+				ssetfixtures.TestSset{Name: "data_warm", DataWarm: true}.Build(),
+				ssetfixtures.TestSset{Name: "data_cold", DataCold: true}.Build(),
+				ssetfixtures.TestSset{Name: "ingest", Ingest: true, ML: true}.Build(),
+				ssetfixtures.TestSset{Name: "ml", ML: true}.Build(),
+			},
+			want: [][]appsv1.StatefulSet{
+				{
+					ssetfixtures.TestSset{Name: "master", Master: true, Data: true}.Build(),
+					ssetfixtures.TestSset{Name: "data", Data: true}.Build(),
+					ssetfixtures.TestSset{Name: "data_hot", DataHot: true}.Build(),
+					ssetfixtures.TestSset{Name: "data_warm", DataWarm: true}.Build(),
+					ssetfixtures.TestSset{Name: "data_cold", DataCold: true}.Build(),
+				},
+				{
+					ssetfixtures.TestSset{Name: "ingest", Ingest: true, ML: true}.Build(),
+					ssetfixtures.TestSset{Name: "ml", ML: true}.Build(),
+				},
+			},
+		},
+		{
+			name: "coordinating nodes (no roles) in separate group",
+			statefulSets: sset.StatefulSetList{
+				ssetfixtures.TestSset{Name: "data", Data: true}.Build(),
+				ssetfixtures.TestSset{Name: "coordinating1"}.Build(),
+				ssetfixtures.TestSset{Name: "coordinating2"}.Build(),
+			},
+			want: [][]appsv1.StatefulSet{
+				{
+					ssetfixtures.TestSset{Name: "data", Data: true}.Build(),
+				},
+				{
+					ssetfixtures.TestSset{Name: "coordinating1"}.Build(),
+					ssetfixtures.TestSset{Name: "coordinating2"}.Build(),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := groupBySharedRoles(tt.statefulSets)
+			sortStatefulSetGroups(tt.want)
+			sortStatefulSetGroups(got)
+			assert.Equal(t, len(tt.want), len(got), "Expected %d groups, got %d", len(tt.want), len(got))
+
+			for i := 0; i < len(tt.want); i++ {
+				if i >= len(got) {
+					t.Errorf("Missing group at index %d", i)
+					continue
+				}
+
+				assert.Equal(t, len(tt.want[i]), len(got[i]), "Group %d has wrong size", i)
+
+				// Check if all StatefulSets in the group match
+				for j := 0; j < len(tt.want[i]); j++ {
+					if j >= len(got[i]) {
+						t.Errorf("Missing StatefulSet at index %d in group %d", j, i)
+						continue
+					}
+
+					assert.Equal(t, tt.want[i][j].Name, got[i][j].Name, "StatefulSet names do not match in group %d", i)
+					assert.Equal(t, tt.want[i][j].Spec.Template.Labels, got[i][j].Spec.Template.Labels, "StatefulSet labels do not match in group %d", i)
+				}
+			}
+		})
+	}
+}
+
+// sortStatefulSetGroups sorts the groups and StatefulSets within groups by name
+// for consistent comparison in tests
+func sortStatefulSetGroups(groups [][]appsv1.StatefulSet) {
+	// Sort the StatefulSets within each group by name
+	for i := range groups {
+		sortStatefulSets(groups[i])
+	}
+
+	// Consistent sorting:
+	// 1. First by size (largest first)
+	// 2. For groups of same size, sort by first StatefulSet name
+	for i := range groups {
+		for j := i + 1; j < len(groups); j++ {
+			// Sort by size (largest first)
+			if len(groups[i]) < len(groups[j]) {
+				groups[i], groups[j] = groups[j], groups[i]
+			} else if len(groups[i]) == len(groups[j]) && len(groups[i]) > 0 && len(groups[j]) > 0 {
+				// If same size and not empty, sort by name
+				if groups[i][0].Name > groups[j][0].Name {
+					groups[i], groups[j] = groups[j], groups[i]
+				}
+			}
+		}
+	}
+}
+
+func sortStatefulSets(sts []appsv1.StatefulSet) {
+	slices.SortFunc(sts, func(i, j appsv1.StatefulSet) int {
+		return strings.Compare(i.Name, j.Name)
+	})
+}
+
+// TestNormalizeRole tests the normalizeRole function
+func TestNormalizeRole(t *testing.T) {
+	tests := []struct {
+		name     string
+		role     string
+		expected string
+	}{
+		{
+			name:     "data role should remain the same",
+			role:     "data",
+			expected: "data",
+		},
+		{
+			name:     "data_hot role should be normalized to data",
+			role:     "data_hot",
+			expected: "data",
+		},
+		{
+			name:     "data_frozen role should remain the same",
+			role:     "data_frozen",
+			expected: "data_frozen",
+		},
+		{
+			name:     "other roles should remain the same",
+			role:     "master",
+			expected: "master",
+		},
+		{
+			name:     "empty role should remain empty",
+			role:     "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeRole(tt.role)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/pkg/controller/elasticsearch/pdb/dfs_test.go
+++ b/pkg/controller/elasticsearch/pdb/dfs_test.go
@@ -161,7 +161,6 @@ func sortStatefulSetGroups(groups [][]appsv1.StatefulSet) {
 	})
 }
 
-// TestNormalizeRole tests the normalizeRole function
 func TestNormalizeRole(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/controller/elasticsearch/pdb/dfs_test.go
+++ b/pkg/controller/elasticsearch/pdb/dfs_test.go
@@ -156,13 +156,6 @@ func sortStatefulSetGroups(groups [][]appsv1.StatefulSet) {
 
 	// Then sort the groups by the name of the first StatefulSet in each group
 	slices.SortFunc(groups, func(a, b []appsv1.StatefulSet) int {
-		// Empty groups come last
-		if len(a) == 0 {
-			return 1
-		}
-		if len(b) == 0 {
-			return -1
-		}
 		// Compare first StatefulSet names
 		return strings.Compare(a[0].Name, b[0].Name)
 	})

--- a/pkg/controller/elasticsearch/pdb/reconcile.go
+++ b/pkg/controller/elasticsearch/pdb/reconcile.go
@@ -6,6 +6,7 @@ package pdb
 
 import (
 	"context"
+	"fmt"
 
 	policyv1 "k8s.io/api/policy/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
@@ -36,7 +37,7 @@ func Reconcile(ctx context.Context, k8sClient k8s.Client, es esv1.Elasticsearch,
 	licenseChecker := lic.NewLicenseChecker(k8sClient, es.Namespace)
 	enterpriseEnabled, err := licenseChecker.EnterpriseFeaturesEnabled(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("while checking license during pdb reconciliation: %w", err)
 	}
 	if enterpriseEnabled {
 		return reconcileRoleSpecificPDBs(ctx, k8sClient, es, statefulSets, meta)

--- a/pkg/controller/elasticsearch/pdb/reconcile.go
+++ b/pkg/controller/elasticsearch/pdb/reconcile.go
@@ -28,10 +28,11 @@ import (
 )
 
 // Reconcile ensures that a PodDisruptionBudget exists for this cluster, inheriting the spec content.
-// The default PDB we setup dynamically adapts MinAvailable to the number of nodes in the cluster.
+// For non-enterprise users: The default PDB we setup dynamically adapts MinAvailable to the number of nodes in the cluster.
+// For enterprise users: We optimize the PDBs that we setup to speed up Kubernetes cluster operations such as upgrades as much as safely possible.
+//
 // If the spec has disabled the default PDB, it will ensure none exist.
 func Reconcile(ctx context.Context, k8sClient k8s.Client, es esv1.Elasticsearch, statefulSets sset.StatefulSetList, meta metadata.Metadata) error {
-	// License check: enterprise-specific PDBs
 	licenseChecker := lic.NewLicenseChecker(k8sClient, es.Namespace)
 	enterpriseEnabled, err := licenseChecker.EnterpriseFeaturesEnabled(ctx)
 	if err != nil {

--- a/pkg/controller/elasticsearch/pdb/reconcile.go
+++ b/pkg/controller/elasticsearch/pdb/reconcile.go
@@ -28,9 +28,12 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
 )
 
-// Reconcile ensures that a PodDisruptionBudget exists for this cluster, inheriting the spec content.
+// Reconcile ensures that PodDisruptionBudget(s) exists for this cluster, inheriting the spec content.
+//
 // For non-enterprise users: The default PDB we setup dynamically adapts MinAvailable to the number of nodes in the cluster.
-// For enterprise users: We optimize the PDBs that we setup to speed up Kubernetes cluster operations such as upgrades as much as safely possible.
+// For enterprise users: We optimize the PDBs that we setup to speed up Kubernetes cluster operations such as upgrades as much as safely possible
+//	                     by grouping statefulSets by associated Elasticsearch node roles into the same PDB, and then dynamically maxUnavailable
+//	                     according to whatever cluster health is optimal for the set of roles.
 //
 // If the spec has disabled the default PDB, it will ensure none exist.
 func Reconcile(ctx context.Context, k8sClient k8s.Client, es esv1.Elasticsearch, statefulSets sset.StatefulSetList, meta metadata.Metadata) error {

--- a/pkg/controller/elasticsearch/pdb/reconcile_test.go
+++ b/pkg/controller/elasticsearch/pdb/reconcile_test.go
@@ -32,25 +32,26 @@ import (
 	es_sset "github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/sset"
 )
 
-func TestReconcile(t *testing.T) {
-	defaultPDB := func() *policyv1.PodDisruptionBudget {
-		return &policyv1.PodDisruptionBudget{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      esv1.DefaultPodDisruptionBudget("cluster"),
-				Namespace: "ns",
-				Labels:    map[string]string{label.ClusterNameLabelName: "cluster", commonv1.TypeLabelName: label.Type},
-			},
-			Spec: policyv1.PodDisruptionBudgetSpec{
-				MinAvailable: intStrPtr(intstr.FromInt(3)),
-				Selector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						label.ClusterNameLabelName: "cluster",
-					},
+func defaultPDB() *policyv1.PodDisruptionBudget {
+	return &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      esv1.DefaultPodDisruptionBudget("cluster"),
+			Namespace: "ns",
+			Labels:    map[string]string{label.ClusterNameLabelName: "cluster", commonv1.TypeLabelName: label.Type},
+		},
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			MinAvailable: intStrPtr(intstr.FromInt(3)),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					label.ClusterNameLabelName: "cluster",
 				},
-				MaxUnavailable: nil,
 			},
-		}
+			MaxUnavailable: nil,
+		},
 	}
+}
+
+func TestReconcile(t *testing.T) {
 	defaultEs := esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{Name: "cluster", Namespace: "ns"}}
 	type args struct {
 		initObjs     []client.Object
@@ -371,7 +372,7 @@ func Test_allowedDisruptions(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := allowedDisruptions(tt.args.es, tt.args.actualSsets); got != tt.want {
+			if got := allowedDisruptionsForRole(tt.args.es, esv1.DataRole, tt.args.actualSsets); got != tt.want {
 				t.Errorf("allowedDisruptions() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/controller/elasticsearch/pdb/roles.go
+++ b/pkg/controller/elasticsearch/pdb/roles.go
@@ -1,0 +1,435 @@
+package pdb
+
+import (
+	"context"
+	"slices"
+	"sort"
+
+	appsv1 "k8s.io/api/apps/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	esv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/metadata"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/label"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/sset"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
+)
+
+// reconcileRoleSpecificPDBs creates and reconciles PodDisruptionBudgets per nodeSet role for enterprise-licensed clusters.
+func reconcileRoleSpecificPDBs(
+	ctx context.Context,
+	k8sClient k8s.Client,
+	es esv1.Elasticsearch,
+	statefulSets sset.StatefulSetList,
+	meta metadata.Metadata,
+) error {
+	// First, ensure any existing single PDB is removed
+	if err := deleteDefaultPDB(ctx, k8sClient, es); err != nil {
+		return err
+	}
+
+	// Check if PDB is disabled in the ES spec
+	if es.Spec.PodDisruptionBudget != nil && es.Spec.PodDisruptionBudget.IsDisabled() {
+		// PDB is disabled, we've already deleted the default PDB, so we're done
+		return nil
+	}
+
+	// Get the expected role-specific PDBs
+	pdbs, err := expectedRolePDBs(es, statefulSets, meta)
+	if err != nil {
+		return err
+	}
+
+	// Reconcile each PDB using the shared reconciliation function
+	for _, expected := range pdbs {
+		if err := reconcilePDB(ctx, k8sClient, es, expected); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// expectedRolePDBs returns a slice of PDBs to reconcile based on statefulSet roles.
+func expectedRolePDBs(
+	es esv1.Elasticsearch,
+	statefulSets sset.StatefulSetList,
+	meta metadata.Metadata,
+) ([]*policyv1.PodDisruptionBudget, error) {
+	pdbs := make([]*policyv1.PodDisruptionBudget, 0)
+
+	// Group StatefulSets by connected components (StatefulSets that share roles)
+	groups := groupStatefulSetsByConnectedRoles(statefulSets)
+
+	// Create one PDB per group
+	for _, group := range groups {
+		if len(group) == 0 {
+			continue
+		}
+
+		// Determine the roles for this group (union of all roles in the group)
+		groupRoles := make(map[esv1.NodeRole]bool)
+		for _, sset := range group {
+			roles := getRolesFromStatefulSetPodTemplate(sset)
+			for _, role := range roles {
+				groupRoles[role] = true
+			}
+		}
+
+		// Determine the most conservative role for disruption rules
+		// If group has no roles, it's coordinating nodes
+		var primaryRole esv1.NodeRole
+		if len(groupRoles) == 0 {
+			primaryRole = "" // coordinating nodes
+		} else {
+			// Use the most conservative role (master > data roles > others)
+			primaryRole = getMostConservativeRole(groupRoles)
+		}
+
+		// Create a PDB for this group
+		pdb, err := createPDBForStatefulSets(es, primaryRole, group, statefulSets, meta)
+		if err != nil {
+			return nil, err
+		}
+		if pdb != nil {
+			pdbs = append(pdbs, pdb)
+		}
+	}
+
+	return pdbs, nil
+}
+
+// groupStatefulSetsByConnectedRoles groups StatefulSets by merging those that share roles.
+// Uses a simple iterative approach: for each role, collect all StatefulSets with that role,
+// then merge overlapping groups until no more merging is possible.
+// Coordinating nodes (with no roles) are treated as having an empty role ("") and are
+// merged together using the same logic.
+func groupStatefulSetsByConnectedRoles(statefulSets sset.StatefulSetList) [][]appsv1.StatefulSet {
+	if len(statefulSets) == 0 {
+		return nil
+	}
+
+	// Start with each StatefulSet as its own group and collect all unique roles
+	groups := make([][]appsv1.StatefulSet, 0, len(statefulSets))
+	allRoles := make(map[esv1.NodeRole]bool)
+
+	for _, sset := range statefulSets {
+		// Add StatefulSet as its own group
+		groups = append(groups, []appsv1.StatefulSet{sset})
+
+		// Collect all roles from this StatefulSet
+		roles := getRolesFromStatefulSetPodTemplate(sset)
+		if len(roles) == 0 {
+			// Coordinating nodes have no roles, treat as empty role
+			allRoles[""] = true
+		} else {
+			for _, role := range roles {
+				allRoles[role] = true
+			}
+		}
+	}
+
+	// For each role (including empty role for coordinating nodes), merge groups
+	for role := range allRoles {
+		groups = mergeGroupsWithRole(groups, role)
+	}
+
+	return groups
+}
+
+// mergeGroupsWithRole merges all groups that contain StatefulSets with the specified role
+func mergeGroupsWithRole(groups [][]appsv1.StatefulSet, role esv1.NodeRole) [][]appsv1.StatefulSet {
+	var groupsWithRole []int
+	var groupsWithoutRole [][]appsv1.StatefulSet
+
+	// Separate groups that have the role from those that don't
+	for i, group := range groups {
+		hasRole := false
+		for _, sset := range group {
+			roles := getRolesFromStatefulSetPodTemplate(sset)
+			// Handle empty role (coordinating nodes) specially
+			if role == "" {
+				// Empty role matches StatefulSets with no roles
+				if len(roles) == 0 {
+					hasRole = true
+					break
+				}
+			} else {
+				// Non-empty role uses normal contains check
+				if slices.Contains(roles, role) {
+					hasRole = true
+					break
+				}
+			}
+		}
+
+		if hasRole {
+			groupsWithRole = append(groupsWithRole, i)
+		} else {
+			groupsWithoutRole = append(groupsWithoutRole, group)
+		}
+	}
+
+	// If 0 or 1 groups have the role, no merging needed
+	if len(groupsWithRole) <= 1 {
+		return groups
+	}
+
+	// Merge all groups with the role into the first one
+	mergedGroup := []appsv1.StatefulSet{}
+	for _, groupIdx := range groupsWithRole {
+		mergedGroup = append(mergedGroup, groups[groupIdx]...)
+	}
+
+	// Return the merged group plus all groups without the role
+	result := [][]appsv1.StatefulSet{mergedGroup}
+	result = append(result, groupsWithoutRole...)
+	return result
+}
+
+// getMostConservativeRole returns the most conservative role from a set of roles
+// for determining PDB disruption rules. The hierarchy is:
+// master > data roles > other roles
+func getMostConservativeRole(roles map[esv1.NodeRole]bool) esv1.NodeRole {
+	// Master role is most conservative
+	if roles[esv1.MasterRole] {
+		return esv1.MasterRole
+	}
+
+	// Data roles are next most conservative
+	dataRoles := []esv1.NodeRole{
+		esv1.DataRole,
+		esv1.DataHotRole,
+		esv1.DataWarmRole,
+		esv1.DataColdRole,
+		esv1.DataContentRole,
+		esv1.DataFrozenRole,
+	}
+
+	for _, dataRole := range dataRoles {
+		if roles[dataRole] {
+			return dataRole
+		}
+	}
+
+	// Return the first role we encounter
+	for role := range roles {
+		return role
+	}
+
+	// Should never reach here if roles is not empty
+	return ""
+}
+
+// getRolesFromStatefulSetPodTemplate extracts the roles from a StatefulSet's pod template labels.
+func getRolesFromStatefulSetPodTemplate(statefulSet appsv1.StatefulSet) []esv1.NodeRole {
+	roles := []esv1.NodeRole{}
+
+	// Get the pod template labels
+	labels := statefulSet.Spec.Template.Labels
+	if labels == nil {
+		return roles
+	}
+
+	// Define label-role mappings
+	labelRoleMappings := []struct {
+		labelName string
+		role      esv1.NodeRole
+	}{
+		{string(label.NodeTypesMasterLabelName), esv1.MasterRole},
+		{string(label.NodeTypesDataLabelName), esv1.DataRole},
+		{string(label.NodeTypesIngestLabelName), esv1.IngestRole},
+		{string(label.NodeTypesMLLabelName), esv1.MLRole},
+		{string(label.NodeTypesTransformLabelName), esv1.TransformRole},
+		{string(label.NodeTypesRemoteClusterClientLabelName), esv1.RemoteClusterClientRole},
+		{string(label.NodeTypesDataHotLabelName), esv1.DataHotRole},
+		{string(label.NodeTypesDataWarmLabelName), esv1.DataWarmRole},
+		{string(label.NodeTypesDataColdLabelName), esv1.DataColdRole},
+		{string(label.NodeTypesDataContentLabelName), esv1.DataContentRole},
+		{string(label.NodeTypesDataFrozenLabelName), esv1.DataFrozenRole},
+	}
+
+	// Check each label-role mapping
+	for _, mapping := range labelRoleMappings {
+		if val, exists := labels[mapping.labelName]; exists && val == "true" {
+			roles = append(roles, mapping.role)
+		}
+	}
+
+	return roles
+}
+
+// createPDBForStatefulSets creates a PDB for a group of StatefulSets with a shared role.
+func createPDBForStatefulSets(
+	es esv1.Elasticsearch,
+	role esv1.NodeRole,
+	statefulSets []appsv1.StatefulSet,
+	allStatefulSets sset.StatefulSetList,
+	meta metadata.Metadata,
+) (*policyv1.PodDisruptionBudget, error) {
+	// Skip if no StatefulSets
+	if len(statefulSets) == 0 {
+		return nil, nil
+	}
+
+	// Create the PDB spec
+	spec := buildRoleSpecificPDBSpec(es, role, allStatefulSets)
+
+	// Get StatefulSet names for the selector
+	ssetNames := make([]string, 0, len(statefulSets))
+	for _, sset := range statefulSets {
+		ssetNames = append(ssetNames, sset.Name)
+	}
+
+	// Sort for consistent results
+	sort.Strings(ssetNames)
+
+	// Set the selector to target all StatefulSets in this group
+	spec.Selector = selectorForStatefulSets(es, ssetNames)
+
+	// Create the PDB object
+	pdb := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      rolePodDisruptionBudgetName(es.Name, role),
+			Namespace: es.Namespace,
+		},
+		Spec: spec,
+	}
+
+	// Add labels and annotations
+	mergedMeta := meta.Merge(metadata.Metadata{
+		Labels:      pdb.Labels,
+		Annotations: pdb.Annotations,
+	})
+	pdb.Labels = mergedMeta.Labels
+	pdb.Annotations = mergedMeta.Annotations
+
+	// Set owner reference
+	if err := controllerutil.SetControllerReference(&es, pdb, scheme.Scheme); err != nil {
+		return nil, err
+	}
+
+	return pdb, nil
+}
+
+// buildRoleSpecificPDBSpec returns a PDBSpec for a specific node role.
+func buildRoleSpecificPDBSpec(
+	es esv1.Elasticsearch,
+	role esv1.NodeRole,
+	statefulSets sset.StatefulSetList,
+) policyv1.PodDisruptionBudgetSpec {
+	// Get the allowed disruptions for this role based on cluster health and role type
+	allowedDisruptions := allowedDisruptionsForRole(es, role, statefulSets)
+
+	// We'll set the selector later in createRolePDB
+	return policyv1.PodDisruptionBudgetSpec{
+		MaxUnavailable: &intstr.IntOrString{Type: intstr.Int, IntVal: allowedDisruptions},
+	}
+}
+
+// allowedDisruptionsForRole returns the number of pods that can be disrupted for a given role.
+func allowedDisruptionsForRole(
+	es esv1.Elasticsearch,
+	role esv1.NodeRole,
+	statefulSets sset.StatefulSetList,
+) int32 {
+	// Single node clusters should allow 1 disruption to enable k8s operations
+	if statefulSets.ExpectedNodeCount() == 1 {
+		return 1
+	}
+
+	// Check if this is a data role (any of the data variants)
+	isDataRole := role == esv1.DataRole ||
+		role == esv1.DataHotRole ||
+		role == esv1.DataWarmRole ||
+		role == esv1.DataColdRole ||
+		role == esv1.DataContentRole
+
+	// For data roles, only allow disruption if cluster is green
+	if isDataRole && es.Status.Health != esv1.ElasticsearchGreenHealth {
+		return 0
+	}
+
+	// For data_frozen role, allow disruption if cluster is at least yellow
+	if role == esv1.DataFrozenRole && es.Status.Health != esv1.ElasticsearchGreenHealth && es.Status.Health != esv1.ElasticsearchYellowHealth {
+		return 0
+	}
+
+	// For master role, check if we have enough masters
+	if role == esv1.MasterRole {
+		if statefulSets.ExpectedMasterNodesCount() <= 1 {
+			// Don't allow disruption if there's only one master
+			return 0
+		}
+		// For multiple masters, allow disruption if cluster is at least yellow
+		if es.Status.Health != esv1.ElasticsearchGreenHealth && es.Status.Health != esv1.ElasticsearchYellowHealth {
+			return 0
+		}
+	}
+
+	// For ingest role, check if we have enough ingest nodes
+	if role == esv1.IngestRole {
+		if statefulSets.ExpectedIngestNodesCount() <= 1 {
+			// Don't allow disruption if there's only one ingest node
+			return 0
+		}
+		// For multiple ingest nodes, allow disruption if cluster is at least yellow
+		if es.Status.Health != esv1.ElasticsearchGreenHealth && es.Status.Health != esv1.ElasticsearchYellowHealth {
+			return 0
+		}
+	}
+
+	// For ML, transform, and coordinating (no roles) nodes, allow disruption if cluster is at least yellow
+	if role == esv1.MLRole || role == esv1.TransformRole || role == "" {
+		if es.Status.Health != esv1.ElasticsearchGreenHealth && es.Status.Health != esv1.ElasticsearchYellowHealth {
+			return 0
+		}
+	}
+
+	// Allow one pod to be disrupted for all other cases
+	return 1
+}
+
+// selectorForStatefulSets returns a label selector that matches pods from specific StatefulSets.
+// If there's only one StatefulSet, it uses simple matchLabels.
+// If there are multiple StatefulSets, it uses matchExpressions with In operator.
+func selectorForStatefulSets(es esv1.Elasticsearch, ssetNames []string) *metav1.LabelSelector {
+	// For a single StatefulSet, use simple matchLabels
+	if len(ssetNames) == 1 {
+		return &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				label.ClusterNameLabelName:     es.Name,
+				label.StatefulSetNameLabelName: ssetNames[0],
+			},
+		}
+	}
+
+	// For multiple StatefulSets, use matchExpressions with In operator
+	return &metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      label.ClusterNameLabelName,
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{es.Name},
+			},
+			{
+				Key:      label.StatefulSetNameLabelName,
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   ssetNames,
+			},
+		},
+	}
+}
+
+// rolePodDisruptionBudgetName returns the name of the PDB for a specific role.
+func rolePodDisruptionBudgetName(esName string, role esv1.NodeRole) string {
+	name := esv1.DefaultPodDisruptionBudget(esName) + "-" + string(role)
+	// For coordinating nodes (no roles), append "coord" to the name
+	if role == "" {
+		name += "coord"
+	}
+	return name
+}

--- a/pkg/controller/elasticsearch/pdb/roles.go
+++ b/pkg/controller/elasticsearch/pdb/roles.go
@@ -174,7 +174,6 @@ func getPrimaryRoleForPDB(roles map[esv1.NodeRole]struct{}) esv1.NodeRole {
 func getRolesFromStatefulSetPodTemplate(statefulSet appsv1.StatefulSet) []esv1.NodeRole {
 	roles := []esv1.NodeRole{}
 
-	// Get the pod template labels
 	labels := statefulSet.Spec.Template.Labels
 	if labels == nil {
 		return roles

--- a/pkg/controller/elasticsearch/pdb/roles.go
+++ b/pkg/controller/elasticsearch/pdb/roles.go
@@ -99,10 +99,16 @@ func expectedRolePDBs(
 
 		// Create a PDB for this group
 		//
-		// TODO: It feels like there's a possibility of overlapping pdb names here.
+		// TODO: Remove before merge: It feels like there's a possibility of overlapping pdb names here.
+		//
 		//       How do we ensure:
 		//       1. idempotency
 		//       2. no overlapping pdb names
+		//
+		// Even though it feels like there's a possibility for the same pdb name in the same namespace,
+		// since we are grouping associated roles into the same pdb, in theory this should never happen.
+		// I'm leaving this comment in for the review to spark a discussion and see if there's a better
+		// way to handle this section of the code.
 		pdb, err := createPDBForStatefulSets(es, primaryRole, group, statefulSets, meta)
 		if err != nil {
 			return nil, err

--- a/pkg/controller/elasticsearch/pdb/roles_test.go
+++ b/pkg/controller/elasticsearch/pdb/roles_test.go
@@ -258,6 +258,32 @@ func TestReconcileRoleSpecificPDBs(t *testing.T) {
 			},
 		},
 		{
+			name: "no existing PDBs: should create role-specific PDBs with data roles grouped",
+			args: args{
+				es: defaultEs,
+				statefulSets: sset.StatefulSetList{
+					ssetfixtures.TestSset{
+						Name:        "master-data1",
+						Namespace:   "ns",
+						ClusterName: "cluster",
+						Master:      true,
+						Data:        true,
+						Replicas:    1,
+					}.Build(),
+					ssetfixtures.TestSset{
+						Name:        "data2",
+						Namespace:   "ns",
+						ClusterName: "cluster",
+						DataHot:     true,
+						Replicas:    1,
+					}.Build(),
+				},
+			},
+			wantedPDBs: []*policyv1.PodDisruptionBudget{
+				rolePDB("cluster", "ns", esv1.DataRole, []string{"data2"}, 0),
+			},
+		},
+		{
 			name: "existing default PDB: should delete it and create role-specific PDBs",
 			args: args{
 				initObjs: []client.Object{

--- a/pkg/controller/elasticsearch/pdb/roles_test.go
+++ b/pkg/controller/elasticsearch/pdb/roles_test.go
@@ -182,36 +182,24 @@ func TestReconcileRoleSpecificPDBs(t *testing.T) {
 			},
 		}
 
-		// Set selector based on number of StatefulSets
-		if len(statefulSetNames) == 1 {
-			// Single StatefulSet - use MatchLabels
-			pdb.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					label.ClusterNameLabelName:     esName,
-					label.StatefulSetNameLabelName: statefulSetNames[0],
-				},
-			}
-		} else {
-			// Sort for consistent test comparison
-			sorted := make([]string, len(statefulSetNames))
-			copy(sorted, statefulSetNames)
-			slices.Sort(sorted)
+		// Sort for consistent test comparison
+		sorted := make([]string, len(statefulSetNames))
+		copy(sorted, statefulSetNames)
+		slices.Sort(sorted)
 
-			// Multiple StatefulSets - use MatchExpressions
-			pdb.Spec.Selector = &metav1.LabelSelector{
-				MatchExpressions: []metav1.LabelSelectorRequirement{
-					{
-						Key:      label.ClusterNameLabelName,
-						Operator: metav1.LabelSelectorOpIn,
-						Values:   []string{esName},
-					},
-					{
-						Key:      label.StatefulSetNameLabelName,
-						Operator: metav1.LabelSelectorOpIn,
-						Values:   sorted,
-					},
+		pdb.Spec.Selector = &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				{
+					Key:      label.ClusterNameLabelName,
+					Operator: metav1.LabelSelectorOpIn,
+					Values:   []string{esName},
 				},
-			}
+				{
+					Key:      label.StatefulSetNameLabelName,
+					Operator: metav1.LabelSelectorOpIn,
+					Values:   sorted,
+				},
+			},
 		}
 
 		return pdb
@@ -280,7 +268,7 @@ func TestReconcileRoleSpecificPDBs(t *testing.T) {
 				},
 			},
 			wantedPDBs: []*policyv1.PodDisruptionBudget{
-				rolePDB("cluster", "ns", esv1.DataRole, []string{"data2"}, 0),
+				rolePDB("cluster", "ns", esv1.DataRole, []string{"data2", "master-data1"}, 0),
 			},
 		},
 		{
@@ -521,9 +509,17 @@ func TestExpectedRolePDBs(t *testing.T) {
 					},
 					Spec: policyv1.PodDisruptionBudgetSpec{
 						Selector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{
-								label.ClusterNameLabelName:     "test-es",
-								label.StatefulSetNameLabelName: "master1",
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      label.ClusterNameLabelName,
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"test-es"},
+								},
+								{
+									Key:      label.StatefulSetNameLabelName,
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"master1"},
+								},
 							},
 						},
 						MaxUnavailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 1},
@@ -561,9 +557,17 @@ func TestExpectedRolePDBs(t *testing.T) {
 					},
 					Spec: policyv1.PodDisruptionBudgetSpec{
 						Selector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{
-								label.ClusterNameLabelName:     "test-es",
-								label.StatefulSetNameLabelName: "coord1",
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      label.ClusterNameLabelName,
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"test-es"},
+								},
+								{
+									Key:      label.StatefulSetNameLabelName,
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"coord1"},
+								},
 							},
 						},
 						MaxUnavailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 1},
@@ -616,9 +620,17 @@ func TestExpectedRolePDBs(t *testing.T) {
 					},
 					Spec: policyv1.PodDisruptionBudgetSpec{
 						Selector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{
-								label.ClusterNameLabelName:     "test-es",
-								label.StatefulSetNameLabelName: "master1",
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      label.ClusterNameLabelName,
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"test-es"},
+								},
+								{
+									Key:      label.StatefulSetNameLabelName,
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"master1"},
+								},
 							},
 						},
 						MaxUnavailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 0},
@@ -643,9 +655,17 @@ func TestExpectedRolePDBs(t *testing.T) {
 					},
 					Spec: policyv1.PodDisruptionBudgetSpec{
 						Selector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{
-								label.ClusterNameLabelName:     "test-es",
-								label.StatefulSetNameLabelName: "data1",
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      label.ClusterNameLabelName,
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"test-es"},
+								},
+								{
+									Key:      label.StatefulSetNameLabelName,
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"data1"},
+								},
 							},
 						},
 						MaxUnavailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 0},
@@ -670,9 +690,17 @@ func TestExpectedRolePDBs(t *testing.T) {
 					},
 					Spec: policyv1.PodDisruptionBudgetSpec{
 						Selector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{
-								label.ClusterNameLabelName:     "test-es",
-								label.StatefulSetNameLabelName: "ingest1",
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      label.ClusterNameLabelName,
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"test-es"},
+								},
+								{
+									Key:      label.StatefulSetNameLabelName,
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"ingest1"},
+								},
 							},
 						},
 						MaxUnavailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 0},
@@ -762,9 +790,17 @@ func TestExpectedRolePDBs(t *testing.T) {
 					},
 					Spec: policyv1.PodDisruptionBudgetSpec{
 						Selector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{
-								label.ClusterNameLabelName:     "test-es",
-								label.StatefulSetNameLabelName: "ml1",
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      label.ClusterNameLabelName,
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"test-es"},
+								},
+								{
+									Key:      label.StatefulSetNameLabelName,
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"ml1"},
+								},
 							},
 						},
 						MaxUnavailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 0},

--- a/pkg/controller/elasticsearch/pdb/roles_test.go
+++ b/pkg/controller/elasticsearch/pdb/roles_test.go
@@ -1,0 +1,603 @@
+package pdb
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+
+	esv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/metadata"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/label"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/sset"
+)
+
+// Helper function to create a StatefulSet with specific roles in pod template labels
+func createStatefulSetWithRoles(name string, roles []esv1.NodeRole) appsv1.StatefulSet {
+	labels := make(map[string]string)
+
+	// Add role labels based on the roles provided
+	for _, role := range roles {
+		switch role {
+		case esv1.MasterRole:
+			labels[string(label.NodeTypesMasterLabelName)] = "true"
+		case esv1.DataRole:
+			labels[string(label.NodeTypesDataLabelName)] = "true"
+		case esv1.IngestRole:
+			labels[string(label.NodeTypesIngestLabelName)] = "true"
+		case esv1.MLRole:
+			labels[string(label.NodeTypesMLLabelName)] = "true"
+		case esv1.TransformRole:
+			labels[string(label.NodeTypesTransformLabelName)] = "true"
+		case esv1.RemoteClusterClientRole:
+			labels[string(label.NodeTypesRemoteClusterClientLabelName)] = "true"
+		case esv1.DataHotRole:
+			labels[string(label.NodeTypesDataHotLabelName)] = "true"
+		case esv1.DataWarmRole:
+			labels[string(label.NodeTypesDataWarmLabelName)] = "true"
+		case esv1.DataColdRole:
+			labels[string(label.NodeTypesDataColdLabelName)] = "true"
+		case esv1.DataContentRole:
+			labels[string(label.NodeTypesDataContentLabelName)] = "true"
+		case esv1.DataFrozenRole:
+			labels[string(label.NodeTypesDataFrozenLabelName)] = "true"
+		}
+	}
+
+	return appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+			},
+		},
+	}
+}
+
+func TestMergeGroupsWithRole(t *testing.T) {
+	tests := []struct {
+		name     string
+		groups   [][]appsv1.StatefulSet
+		role     esv1.NodeRole
+		expected [][]appsv1.StatefulSet
+	}{
+		{
+			name: "no groups have the role",
+			groups: [][]appsv1.StatefulSet{
+				{createStatefulSetWithRoles("sset1", []esv1.NodeRole{esv1.MasterRole})},
+				{createStatefulSetWithRoles("sset2", []esv1.NodeRole{esv1.IngestRole})},
+			},
+			role: esv1.DataRole,
+			expected: [][]appsv1.StatefulSet{
+				{createStatefulSetWithRoles("sset1", []esv1.NodeRole{esv1.MasterRole})},
+				{createStatefulSetWithRoles("sset2", []esv1.NodeRole{esv1.IngestRole})},
+			},
+		},
+		{
+			name: "only one group has the role",
+			groups: [][]appsv1.StatefulSet{
+				{createStatefulSetWithRoles("sset1", []esv1.NodeRole{esv1.MasterRole, esv1.DataRole})},
+				{createStatefulSetWithRoles("sset2", []esv1.NodeRole{esv1.IngestRole})},
+			},
+			role: esv1.DataRole,
+			expected: [][]appsv1.StatefulSet{
+				{createStatefulSetWithRoles("sset1", []esv1.NodeRole{esv1.MasterRole, esv1.DataRole})},
+				{createStatefulSetWithRoles("sset2", []esv1.NodeRole{esv1.IngestRole})},
+			},
+		},
+		{
+			name: "two groups have the role - should merge",
+			groups: [][]appsv1.StatefulSet{
+				{createStatefulSetWithRoles("sset1", []esv1.NodeRole{esv1.MasterRole, esv1.DataRole})},
+				{createStatefulSetWithRoles("sset2", []esv1.NodeRole{esv1.DataRole, esv1.IngestRole})},
+				{createStatefulSetWithRoles("sset3", []esv1.NodeRole{esv1.MLRole})},
+			},
+			role: esv1.DataRole,
+			expected: [][]appsv1.StatefulSet{
+				{createStatefulSetWithRoles("sset1", []esv1.NodeRole{esv1.MasterRole, esv1.DataRole}), createStatefulSetWithRoles("sset2", []esv1.NodeRole{esv1.DataRole, esv1.IngestRole})},
+				{createStatefulSetWithRoles("sset3", []esv1.NodeRole{esv1.MLRole})},
+			},
+		},
+		{
+			name: "three groups have the role - should merge all",
+			groups: [][]appsv1.StatefulSet{
+				{createStatefulSetWithRoles("sset1", []esv1.NodeRole{esv1.MasterRole})},
+				{createStatefulSetWithRoles("sset2", []esv1.NodeRole{esv1.DataRole})},
+				{createStatefulSetWithRoles("sset3", []esv1.NodeRole{esv1.DataRole, esv1.IngestRole})},
+				{createStatefulSetWithRoles("sset4", []esv1.NodeRole{esv1.DataRole})},
+			},
+			role: esv1.DataRole,
+			expected: [][]appsv1.StatefulSet{
+				{createStatefulSetWithRoles("sset2", []esv1.NodeRole{esv1.DataRole}), createStatefulSetWithRoles("sset3", []esv1.NodeRole{esv1.DataRole, esv1.IngestRole}), createStatefulSetWithRoles("sset4", []esv1.NodeRole{esv1.DataRole})},
+				{createStatefulSetWithRoles("sset1", []esv1.NodeRole{esv1.MasterRole})},
+			},
+		},
+		{
+			name:     "empty groups",
+			groups:   [][]appsv1.StatefulSet{},
+			role:     esv1.DataRole,
+			expected: [][]appsv1.StatefulSet{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := mergeGroupsWithRole(tt.groups, tt.role)
+
+			if len(result) != len(tt.expected) {
+				t.Errorf("Expected %d groups, got %d", len(tt.expected), len(result))
+				return
+			}
+
+			if !cmp.Equal(tt.expected, result) {
+				t.Errorf("Expected %v\ngot %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestGroupStatefulSetsByConnectedRoles(t *testing.T) {
+	tests := []struct {
+		name         string
+		statefulSets []appsv1.StatefulSet
+		expected     [][]appsv1.StatefulSet
+	}{
+		{
+			name:         "empty input",
+			statefulSets: []appsv1.StatefulSet{},
+			expected:     nil,
+		},
+		{
+			name: "single StatefulSet",
+			statefulSets: []appsv1.StatefulSet{
+				createStatefulSetWithRoles("sset1", []esv1.NodeRole{esv1.MasterRole}),
+			},
+			expected: [][]appsv1.StatefulSet{
+				{createStatefulSetWithRoles("sset1", []esv1.NodeRole{esv1.MasterRole})},
+			},
+		},
+		{
+			name: "two StatefulSets with no shared roles",
+			statefulSets: []appsv1.StatefulSet{
+				createStatefulSetWithRoles("sset1", []esv1.NodeRole{esv1.MasterRole}),
+				createStatefulSetWithRoles("sset2", []esv1.NodeRole{esv1.IngestRole}),
+			},
+			expected: [][]appsv1.StatefulSet{
+				{createStatefulSetWithRoles("sset1", []esv1.NodeRole{esv1.MasterRole})},
+				{createStatefulSetWithRoles("sset2", []esv1.NodeRole{esv1.IngestRole})},
+			},
+		},
+		{
+			name: "two StatefulSets with shared role",
+			statefulSets: []appsv1.StatefulSet{
+				createStatefulSetWithRoles("sset1", []esv1.NodeRole{esv1.MasterRole, esv1.DataRole}),
+				createStatefulSetWithRoles("sset2", []esv1.NodeRole{esv1.DataRole, esv1.IngestRole}),
+			},
+			expected: [][]appsv1.StatefulSet{
+				{createStatefulSetWithRoles("sset1", []esv1.NodeRole{esv1.MasterRole, esv1.DataRole}), createStatefulSetWithRoles("sset2", []esv1.NodeRole{esv1.DataRole, esv1.IngestRole})},
+			},
+		},
+		{
+			name: "complex scenario - transitive connections",
+			statefulSets: []appsv1.StatefulSet{
+				createStatefulSetWithRoles("sset1", []esv1.NodeRole{esv1.MasterRole, esv1.DataRole}),
+				createStatefulSetWithRoles("sset2", []esv1.NodeRole{esv1.DataRole, esv1.IngestRole}),
+				createStatefulSetWithRoles("sset3", []esv1.NodeRole{esv1.IngestRole}),
+				createStatefulSetWithRoles("sset4", []esv1.NodeRole{esv1.MLRole}),
+			},
+			expected: [][]appsv1.StatefulSet{
+				{createStatefulSetWithRoles("sset1", []esv1.NodeRole{esv1.MasterRole, esv1.DataRole}), createStatefulSetWithRoles("sset2", []esv1.NodeRole{esv1.DataRole, esv1.IngestRole}), createStatefulSetWithRoles("sset3", []esv1.NodeRole{esv1.IngestRole})},
+				{createStatefulSetWithRoles("sset4", []esv1.NodeRole{esv1.MLRole})},
+			},
+		},
+		{
+			name: "coordinating nodes (no roles)",
+			statefulSets: []appsv1.StatefulSet{
+				createStatefulSetWithRoles("coord1", []esv1.NodeRole{}),
+				createStatefulSetWithRoles("coord2", []esv1.NodeRole{}),
+				createStatefulSetWithRoles("master1", []esv1.NodeRole{esv1.MasterRole}),
+			},
+			expected: [][]appsv1.StatefulSet{
+				// Coordinating nodes should be grouped together to avoid PDB naming conflicts
+				{
+					createStatefulSetWithRoles("coord1", []esv1.NodeRole{}),
+					createStatefulSetWithRoles("coord2", []esv1.NodeRole{}),
+				},
+				{createStatefulSetWithRoles("master1", []esv1.NodeRole{esv1.MasterRole})},
+			},
+		},
+		{
+			name: "multiple data tier roles",
+			statefulSets: []appsv1.StatefulSet{
+				createStatefulSetWithRoles("hot1", []esv1.NodeRole{esv1.DataHotRole}),
+				createStatefulSetWithRoles("warm1", []esv1.NodeRole{esv1.DataWarmRole}),
+				createStatefulSetWithRoles("cold1", []esv1.NodeRole{esv1.DataColdRole}),
+				createStatefulSetWithRoles("mixed1", []esv1.NodeRole{esv1.DataHotRole, esv1.DataWarmRole}),
+			},
+			expected: [][]appsv1.StatefulSet{
+				{createStatefulSetWithRoles("hot1", []esv1.NodeRole{esv1.DataHotRole}), createStatefulSetWithRoles("mixed1", []esv1.NodeRole{esv1.DataHotRole, esv1.DataWarmRole}), createStatefulSetWithRoles("warm1", []esv1.NodeRole{esv1.DataWarmRole})},
+				{createStatefulSetWithRoles("cold1", []esv1.NodeRole{esv1.DataColdRole})},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Convert to StatefulSetList
+			statefulSetList := sset.StatefulSetList{}
+			for _, s := range tt.statefulSets {
+				statefulSetList = append(statefulSetList, s)
+			}
+
+			result := groupStatefulSetsByConnectedRoles(statefulSetList)
+
+			if !cmp.Equal(result, tt.expected) {
+				t.Errorf("Result does not match expected:\n%s", cmp.Diff(tt.expected, result))
+			}
+		})
+	}
+}
+
+func TestExpectedRolePDBs(t *testing.T) {
+	tests := []struct {
+		name         string
+		statefulSets []appsv1.StatefulSet
+		expected     []*policyv1.PodDisruptionBudget
+	}{
+		{
+			name:         "empty input",
+			statefulSets: []appsv1.StatefulSet{},
+			expected:     []*policyv1.PodDisruptionBudget{},
+		},
+		{
+			name: "single master nodeset",
+			statefulSets: []appsv1.StatefulSet{
+				createStatefulSetWithRoles("master1", []esv1.NodeRole{esv1.MasterRole}),
+			},
+			expected: []*policyv1.PodDisruptionBudget{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-es-es-default-master",
+						Namespace: "default",
+						Labels: map[string]string{
+							label.ClusterNameLabelName: "test-es",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion:         "elasticsearch.k8s.elastic.co/v1",
+								Kind:               "Elasticsearch",
+								Name:               "test-es",
+								Controller:         ptr.To[bool](true),
+								BlockOwnerDeletion: ptr.To[bool](true),
+							},
+						},
+					},
+					Spec: policyv1.PodDisruptionBudgetSpec{
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								label.ClusterNameLabelName:     "test-es",
+								label.StatefulSetNameLabelName: "master1",
+							},
+						},
+						MaxUnavailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 0},
+					},
+				},
+			},
+		},
+		{
+			name: "single coordinating node (no roles)",
+			statefulSets: []appsv1.StatefulSet{
+				createStatefulSetWithRoles("coord1", []esv1.NodeRole{}),
+			},
+			expected: []*policyv1.PodDisruptionBudget{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-es-es-default-coord",
+						Namespace: "default",
+						Labels: map[string]string{
+							label.ClusterNameLabelName: "test-es",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion:         "elasticsearch.k8s.elastic.co/v1",
+								Kind:               "Elasticsearch",
+								Name:               "test-es",
+								Controller:         ptr.To[bool](true),
+								BlockOwnerDeletion: ptr.To[bool](true),
+							},
+						},
+					},
+					Spec: policyv1.PodDisruptionBudgetSpec{
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								label.ClusterNameLabelName:     "test-es",
+								label.StatefulSetNameLabelName: "coord1",
+							},
+						},
+						MaxUnavailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 0},
+					},
+				},
+			},
+		},
+		{
+			name: "separate roles - no shared roles",
+			statefulSets: []appsv1.StatefulSet{
+				createStatefulSetWithRoles("master1", []esv1.NodeRole{esv1.MasterRole}),
+				createStatefulSetWithRoles("data1", []esv1.NodeRole{esv1.DataRole}),
+				createStatefulSetWithRoles("ingest1", []esv1.NodeRole{esv1.IngestRole}),
+			},
+			expected: []*policyv1.PodDisruptionBudget{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-es-es-default-master",
+						Namespace: "default",
+						Labels: map[string]string{
+							label.ClusterNameLabelName: "test-es",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion:         "elasticsearch.k8s.elastic.co/v1",
+								Kind:               "Elasticsearch",
+								Name:               "test-es",
+								Controller:         ptr.To[bool](true),
+								BlockOwnerDeletion: ptr.To[bool](true),
+							},
+						},
+					},
+					Spec: policyv1.PodDisruptionBudgetSpec{
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								label.ClusterNameLabelName:     "test-es",
+								label.StatefulSetNameLabelName: "master1",
+							},
+						},
+						MaxUnavailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 0},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-es-es-default-data",
+						Namespace: "default",
+						Labels: map[string]string{
+							label.ClusterNameLabelName: "test-es",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion:         "elasticsearch.k8s.elastic.co/v1",
+								Kind:               "Elasticsearch",
+								Name:               "test-es",
+								Controller:         ptr.To[bool](true),
+								BlockOwnerDeletion: ptr.To[bool](true),
+							},
+						},
+					},
+					Spec: policyv1.PodDisruptionBudgetSpec{
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								label.ClusterNameLabelName:     "test-es",
+								label.StatefulSetNameLabelName: "data1",
+							},
+						},
+						MaxUnavailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 0},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-es-es-default-ingest",
+						Namespace: "default",
+						Labels: map[string]string{
+							label.ClusterNameLabelName: "test-es",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion:         "elasticsearch.k8s.elastic.co/v1",
+								Kind:               "Elasticsearch",
+								Name:               "test-es",
+								Controller:         ptr.To[bool](true),
+								BlockOwnerDeletion: ptr.To[bool](true),
+							},
+						},
+					},
+					Spec: policyv1.PodDisruptionBudgetSpec{
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								label.ClusterNameLabelName:     "test-es",
+								label.StatefulSetNameLabelName: "ingest1",
+							},
+						},
+						MaxUnavailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 0},
+					},
+				},
+			},
+		},
+		{
+			name: "shared roles - should be grouped",
+			statefulSets: []appsv1.StatefulSet{
+				createStatefulSetWithRoles("master-data1", []esv1.NodeRole{esv1.MasterRole, esv1.DataRole}),
+				createStatefulSetWithRoles("data-ingest1", []esv1.NodeRole{esv1.DataRole, esv1.IngestRole}),
+				createStatefulSetWithRoles("ml1", []esv1.NodeRole{esv1.MLRole}),
+			},
+			expected: []*policyv1.PodDisruptionBudget{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-es-es-default-master",
+						Namespace: "default",
+						Labels: map[string]string{
+							label.ClusterNameLabelName: "test-es",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion:         "elasticsearch.k8s.elastic.co/v1",
+								Kind:               "Elasticsearch",
+								Name:               "test-es",
+								Controller:         ptr.To[bool](true),
+								BlockOwnerDeletion: ptr.To[bool](true),
+							},
+						},
+					},
+					Spec: policyv1.PodDisruptionBudgetSpec{
+						Selector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      label.ClusterNameLabelName,
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"test-es"},
+								},
+								{
+									Key:      label.StatefulSetNameLabelName,
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"data-ingest1", "master-data1"},
+								},
+							},
+						},
+						MaxUnavailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 0},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-es-es-default-ml",
+						Namespace: "default",
+						Labels: map[string]string{
+							label.ClusterNameLabelName: "test-es",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion:         "elasticsearch.k8s.elastic.co/v1",
+								Kind:               "Elasticsearch",
+								Name:               "test-es",
+								Controller:         ptr.To[bool](true),
+								BlockOwnerDeletion: ptr.To[bool](true),
+							},
+						},
+					},
+					Spec: policyv1.PodDisruptionBudgetSpec{
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								label.ClusterNameLabelName:     "test-es",
+								label.StatefulSetNameLabelName: "ml1",
+							},
+						},
+						MaxUnavailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 0},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple coordinating nodeSets",
+			statefulSets: []appsv1.StatefulSet{
+				createStatefulSetWithRoles("coord1", []esv1.NodeRole{}),
+				createStatefulSetWithRoles("coord2", []esv1.NodeRole{}),
+				createStatefulSetWithRoles("coord3", []esv1.NodeRole{}),
+			},
+			expected: []*policyv1.PodDisruptionBudget{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-es-es-default-coord",
+						Namespace: "default",
+						Labels: map[string]string{
+							label.ClusterNameLabelName: "test-es",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion:         "elasticsearch.k8s.elastic.co/v1",
+								Kind:               "Elasticsearch",
+								Name:               "test-es",
+								Controller:         ptr.To[bool](true),
+								BlockOwnerDeletion: ptr.To[bool](true),
+							},
+						},
+					},
+					Spec: policyv1.PodDisruptionBudgetSpec{
+						Selector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      label.ClusterNameLabelName,
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"test-es"},
+								},
+								{
+									Key:      label.StatefulSetNameLabelName,
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"coord1", "coord2", "coord3"},
+								},
+							},
+						},
+						MaxUnavailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 0},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create test Elasticsearch resource
+			es := esv1.Elasticsearch{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-es",
+					Namespace: "default",
+				},
+				Spec: esv1.ElasticsearchSpec{
+					Version: "8.0.0",
+				},
+			}
+
+			statefulSetList := sset.StatefulSetList{}
+			for _, s := range tt.statefulSets {
+				statefulSetList = append(statefulSetList, s)
+			}
+
+			meta := metadata.Metadata{
+				Labels: map[string]string{
+					"elasticsearch.k8s.elastic.co/cluster-name": "test-es",
+				},
+			}
+
+			pdbs, err := expectedRolePDBs(es, statefulSetList, meta)
+			if err != nil {
+				t.Fatalf("expectedRolePDBs returned error: %v", err)
+			}
+
+			if !cmp.Equal(tt.expected, pdbs) {
+				t.Errorf("Result does not match expected:\n%s", cmp.Diff(tt.expected, pdbs))
+			}
+
+			// // Run custom validation if provided
+			// if tt.validation != nil {
+			// 	tt.validation(t, pdbs)
+			// }
+
+			// // Basic validation for all PDBs
+			// for i, pdb := range pdbs {
+			// 	if pdb == nil {
+			// 		t.Errorf("PDB %d is nil", i)
+			// 		continue
+			// 	}
+			// 	// Verify PDB has proper metadata
+			// 	if pdb.Namespace != "default" {
+			// 		t.Errorf("Expected PDB namespace 'default', got '%s'", pdb.Namespace)
+			// 	}
+			// 	if pdb.Labels == nil || pdb.Labels["elasticsearch.k8s.elastic.co/cluster-name"] != "test-es" {
+			// 		t.Errorf("PDB missing proper cluster label")
+			// 	}
+			// 	// Verify PDB has selector
+			// 	if pdb.Spec.Selector == nil {
+			// 		t.Errorf("PDB %s missing selector", pdb.Name)
+			// 	}
+			// 	// Verify MaxUnavailable is set
+			// 	if pdb.Spec.MaxUnavailable == nil {
+			// 		t.Errorf("PDB %s missing MaxUnavailable", pdb.Name)
+			// 	}
+			// }
+		})
+	}
+}


### PR DESCRIPTION
Resolves #2936 

## What is this change?

This adds an Enterprise feature which allows the ECK operator to create multiple PDBs which map to grouped roles within nodesets (ideally a PDB per nodeset of role 'X'). For non-enterprise customers, the behavior remains the same, which creates a single default pdb for the whole cluster allowing 1 disruption when the cluster is green.

### Examples

Simple example (pdb per nodeset with single roles)
```
# Manifest
kind: Elasticsearch
spec:
  version: 8.12.1
  nodeSets:
    - name: masters
      count: 3
      config:
        node.roles: ["master"]
    - name: data
      count: 3
      config:
        node.roles: ["data", "ingest"]

# PDBs created
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  labels:
    common.k8s.elastic.co/type: elasticsearch
    elasticsearch.k8s.elastic.co/cluster-name: cluster-name
  name: cluster-name-es-default-master
spec:
  maxUnavailable: 1
  selector:
    matchExpressions:
    -  key: elasticsearch.k8s.elastic.co/cluster-name
        operator: "In"
        values: ["cluster-name"]
    -  key: elasticsearch.k8s.elastic.co/statefulset-name
        operator: "In"
        values: ["cluster-name-es-masters"]

apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  labels:
    common.k8s.elastic.co/type: elasticsearch
    elasticsearch.k8s.elastic.co/cluster-name: cluster-name
  name: cluster-name-es-default-data
spec:
  maxUnavailable: 1
  selector:
    matchExpressions:
    -  key: elasticsearch.k8s.elastic.co/cluster-name
        operator: "In"
        values: ["cluster-name"]
    -  key: elasticsearch.k8s.elastic.co/statefulset-name
        operator: "In"
        values: ["cluster-name-es-data"]
```

Complex example (mixed roles across nodeSets)
```
# Manifest
kind: Elasticsearch
spec:
  version: 8.12.1
  nodeSets:
    - name: masters
      count: 3
      config:
        node.roles: ["master", "data", "ingest"]
    - name: data-warm
      count: 3
      config:
        node.roles: ["data_warm"]
    - name: data-cold
      count: 3
      config:
        node.roles: ["data_cold"]
    - name: data-frozen
      count: 3
      config:
        node.roles: ["data_frozen"]
    - name: coordinating
      count: 1
      config:
        node.roles: []

# PDBs created
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  labels:
    common.k8s.elastic.co/type: elasticsearch
    elasticsearch.k8s.elastic.co/cluster-name: cluster-name
  name: cluster-name-es-default-data
spec:
  maxUnavailable: 1
  selector:
    matchExpressions:
    -  key: elasticsearch.k8s.elastic.co/cluster-name
        operator: "In"
        values: ["cluster-name"]
    -  key: elasticsearch.k8s.elastic.co/statefulset-name
        operator: "In"
        # All of these statefulsets share data* roles, so they must be grouped together.
        values: ["cluster-name-es-masters", "cluster-name-es-data-warm", "cluster-name-es-data-cold"]

apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  labels:
    common.k8s.elastic.co/type: elasticsearch
    elasticsearch.k8s.elastic.co/cluster-name: cluster-name
  name: cluster-name-es-default-data_frozen
spec:
  maxUnavailable: 1
  selector:
    matchExpressions:
    -  key: elasticsearch.k8s.elastic.co/cluster-name
        operator: "In"
        values: ["cluster-name"]
    -  key: elasticsearch.k8s.elastic.co/statefulset-name
        operator: "In"
        values: ["cluster-name-es-data_frozen"]

apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  labels:
    common.k8s.elastic.co/type: elasticsearch
    elasticsearch.k8s.elastic.co/cluster-name: cluster-name
  name: cluster-name-es-default-coord
spec:
  maxUnavailable: 1
  selector:
    matchExpressions:
    -  key: elasticsearch.k8s.elastic.co/cluster-name
        operator: "In"
        values: ["cluster-name"]
    -  key: elasticsearch.k8s.elastic.co/statefulset-name
        operator: "In"
        values: ["cluster-name-es-coordinating"]
```

## Implementation notes for review

I admittedly went back and forth on the implementation, specifically the method of grouping statefulSets by their associated roles. Initially when thinking through how I would group these nodeSets together I logically land on a recursive-style algorithm (traverse all sts' roles, and find all other sts' with this role, and traverse that sts' roles), which I don't want to bring into this code base, so I began investigating other potential options for this grouping. I seemed to recall something along the lines of connected points on a graph, which led me to the current implementation which is building an adjacency list, then using depth first search to build the connected "groups" of statefulsets. I keep feeling that there's a simpler method of doing this grouping, so suggestions are *strongly* welcome in this area.

### TODO

- [ ] full testing in a cluster
- [x] unit tests
- [ ] Documentation (do we want docs in this PR, or in an additional?)