### PR TITLE
ssd-provisioner: install e2fsprogs

### DIFF
--- a/hack/deployer/config/local-disks/ssd-provisioner.yaml
+++ b/hack/deployer/config/local-disks/ssd-provisioner.yaml
@@ -33,7 +33,7 @@ data:
     set -o pipefail
 
     # TODO custom docker image
-    apt-get update && apt-get -y install nvme-cli
+    apt-get update && apt-get -y install nvme-cli e2fsprogs
 
     SSD_NVME_DEVICE_LIST=($(nvme list | grep "Amazon EC2 NVMe Instance Storage" | cut -d " " -f 1 || true))
     SSD_NVME_DEVICE_COUNT=${#SSD_NVME_DEVICE_LIST[@]}

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -832,7 +832,7 @@ func (h *helper) dumpEventLog() {
 
 func (h *helper) runECKDiagnostics() {
 	operatorNS := h.testContext.Operator.Namespace
-	otherNS := append([]string{h.testContext.E2ENamespace}, h.testContext.Operator.ManagedNamespaces...)
+	otherNS := append([]string{h.testContext.E2ENamespace, "default"}, h.testContext.Operator.ManagedNamespaces...)
 	cmd := exec.Command("eck-diagnostics", "-o", operatorNS, "-r", strings.Join(otherNS, ","), "--run-agent-diagnostics")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -832,6 +832,7 @@ func (h *helper) dumpEventLog() {
 
 func (h *helper) runECKDiagnostics() {
 	operatorNS := h.testContext.Operator.Namespace
+	// include the default namespace to have diagnostics on the local disk provisioner used in some environments
 	otherNS := append([]string{h.testContext.E2ENamespace, "default"}, h.testContext.Operator.ManagedNamespaces...)
 	cmd := exec.Command("eck-diagnostics", "-o", operatorNS, "-r", strings.Join(otherNS, ","), "--run-agent-diagnostics")
 	cmd.Stdout = os.Stdout

--- a/test/e2e/test/diagnostics.go
+++ b/test/e2e/test/diagnostics.go
@@ -45,7 +45,8 @@ func maybeRunECKDiagnostics(ctx context.Context, testName string, step Step) {
 	}
 	log.Info("Running eck-diagnostics", "cluster", testCtx.ClusterName, "test", testName, "step", step.Name)
 
-	otherNS := append([]string{testCtx.E2ENamespace}, testCtx.Operator.ManagedNamespaces...)
+	// include the default namespace to have diagnostics on the local disk provisioner used in some environments
+	otherNS := append([]string{testCtx.E2ENamespace, "default"}, testCtx.Operator.ManagedNamespaces...)
 	// The following appends the clustername, test name, and it's sub-test names together with a '-'.
 	// The cluster name is added to the eck-diagnostics file name to avoid conflicts at the last step
 	// of the e2e tests where all diagnostics are downloaded locally to the same directory, and uploaded to buildkite as artifacts.


### PR DESCRIPTION
Our EKS tests were broken since ~ August 12 which I assume roughly lines up with Debian Trixie becoming stable and the new image being made available https://hub.docker.com/layers/library/debian/stable-slim/images/sha256-6123a062e9bcf2c466e9b8ee616c3120ea3e1e69c085f91791714e1be247b0b3 

```
docker run --rm debian:stable-slim dpkg --get-selections >debian-stable-slim-pkgs.txt
docker run --rm debian:bookworm-slim dpkg --get-selections > debian-bookworm-slim-pkgs.txt
diff debian-bookworm-slim-pkgs.txt debian-stable-slim-pkgs.txt 
1d0
< adduser						install
14d12
< e2fsprogs					install
...SNIP...
```

It seems that `e2fsprogs` is no longer contained in the `slim` variant. This broke the SSD formating script which relied on it. 

Build to watch https://buildkite.com/elastic/cloud-on-k8s-operator/builds/11426