### PR TITLE
Fix broken Logstash samples

### DIFF
--- a/config/recipes/logstash/logstash-eck.yaml
+++ b/config/recipes/logstash/logstash-eck.yaml
@@ -31,7 +31,8 @@ spec:
   version: 9.0.0
   config:
     filebeat.inputs:
-      - type: log
+      - type: filestream
+        id: logstash-tutorial
         paths:
           - /data/logstash-tutorial.log
     output.logstash:

--- a/config/recipes/logstash/logstash-monitored.yaml
+++ b/config/recipes/logstash/logstash-monitored.yaml
@@ -31,7 +31,8 @@ spec:
   version: 9.0.0
   config:
     filebeat.inputs:
-      - type: log
+      - type: filestream
+        id: logstash
         paths:
           - /data/logstash-tutorial.log
     output.logstash:

--- a/config/recipes/logstash/logstash-multi.yaml
+++ b/config/recipes/logstash/logstash-multi.yaml
@@ -42,7 +42,8 @@ spec:
   version: 9.0.0
   config:
     filebeat.inputs:
-      - type: log
+      - type: filestream
+        id: logstash-tutorial
         paths:
           - /data/logstash-tutorial.log
     output.logstash:

--- a/config/recipes/logstash/logstash-pipeline-as-secret.yaml
+++ b/config/recipes/logstash/logstash-pipeline-as-secret.yaml
@@ -31,7 +31,8 @@ spec:
   version: 9.0.0
   config:
     filebeat.inputs:
-      - type: log
+      - type: filestream
+        id: logstash-tutorial
         paths:
           - /data/logstash-tutorial.log
     output.logstash:

--- a/config/recipes/logstash/logstash-pipeline-as-volume.yaml
+++ b/config/recipes/logstash/logstash-pipeline-as-volume.yaml
@@ -31,7 +31,8 @@ spec:
   version: 9.0.0
   config:
     filebeat.inputs:
-      - type: log
+      - type: filestream
+        id: logstash-tutorial
         paths:
           - /data/logstash-tutorial.log
     output.logstash:

--- a/config/recipes/logstash/logstash-volumes.yaml
+++ b/config/recipes/logstash/logstash-volumes.yaml
@@ -21,7 +21,8 @@ spec:
   version: 9.0.0
   config:
     filebeat.inputs:
-      - type: log
+      - type: filestream
+        id: logstash-tutorial
         paths:
           - /data/logstash-tutorial.log
     output.logstash:

--- a/deploy/eck-stack/examples/logstash/basic-eck.yaml
+++ b/deploy/eck-stack/examples/logstash/basic-eck.yaml
@@ -56,7 +56,8 @@ eck-beats:
   type: filebeat
   config:
     filebeat.inputs:
-    - type: log
+    - type: filestream
+      id: logstash-tutorial
       paths:
         - /data/logstash-tutorial.log
     processors:


### PR DESCRIPTION
Logstash samples were broken since 9.0.0 as the log input type is no longer supported. 