### PR TITLE
Remove v1beta1 admission review webhooks

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -558,8 +558,6 @@ func startOperator(ctx context.Context) error {
 	// Setup Scheme for all resources
 	log.Info("Setting up scheme")
 	controllerscheme.SetupScheme()
-	// also set up the v1beta1 scheme, used by the v1beta1 webhook
-	controllerscheme.SetupV1beta1Scheme()
 
 	// Create a new Cmd to provide shared dependencies and start components
 	opts := ctrl.Options{

--- a/config/dev/registry.yaml
+++ b/config/dev/registry.yaml
@@ -64,7 +64,7 @@ spec:
 
 ---
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: kube-registry-proxy

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -6,7 +6,6 @@ metadata:
 webhooks:
 - admissionReviewVersions:
   - v1
-  - v1beta1
   clientConfig:
     service:
       name: webhook-service
@@ -28,7 +27,6 @@ webhooks:
   sideEffects: None
 - admissionReviewVersions:
   - v1
-  - v1beta1
   clientConfig:
     service:
       name: webhook-service
@@ -50,7 +48,6 @@ webhooks:
   sideEffects: None
 - admissionReviewVersions:
   - v1
-  - v1beta1
   clientConfig:
     service:
       name: webhook-service
@@ -72,7 +69,6 @@ webhooks:
   sideEffects: None
 - admissionReviewVersions:
   - v1
-  - v1beta1
   clientConfig:
     service:
       name: webhook-service
@@ -94,7 +90,6 @@ webhooks:
   sideEffects: None
 - admissionReviewVersions:
   - v1
-  - v1beta1
   clientConfig:
     service:
       name: webhook-service
@@ -116,7 +111,6 @@ webhooks:
   sideEffects: None
 - admissionReviewVersions:
   - v1
-  - v1beta1
   clientConfig:
     service:
       name: webhook-service
@@ -138,7 +132,6 @@ webhooks:
   sideEffects: None
 - admissionReviewVersions:
   - v1
-  - v1beta1
   clientConfig:
     service:
       name: webhook-service
@@ -160,7 +153,6 @@ webhooks:
   sideEffects: None
 - admissionReviewVersions:
   - v1
-  - v1beta1
   clientConfig:
     service:
       name: webhook-service
@@ -182,7 +174,6 @@ webhooks:
   sideEffects: None
 - admissionReviewVersions:
   - v1
-  - v1beta1
   clientConfig:
     service:
       name: webhook-service
@@ -204,7 +195,6 @@ webhooks:
   sideEffects: None
 - admissionReviewVersions:
   - v1
-  - v1beta1
   clientConfig:
     service:
       name: webhook-service
@@ -226,7 +216,6 @@ webhooks:
   sideEffects: None
 - admissionReviewVersions:
   - v1
-  - v1beta1
   clientConfig:
     service:
       name: webhook-service
@@ -248,7 +237,6 @@ webhooks:
   sideEffects: None
 - admissionReviewVersions:
   - v1
-  - v1beta1
   clientConfig:
     service:
       name: webhook-service
@@ -270,7 +258,6 @@ webhooks:
   sideEffects: None
 - admissionReviewVersions:
   - v1
-  - v1beta1
   clientConfig:
     service:
       name: webhook-service
@@ -292,7 +279,6 @@ webhooks:
   sideEffects: None
 - admissionReviewVersions:
   - v1
-  - v1beta1
   clientConfig:
     service:
       name: webhook-service

--- a/deploy/eck-operator/templates/webhook.yaml
+++ b/deploy/eck-operator/templates/webhook.yaml
@@ -30,7 +30,7 @@ webhooks:
 {{- end }}
   name: elastic-agent-validation-v1alpha1.k8s.elastic.co
   matchPolicy: Exact
-  admissionReviewVersions: [v1,v1beta1]
+  admissionReviewVersions: [v1]
   sideEffects: None
   rules:
   - apiGroups:
@@ -52,7 +52,7 @@ webhooks:
       path: /validate-apm-k8s-elastic-co-v1-apmserver
   failurePolicy: {{ .Values.webhook.failurePolicy }}
 {{- with .Values.webhook.namespaceSelector }}
-  namespaceSelector: 
+  namespaceSelector:
     {{- toYaml . | nindent 4 }}
 {{- end }}
 {{- with .Values.webhook.objectSelector }}
@@ -61,7 +61,7 @@ webhooks:
 {{- end }}
   name: elastic-apm-validation-v1.k8s.elastic.co
   matchPolicy: Exact
-  admissionReviewVersions: [v1,v1beta1]
+  admissionReviewVersions: [v1]
   sideEffects: None
   rules:
   - apiGroups:
@@ -83,7 +83,7 @@ webhooks:
       path: /validate-apm-k8s-elastic-co-v1beta1-apmserver
   failurePolicy: {{ .Values.webhook.failurePolicy }}
 {{- with .Values.webhook.namespaceSelector }}
-  namespaceSelector: 
+  namespaceSelector:
     {{- toYaml . | nindent 4 }}
 {{- end }}
 {{- with .Values.webhook.objectSelector }}
@@ -92,7 +92,7 @@ webhooks:
 {{- end }}
   name: elastic-apm-validation-v1beta1.k8s.elastic.co
   matchPolicy: Exact
-  admissionReviewVersions: [v1,v1beta1]
+  admissionReviewVersions: [v1]
   sideEffects: None
   rules:
   - apiGroups:
@@ -114,7 +114,7 @@ webhooks:
       path: /validate-beat-k8s-elastic-co-v1beta1-beat
   failurePolicy: {{ .Values.webhook.failurePolicy }}
 {{- with .Values.webhook.namespaceSelector }}
-  namespaceSelector: 
+  namespaceSelector:
     {{- toYaml . | nindent 4 }}
 {{- end }}
 {{- with .Values.webhook.objectSelector }}
@@ -123,7 +123,7 @@ webhooks:
 {{- end }}
   name: elastic-beat-validation-v1beta1.k8s.elastic.co
   matchPolicy: Exact
-  admissionReviewVersions: [v1,v1beta1]
+  admissionReviewVersions: [v1]
   sideEffects: None
   rules:
   - apiGroups:
@@ -154,7 +154,7 @@ webhooks:
 {{- end }}
   name: elastic-ent-validation-v1.k8s.elastic.co
   matchPolicy: Exact
-  admissionReviewVersions: [v1,v1beta1]
+  admissionReviewVersions: [v1]
   sideEffects: None
   rules:
   - apiGroups:
@@ -176,7 +176,7 @@ webhooks:
       path: /validate-enterprisesearch-k8s-elastic-co-v1beta1-enterprisesearch
   failurePolicy: {{ .Values.webhook.failurePolicy }}
 {{- with .Values.webhook.namespaceSelector }}
-  namespaceSelector: 
+  namespaceSelector:
     {{- toYaml . | nindent 4 }}
 {{- end }}
 {{- with .Values.webhook.objectSelector }}
@@ -185,7 +185,7 @@ webhooks:
 {{- end }}
   name: elastic-ent-validation-v1beta1.k8s.elastic.co
   matchPolicy: Exact
-  admissionReviewVersions: [v1,v1beta1]
+  admissionReviewVersions: [v1]
   sideEffects: None
   rules:
   - apiGroups:
@@ -207,7 +207,7 @@ webhooks:
       path: /validate-elasticsearch-k8s-elastic-co-v1-elasticsearch
   failurePolicy: {{ .Values.webhook.failurePolicy }}
 {{- with .Values.webhook.namespaceSelector }}
-  namespaceSelector: 
+  namespaceSelector:
     {{- toYaml . | nindent 4 }}
 {{- end }}
 {{- with .Values.webhook.objectSelector }}
@@ -216,7 +216,7 @@ webhooks:
 {{- end }}
   name: elastic-es-validation-v1.k8s.elastic.co
   matchPolicy: Exact
-  admissionReviewVersions: [v1,v1beta1]
+  admissionReviewVersions: [v1]
   sideEffects: None
   rules:
   - apiGroups:
@@ -238,7 +238,7 @@ webhooks:
       path: /validate-elasticsearch-k8s-elastic-co-v1beta1-elasticsearch
   failurePolicy: {{ .Values.webhook.failurePolicy }}
 {{- with .Values.webhook.namespaceSelector }}
-  namespaceSelector: 
+  namespaceSelector:
     {{- toYaml . | nindent 4 }}
 {{- end }}
 {{- with .Values.webhook.objectSelector }}
@@ -247,7 +247,7 @@ webhooks:
 {{- end }}
   name: elastic-es-validation-v1beta1.k8s.elastic.co
   matchPolicy: Exact
-  admissionReviewVersions: [v1,v1beta1]
+  admissionReviewVersions: [v1]
   sideEffects: None
   rules:
   - apiGroups:
@@ -278,7 +278,7 @@ webhooks:
 {{- end }}
   name: elastic-ems-validation-v1alpha1.k8s.elastic.co
   matchPolicy: Exact
-  admissionReviewVersions: [v1,v1beta1]
+  admissionReviewVersions: [v1]
   sideEffects: None
   rules:
     - apiGroups:
@@ -300,7 +300,7 @@ webhooks:
       path: /validate-kibana-k8s-elastic-co-v1-kibana
   failurePolicy: {{ .Values.webhook.failurePolicy }}
 {{- with .Values.webhook.namespaceSelector }}
-  namespaceSelector: 
+  namespaceSelector:
     {{- toYaml . | nindent 4 }}
 {{- end }}
 {{- with .Values.webhook.objectSelector }}
@@ -309,7 +309,7 @@ webhooks:
 {{- end }}
   name: elastic-kb-validation-v1.k8s.elastic.co
   matchPolicy: Exact
-  admissionReviewVersions: [v1,v1beta1]
+  admissionReviewVersions: [v1]
   sideEffects: None
   rules:
   - apiGroups:
@@ -331,7 +331,7 @@ webhooks:
       path: /validate-kibana-k8s-elastic-co-v1beta1-kibana
   failurePolicy: {{ .Values.webhook.failurePolicy }}
 {{- with .Values.webhook.namespaceSelector }}
-  namespaceSelector: 
+  namespaceSelector:
     {{- toYaml . | nindent 4 }}
 {{- end }}
 {{- with .Values.webhook.objectSelector }}
@@ -340,7 +340,7 @@ webhooks:
 {{- end }}
   name: elastic-kb-validation-v1beta1.k8s.elastic.co
   matchPolicy: Exact
-  admissionReviewVersions: [v1,v1beta1]
+  admissionReviewVersions: [v1]
   sideEffects: None
   rules:
   - apiGroups:
@@ -371,7 +371,7 @@ webhooks:
 {{- end }}
   name: elastic-esa-validation-v1alpha1.k8s.elastic.co
   matchPolicy: Exact
-  admissionReviewVersions: [v1,v1beta1]
+  admissionReviewVersions: [v1]
   sideEffects: None
   rules:
     - apiGroups:
@@ -402,7 +402,7 @@ webhooks:
 {{- end }}
   name: elastic-scp-validation-v1alpha1.k8s.elastic.co
   matchPolicy: Exact
-  admissionReviewVersions: [v1,v1beta1]
+  admissionReviewVersions: [v1]
   sideEffects: None
   rules:
     - apiGroups:
@@ -433,7 +433,7 @@ webhooks:
 {{- end }}
   name: elastic-logstash-validation-v1alpha1.k8s.elastic.co
   matchPolicy: Exact
-  admissionReviewVersions: [v1,v1beta1]
+  admissionReviewVersions: [v1]
   sideEffects: None
   rules:
     - apiGroups:

--- a/pkg/apis/agent/v1alpha1/webhook.go
+++ b/pkg/apis/agent/v1alpha1/webhook.go
@@ -29,7 +29,7 @@ var (
 	validationLog = ulog.Log.WithName("agent-v1alpha1-validation")
 )
 
-// +kubebuilder:webhook:path=/validate-agent-k8s-elastic-co-v1alpha1-agent,mutating=false,failurePolicy=ignore,groups=agent.k8s.elastic.co,resources=agents,verbs=create;update,versions=v1alpha1,name=elastic-agent-validation-v1alpha1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1;v1beta1,matchPolicy=Exact
+// +kubebuilder:webhook:path=/validate-agent-k8s-elastic-co-v1alpha1-agent,mutating=false,failurePolicy=ignore,groups=agent.k8s.elastic.co,resources=agents,verbs=create;update,versions=v1alpha1,name=elastic-agent-validation-v1alpha1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1,matchPolicy=Exact
 
 var _ admission.Validator = &Agent{}
 

--- a/pkg/apis/apm/v1/webhook.go
+++ b/pkg/apis/apm/v1/webhook.go
@@ -44,7 +44,7 @@ var (
 	}
 )
 
-// +kubebuilder:webhook:path=/validate-apm-k8s-elastic-co-v1-apmserver,mutating=false,failurePolicy=ignore,groups=apm.k8s.elastic.co,resources=apmservers,verbs=create;update,versions=v1,name=elastic-apm-validation-v1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1;v1beta1,matchPolicy=Exact
+// +kubebuilder:webhook:path=/validate-apm-k8s-elastic-co-v1-apmserver,mutating=false,failurePolicy=ignore,groups=apm.k8s.elastic.co,resources=apmservers,verbs=create;update,versions=v1,name=elastic-apm-validation-v1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1,matchPolicy=Exact
 
 var _ admission.Validator = &ApmServer{}
 

--- a/pkg/apis/apm/v1/webhook_test.go
+++ b/pkg/apis/apm/v1/webhook_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -24,7 +24,7 @@ func TestWebhook(t *testing.T) {
 	testCases := []test.ValidationWebhookTestCase{
 		{
 			Name:      "create-valid",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				apm := mkApmServer(uid)
@@ -34,7 +34,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "unknown-field",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				apm := mkApmServer(uid)
@@ -49,7 +49,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "long-name",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				apm := mkApmServer(uid)
@@ -62,7 +62,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "invalid-version",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				apm := mkApmServer(uid)
@@ -75,7 +75,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "unsupported-version-lower",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				apm := mkApmServer(uid)
@@ -88,7 +88,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "unsupported-version-higher",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				apm := mkApmServer(uid)
@@ -101,7 +101,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "unsupported-version-for-kibana-ref",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				apm := mkApmServer(uid)
@@ -115,7 +115,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "support-74-if-kibana-ref-not-set",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				apm := mkApmServer(uid)
@@ -128,7 +128,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "update-valid",
-			Operation: admissionv1beta1.Update,
+			Operation: admissionv1.Update,
 			OldObject: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				apm := mkApmServer(uid)
@@ -145,7 +145,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "version-downgrade",
-			Operation: admissionv1beta1.Update,
+			Operation: admissionv1.Update,
 			OldObject: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				apm := mkApmServer(uid)
@@ -164,7 +164,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "version-downgrade with override",
-			Operation: admissionv1beta1.Update,
+			Operation: admissionv1.Update,
 			OldObject: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				apm := mkApmServer(uid)
@@ -184,7 +184,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "named-es-kibana-ref",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				apm := mkApmServer(uid)
@@ -196,7 +196,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "secret-named-kibana-ref",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				apm := mkApmServer(uid)
@@ -208,7 +208,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "invalid-secret-kibana-ref-with-name",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				apm := mkApmServer(uid)
@@ -221,7 +221,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "invalid-secret-es-ref-with-namespace",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				apm := mkApmServer(uid)

--- a/pkg/apis/apm/v1beta1/webhook.go
+++ b/pkg/apis/apm/v1beta1/webhook.go
@@ -38,7 +38,7 @@ var (
 	}
 )
 
-// +kubebuilder:webhook:path=/validate-apm-k8s-elastic-co-v1beta1-apmserver,mutating=false,failurePolicy=ignore,groups=apm.k8s.elastic.co,resources=apmservers,verbs=create;update,versions=v1beta1,name=elastic-apm-validation-v1beta1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1;v1beta1,matchPolicy=Exact
+// +kubebuilder:webhook:path=/validate-apm-k8s-elastic-co-v1beta1-apmserver,mutating=false,failurePolicy=ignore,groups=apm.k8s.elastic.co,resources=apmservers,verbs=create;update,versions=v1beta1,name=elastic-apm-validation-v1beta1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1,matchPolicy=Exact
 
 var _ admission.Validator = &ApmServer{}
 

--- a/pkg/apis/apm/v1beta1/webhook_test.go
+++ b/pkg/apis/apm/v1beta1/webhook_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -24,7 +24,7 @@ func TestWebhook(t *testing.T) {
 	testCases := []test.ValidationWebhookTestCase{
 		{
 			Name:      "create-valid",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				apm := mkApmServer(uid)
@@ -34,7 +34,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "unknown-field",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				apm := mkApmServer(uid)
@@ -49,7 +49,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "long-name",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				apm := mkApmServer(uid)
@@ -62,7 +62,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "invalid-version",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				apm := mkApmServer(uid)
@@ -75,7 +75,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "unsupported-version-lower",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				apm := mkApmServer(uid)
@@ -88,7 +88,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "unsupported-version-higher",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				apm := mkApmServer(uid)
@@ -101,7 +101,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "update-valid",
-			Operation: admissionv1beta1.Update,
+			Operation: admissionv1.Update,
 			OldObject: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				apm := mkApmServer(uid)
@@ -118,7 +118,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "version-downgrade",
-			Operation: admissionv1beta1.Update,
+			Operation: admissionv1.Update,
 			OldObject: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				apm := mkApmServer(uid)
@@ -137,7 +137,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "deprecated version",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				apm := mkApmServer(uid)
@@ -150,7 +150,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "version-downgrade with override",
-			Operation: admissionv1beta1.Update,
+			Operation: admissionv1.Update,
 			OldObject: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				apm := mkApmServer(uid)

--- a/pkg/apis/beat/v1beta1/webhook.go
+++ b/pkg/apis/beat/v1beta1/webhook.go
@@ -26,7 +26,7 @@ var (
 	validationLog = ulog.Log.WithName("beat-v1beta1-validation")
 )
 
-// +kubebuilder:webhook:path=/validate-beat-k8s-elastic-co-v1beta1-beat,mutating=false,failurePolicy=ignore,groups=beat.k8s.elastic.co,resources=beats,verbs=create;update,versions=v1beta1,name=elastic-beat-validation-v1beta1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1;v1beta1,matchPolicy=Exact
+// +kubebuilder:webhook:path=/validate-beat-k8s-elastic-co-v1beta1-beat,mutating=false,failurePolicy=ignore,groups=beat.k8s.elastic.co,resources=beats,verbs=create;update,versions=v1beta1,name=elastic-beat-validation-v1beta1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1,matchPolicy=Exact
 
 var _ admission.Validator = &Beat{}
 

--- a/pkg/apis/elasticsearch/v1beta1/webhook.go
+++ b/pkg/apis/elasticsearch/v1beta1/webhook.go
@@ -21,7 +21,7 @@ const (
 	webhookPath = "/validate-elasticsearch-k8s-elastic-co-v1beta1-elasticsearch"
 )
 
-// +kubebuilder:webhook:path=/validate-elasticsearch-k8s-elastic-co-v1beta1-elasticsearch,mutating=false,failurePolicy=ignore,groups=elasticsearch.k8s.elastic.co,resources=elasticsearches,verbs=create;update,versions=v1beta1,name=elastic-es-validation-v1beta1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1;v1beta1,matchPolicy=Exact
+// +kubebuilder:webhook:path=/validate-elasticsearch-k8s-elastic-co-v1beta1-elasticsearch,mutating=false,failurePolicy=ignore,groups=elasticsearch.k8s.elastic.co,resources=elasticsearches,verbs=create;update,versions=v1beta1,name=elastic-es-validation-v1beta1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1,matchPolicy=Exact
 
 var eslog = ulog.Log.WithName("es-validation")
 

--- a/pkg/apis/enterprisesearch/v1/webhook.go
+++ b/pkg/apis/enterprisesearch/v1/webhook.go
@@ -39,7 +39,7 @@ var (
 	}
 )
 
-// +kubebuilder:webhook:path=/validate-enterprisesearch-k8s-elastic-co-v1-enterprisesearch,mutating=false,failurePolicy=ignore,groups=enterprisesearch.k8s.elastic.co,resources=enterprisesearches,verbs=create;update,versions=v1,name=elastic-ent-validation-v1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1;v1beta1,matchPolicy=Exact
+// +kubebuilder:webhook:path=/validate-enterprisesearch-k8s-elastic-co-v1-enterprisesearch,mutating=false,failurePolicy=ignore,groups=enterprisesearch.k8s.elastic.co,resources=enterprisesearches,verbs=create;update,versions=v1,name=elastic-ent-validation-v1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1,matchPolicy=Exact
 
 var _ admission.Validator = &EnterpriseSearch{}
 

--- a/pkg/apis/enterprisesearch/v1/webhook_test.go
+++ b/pkg/apis/enterprisesearch/v1/webhook_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -24,7 +24,7 @@ func TestWebhook(t *testing.T) {
 	testCases := []test.ValidationWebhookTestCase{
 		{
 			Name:      "create-valid",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				ent := mkEnterpriseSearch(uid)
@@ -34,7 +34,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "unknown-field",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				ent := mkEnterpriseSearch(uid)
@@ -49,7 +49,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "long-name",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				ent := mkEnterpriseSearch(uid)
@@ -62,7 +62,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "invalid-version",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				ent := mkEnterpriseSearch(uid)
@@ -75,7 +75,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "unsupported-version-lower",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				ent := mkEnterpriseSearch(uid)
@@ -88,7 +88,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "deprecated-version",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				ent := mkEnterpriseSearch(uid)
@@ -101,7 +101,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "unsupported-version-higher",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				ent := mkEnterpriseSearch(uid)
@@ -114,7 +114,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "update-valid",
-			Operation: admissionv1beta1.Update,
+			Operation: admissionv1.Update,
 			OldObject: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				ent := mkEnterpriseSearch(uid)
@@ -131,7 +131,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "version-downgrade",
-			Operation: admissionv1beta1.Update,
+			Operation: admissionv1.Update,
 			OldObject: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				ent := mkEnterpriseSearch(uid)
@@ -150,7 +150,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "version-downgrade-with-override",
-			Operation: admissionv1beta1.Update,
+			Operation: admissionv1.Update,
 			OldObject: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				ent := mkEnterpriseSearch(uid)
@@ -170,7 +170,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "named-es-ref",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				ent := mkEnterpriseSearch(uid)
@@ -181,7 +181,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "secret-named-es-ref",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				ent := mkEnterpriseSearch(uid)
@@ -192,7 +192,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "invalid-secret-es-ref-with-name",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				ent := mkEnterpriseSearch(uid)
@@ -205,7 +205,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "invalid-secret-es-ref-with-namespace",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				ent := mkEnterpriseSearch(uid)
@@ -218,7 +218,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "invalid-secret-es-ref-with-service",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				ent := mkEnterpriseSearch(uid)

--- a/pkg/apis/enterprisesearch/v1beta1/webhook.go
+++ b/pkg/apis/enterprisesearch/v1beta1/webhook.go
@@ -38,7 +38,7 @@ var (
 	}
 )
 
-// +kubebuilder:webhook:path=/validate-enterprisesearch-k8s-elastic-co-v1beta1-enterprisesearch,mutating=false,failurePolicy=ignore,groups=enterprisesearch.k8s.elastic.co,resources=enterprisesearches,verbs=create;update,versions=v1beta1,name=elastic-ent-validation-v1beta1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1;v1beta1,matchPolicy=Exact
+// +kubebuilder:webhook:path=/validate-enterprisesearch-k8s-elastic-co-v1beta1-enterprisesearch,mutating=false,failurePolicy=ignore,groups=enterprisesearch.k8s.elastic.co,resources=enterprisesearches,verbs=create;update,versions=v1beta1,name=elastic-ent-validation-v1beta1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1,matchPolicy=Exact
 
 var _ admission.Validator = &EnterpriseSearch{}
 

--- a/pkg/apis/enterprisesearch/v1beta1/webhook_test.go
+++ b/pkg/apis/enterprisesearch/v1beta1/webhook_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -24,7 +24,7 @@ func TestWebhook(t *testing.T) {
 	testCases := []test.ValidationWebhookTestCase{
 		{
 			Name:      "create-valid",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				ent := mkEnterpriseSearch(uid)
@@ -34,7 +34,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "unknown-field",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				ent := mkEnterpriseSearch(uid)
@@ -49,7 +49,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "long-name",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				ent := mkEnterpriseSearch(uid)
@@ -62,7 +62,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "invalid-version",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				ent := mkEnterpriseSearch(uid)
@@ -75,7 +75,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "unsupported-version-lower",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				ent := mkEnterpriseSearch(uid)
@@ -88,7 +88,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "unsupported-version-higher",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				ent := mkEnterpriseSearch(uid)
@@ -101,7 +101,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "deprecated-version",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				ent := mkEnterpriseSearch(uid)
@@ -114,7 +114,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "update-valid",
-			Operation: admissionv1beta1.Update,
+			Operation: admissionv1.Update,
 			OldObject: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				ent := mkEnterpriseSearch(uid)
@@ -131,7 +131,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "version-downgrade",
-			Operation: admissionv1beta1.Update,
+			Operation: admissionv1.Update,
 			OldObject: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				ent := mkEnterpriseSearch(uid)
@@ -150,7 +150,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "version-downgrade-with-override",
-			Operation: admissionv1beta1.Update,
+			Operation: admissionv1.Update,
 			OldObject: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				ent := mkEnterpriseSearch(uid)

--- a/pkg/apis/kibana/v1/webhook.go
+++ b/pkg/apis/kibana/v1/webhook.go
@@ -42,7 +42,7 @@ var (
 	}
 )
 
-// +kubebuilder:webhook:path=/validate-kibana-k8s-elastic-co-v1-kibana,mutating=false,failurePolicy=ignore,groups=kibana.k8s.elastic.co,resources=kibanas,verbs=create;update,versions=v1,name=elastic-kb-validation-v1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1;v1beta1,matchPolicy=Exact
+// +kubebuilder:webhook:path=/validate-kibana-k8s-elastic-co-v1-kibana,mutating=false,failurePolicy=ignore,groups=kibana.k8s.elastic.co,resources=kibanas,verbs=create;update,versions=v1,name=elastic-kb-validation-v1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1,matchPolicy=Exact
 
 var _ admission.Validator = &Kibana{}
 

--- a/pkg/apis/kibana/v1/webhook_test.go
+++ b/pkg/apis/kibana/v1/webhook_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -24,7 +24,7 @@ func TestWebhook(t *testing.T) {
 	testCases := []test.ValidationWebhookTestCase{
 		{
 			Name:      "create-valid",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				k := mkKibana(uid)
@@ -34,7 +34,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "unknown-field",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				k := mkKibana(uid)
@@ -49,7 +49,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "long-name",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				k := mkKibana(uid)
@@ -62,7 +62,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "invalid-version",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				k := mkKibana(uid)
@@ -75,7 +75,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "deprecated-version",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				k := mkKibana(uid)
@@ -88,7 +88,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "unsupported-version-lower",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				k := mkKibana(uid)
@@ -101,7 +101,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "unsupported-version-higher",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				k := mkKibana(uid)
@@ -114,7 +114,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "update-valid",
-			Operation: admissionv1beta1.Update,
+			Operation: admissionv1.Update,
 			OldObject: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				k := mkKibana(uid)
@@ -131,7 +131,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "version-downgrade",
-			Operation: admissionv1beta1.Update,
+			Operation: admissionv1.Update,
 			OldObject: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				k := mkKibana(uid)
@@ -150,7 +150,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "version-downgrade-with-override",
-			Operation: admissionv1beta1.Update,
+			Operation: admissionv1.Update,
 			OldObject: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				k := mkKibana(uid)
@@ -170,7 +170,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "named-es-ref",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				ent := mkKibana(uid)
@@ -181,7 +181,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "named-es-ref-with-namesapce",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				ent := mkKibana(uid)
@@ -192,7 +192,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "named-es-ref-with-servicename",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				ent := mkKibana(uid)
@@ -203,7 +203,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "secret-es-ref",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				ent := mkKibana(uid)
@@ -214,7 +214,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "invalid-secret-es-ref-secret-and-name",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				kb := mkKibana(uid)
@@ -227,7 +227,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "invalid-secret-es-ref-secret-and-namespace",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				kb := mkKibana(uid)
@@ -240,7 +240,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "invalid-secret-es-ref-secret-and-service",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				kb := mkKibana(uid)
@@ -253,7 +253,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "simple-stackmon-ref",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				ent := mkKibana(uid)
@@ -266,7 +266,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "multiple-stackmon-ref",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				ent := mkKibana(uid)
@@ -282,7 +282,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "invalid-version-for-stackmon",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				ent := mkKibana(uid)
@@ -297,7 +297,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "invalid-stackmon-ref-with-name",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				ent := mkKibana(uid)
@@ -315,7 +315,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "invalid-stackmon-ref-with-service-name",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				ent := mkKibana(uid)

--- a/pkg/apis/kibana/v1beta1/webhook.go
+++ b/pkg/apis/kibana/v1beta1/webhook.go
@@ -38,7 +38,7 @@ var (
 	}
 )
 
-// +kubebuilder:webhook:path=/validate-kibana-k8s-elastic-co-v1beta1-kibana,mutating=false,failurePolicy=ignore,groups=kibana.k8s.elastic.co,resources=kibanas,verbs=create;update,versions=v1beta1,name=elastic-kb-validation-v1beta1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1;v1beta1,matchPolicy=Exact
+// +kubebuilder:webhook:path=/validate-kibana-k8s-elastic-co-v1beta1-kibana,mutating=false,failurePolicy=ignore,groups=kibana.k8s.elastic.co,resources=kibanas,verbs=create;update,versions=v1beta1,name=elastic-kb-validation-v1beta1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1,matchPolicy=Exact
 
 var _ admission.Validator = &Kibana{}
 

--- a/pkg/apis/kibana/v1beta1/webhook_test.go
+++ b/pkg/apis/kibana/v1beta1/webhook_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -24,7 +24,7 @@ func TestWebhook(t *testing.T) {
 	testCases := []test.ValidationWebhookTestCase{
 		{
 			Name:      "create-valid",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				k := mkKibana(uid)
@@ -34,7 +34,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "unknown-field",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				k := mkKibana(uid)
@@ -49,7 +49,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "long-name",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				k := mkKibana(uid)
@@ -62,7 +62,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "invalid-version",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				k := mkKibana(uid)
@@ -75,7 +75,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "deprecated-version",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				k := mkKibana(uid)
@@ -88,7 +88,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "unsupported-version-lower",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				k := mkKibana(uid)
@@ -101,7 +101,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "unsupported-version-higher",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				k := mkKibana(uid)
@@ -114,7 +114,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "update-valid",
-			Operation: admissionv1beta1.Update,
+			Operation: admissionv1.Update,
 			OldObject: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				k := mkKibana(uid)
@@ -131,7 +131,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "version-downgrade",
-			Operation: admissionv1beta1.Update,
+			Operation: admissionv1.Update,
 			OldObject: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				k := mkKibana(uid)
@@ -150,7 +150,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "version-downgrade-with-override",
-			Operation: admissionv1beta1.Update,
+			Operation: admissionv1.Update,
 			OldObject: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				k := mkKibana(uid)

--- a/pkg/apis/maps/v1alpha1/webhook.go
+++ b/pkg/apis/maps/v1alpha1/webhook.go
@@ -33,7 +33,7 @@ var (
 	}
 )
 
-// +kubebuilder:webhook:path=/validate-ems-k8s-elastic-co-v1alpha1-mapsservers,mutating=false,failurePolicy=ignore,groups=maps.k8s.elastic.co,resources=mapsservers,verbs=create;update,versions=v1alpha1,name=elastic-ems-validation-v1alpha1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1;v1beta1,matchPolicy=Exact
+// +kubebuilder:webhook:path=/validate-ems-k8s-elastic-co-v1alpha1-mapsservers,mutating=false,failurePolicy=ignore,groups=maps.k8s.elastic.co,resources=mapsservers,verbs=create;update,versions=v1alpha1,name=elastic-ems-validation-v1alpha1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1,matchPolicy=Exact
 
 var _ admission.Validator = &ElasticMapsServer{}
 

--- a/pkg/apis/maps/v1alpha1/webhook_test.go
+++ b/pkg/apis/maps/v1alpha1/webhook_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -24,7 +24,7 @@ func TestWebhook(t *testing.T) {
 	testCases := []test.ValidationWebhookTestCase{
 		{
 			Name:      "create-valid",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				m := mkMaps(uid)
@@ -34,7 +34,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "unknown-field",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				m := mkMaps(uid)
@@ -49,7 +49,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "long-name",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				m := mkMaps(uid)
@@ -62,7 +62,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "invalid-version",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				m := mkMaps(uid)
@@ -75,7 +75,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "deprecated-version",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				m := mkMaps(uid)
@@ -88,7 +88,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "unsupported-version-lower",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				m := mkMaps(uid)
@@ -101,7 +101,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "unsupported-version-higher",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				m := mkMaps(uid)
@@ -114,7 +114,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "named-es-ref",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				m := mkMaps(uid)
@@ -126,7 +126,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "secret-es-ref",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				m := mkMaps(uid)
@@ -138,7 +138,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "invalid-secret-es-ref-name",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				m := mkMaps(uid)
@@ -152,7 +152,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "invalid-secret-es-ref-namespace",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				m := mkMaps(uid)

--- a/pkg/apis/stackconfigpolicy/v1alpha1/webhook.go
+++ b/pkg/apis/stackconfigpolicy/v1alpha1/webhook.go
@@ -34,7 +34,7 @@ var (
 	}
 )
 
-// +kubebuilder:webhook:path=/validate-scp-k8s-elastic-co-v1alpha1-stackconfigpolicies,mutating=false,failurePolicy=ignore,groups=stackconfigpolicy.k8s.elastic.co,resources=stackconfigpolicies,verbs=create;update,versions=v1alpha1,name=elastic-scp-validation-v1alpha1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1;v1beta1,matchPolicy=Exact
+// +kubebuilder:webhook:path=/validate-scp-k8s-elastic-co-v1alpha1-stackconfigpolicies,mutating=false,failurePolicy=ignore,groups=stackconfigpolicy.k8s.elastic.co,resources=stackconfigpolicies,verbs=create;update,versions=v1alpha1,name=elastic-scp-validation-v1alpha1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1,matchPolicy=Exact
 
 var _ admission.Validator = &StackConfigPolicy{}
 

--- a/pkg/apis/stackconfigpolicy/v1alpha1/webhook_test.go
+++ b/pkg/apis/stackconfigpolicy/v1alpha1/webhook_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -24,7 +24,7 @@ func TestWebhook(t *testing.T) {
 	testCases := []test.ValidationWebhookTestCase{
 		{
 			Name:      "create-valid",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				m := mkStackConfigPolicy(uid)
@@ -44,7 +44,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "create-valid-kibana",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				m := mkStackConfigPolicy(uid)
@@ -58,7 +58,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "unknown-field",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				m := mkStackConfigPolicy(uid)
@@ -76,7 +76,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "long-name",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				m := mkStackConfigPolicy(uid)
@@ -89,7 +89,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "no-settings",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				m := mkStackConfigPolicy(uid)
@@ -106,7 +106,7 @@ func TestWebhook(t *testing.T) {
 		},
 		{
 			Name:      "create-duplicate-mountpaths",
-			Operation: admissionv1beta1.Create,
+			Operation: admissionv1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				t.Helper()
 				m := mkStackConfigPolicy(uid)

--- a/pkg/controller/autoscaling/elasticsearch/validation/webhook.go
+++ b/pkg/controller/autoscaling/elasticsearch/validation/webhook.go
@@ -23,7 +23,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/set"
 )
 
-// +kubebuilder:webhook:path=/validate-autoscaling-k8s-elastic-co-v1alpha1-elasticsearchautoscaler,mutating=false,failurePolicy=ignore,groups=autoscaling.k8s.elastic.co,resources=elasticsearchautoscalers,verbs=create;update,versions=v1alpha1,name=elastic-esa-validation-v1alpha1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1;v1beta1,matchPolicy=Exact
+// +kubebuilder:webhook:path=/validate-autoscaling-k8s-elastic-co-v1alpha1-elasticsearchautoscaler,mutating=false,failurePolicy=ignore,groups=autoscaling.k8s.elastic.co,resources=elasticsearchautoscalers,verbs=create;update,versions=v1alpha1,name=elastic-esa-validation-v1alpha1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1,matchPolicy=Exact
 
 const (
 	webhookPath = "/validate-autoscaling-k8s-elastic-co-v1alpha1-elasticsearchautoscaler"

--- a/pkg/controller/common/scheme/scheme.go
+++ b/pkg/controller/common/scheme/scheme.go
@@ -14,17 +14,12 @@ import (
 
 	agentv1alpha1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/agent/v1alpha1"
 	apmv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/apm/v1"
-	apmv1beta1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/apm/v1beta1"
 	easv1alpha1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/autoscaling/v1alpha1"
 	beatv1beta1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/beat/v1beta1"
 	commonv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/common/v1"
-	commonv1beta1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/common/v1beta1"
 	esv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/elasticsearch/v1"
-	esv1beta1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/elasticsearch/v1beta1"
 	entv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/enterprisesearch/v1"
-	entv1beta1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/enterprisesearch/v1beta1"
 	kbv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/kibana/v1"
-	kbv1beta1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/kibana/v1beta1"
 	emsv1alpha1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/maps/v1alpha1"
 	policyv1alpha1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/stackconfigpolicy/v1alpha1"
 )
@@ -60,22 +55,4 @@ func SetupScheme() {
 		logstashv1alpha1.AddToScheme,
 	}
 	mustAddSchemeOnce(&addToScheme, schemes)
-}
-
-// SetupV1beta1Scheme sets up a scheme with v1beta1 resources.
-// Should only be used for the v1beta1 admission webhook.
-// The operator should otherwise deal with a single resource version.
-func SetupV1beta1Scheme() {
-	schemes := []func(scheme *runtime.Scheme) error{
-		clientgoscheme.AddToScheme,
-		apmv1beta1.AddToScheme,
-		commonv1beta1.AddToScheme,
-		esv1beta1.AddToScheme,
-		kbv1beta1.AddToScheme,
-		entv1beta1.AddToScheme,
-		beatv1beta1.AddToScheme,
-		agentv1alpha1.AddToScheme,
-		logstashv1alpha1.AddToScheme,
-	}
-	mustAddSchemeOnce(&addToSchemeV1beta1, schemes)
 }

--- a/pkg/controller/elasticsearch/validation/webhook.go
+++ b/pkg/controller/elasticsearch/validation/webhook.go
@@ -23,7 +23,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/set"
 )
 
-// +kubebuilder:webhook:path=/validate-elasticsearch-k8s-elastic-co-v1-elasticsearch,mutating=false,failurePolicy=ignore,groups=elasticsearch.k8s.elastic.co,resources=elasticsearches,verbs=create;update,versions=v1,name=elastic-es-validation-v1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1;v1beta1,matchPolicy=Exact
+// +kubebuilder:webhook:path=/validate-elasticsearch-k8s-elastic-co-v1-elasticsearch,mutating=false,failurePolicy=ignore,groups=elasticsearch.k8s.elastic.co,resources=elasticsearches,verbs=create;update,versions=v1,name=elastic-es-validation-v1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1,matchPolicy=Exact
 
 const (
 	webhookPath = "/validate-elasticsearch-k8s-elastic-co-v1-elasticsearch"

--- a/pkg/controller/logstash/validation/webhook.go
+++ b/pkg/controller/logstash/validation/webhook.go
@@ -22,7 +22,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/set"
 )
 
-// +kubebuilder:webhook:path=/validate-logstash-k8s-elastic-co-v1alpha1-logstash,mutating=false,failurePolicy=ignore,groups=logstash.k8s.elastic.co,resources=logstashes,verbs=create;update,versions=v1alpha1,name=elastic-logstash-validation-v1alpha1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1;v1beta1,matchPolicy=Exact
+// +kubebuilder:webhook:path=/validate-logstash-k8s-elastic-co-v1alpha1-logstash,mutating=false,failurePolicy=ignore,groups=logstash.k8s.elastic.co,resources=logstashes,verbs=create;update,versions=v1alpha1,name=elastic-logstash-validation-v1alpha1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1,matchPolicy=Exact
 
 const (
 	webhookPath = "/validate-logstash-k8s-elastic-co-v1alpha1-logstash"

--- a/pkg/controller/webhook/admission_registration.go
+++ b/pkg/controller/webhook/admission_registration.go
@@ -8,14 +8,10 @@ import (
 	"context"
 
 	v1 "k8s.io/api/admissionregistration/v1"
-	"k8s.io/api/admissionregistration/v1beta1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	ulog "github.com/elastic/cloud-on-k8s/v3/pkg/utils/log"
 )
 
 type webhook struct {
@@ -37,22 +33,6 @@ type AdmissionControllerInterface interface {
 }
 
 func (w *Params) NewAdmissionControllerInterface(ctx context.Context, clientset kubernetes.Interface) (AdmissionControllerInterface, error) {
-	log := ulog.FromContext(ctx)
-	// Detect if V1 is available
-	_, err := clientset.Discovery().ServerResourcesForGroupVersion(v1.SchemeGroupVersion.String())
-	if errors.IsNotFound(err) { // Presumably a K8S cluster older than 1.16
-		log.V(1).Info("admissionregistration.k8s.io/v1 is not available, using v1beta1 for webhook configuration")
-		webhookConfiguration, err := clientset.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Get(ctx, w.Name, metav1.GetOptions{})
-		if err != nil {
-			// 404 is also considered as an error, webhook configuration is expected to be created before the operator is started
-			return nil, err
-		}
-		return &v1beta1webhookHandler{ctx: ctx, clientset: clientset, webhookConfiguration: webhookConfiguration}, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-	log.V(1).Info("using admissionregistration.k8s.io/v1 for webhook configuration")
 	webhookConfiguration, err := clientset.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(ctx, w.Name, metav1.GetOptions{})
 	if err != nil {
 		// 404 is also considered as an error, webhook configuration is expected to be created before the operator is started
@@ -110,56 +90,5 @@ func (v1w *v1webhookHandler) updateCABundle(caCert []byte) error {
 		AdmissionregistrationV1().
 		ValidatingWebhookConfigurations().
 		Update(v1w.ctx, v1w.webhookConfiguration, metav1.UpdateOptions{})
-	return err
-}
-
-// - admissionregistration.k8s.io/v1beta1 implementation
-
-var _ AdmissionControllerInterface = &v1beta1webhookHandler{}
-
-type v1beta1webhookHandler struct {
-	clientset            kubernetes.Interface
-	ctx                  context.Context
-	webhookConfiguration *v1beta1.ValidatingWebhookConfiguration
-}
-
-func (*v1beta1webhookHandler) getType() client.Object {
-	return &v1beta1.ValidatingWebhookConfiguration{}
-}
-
-func (v1beta1w *v1beta1webhookHandler) webhooks() []webhook {
-	webhooks := make([]webhook, 0, len(v1beta1w.webhookConfiguration.Webhooks))
-	for _, wh := range v1beta1w.webhookConfiguration.Webhooks {
-		webhook := webhook{
-			webhookConfigurationName: v1beta1w.webhookConfiguration.Name,
-			caBundle:                 wh.ClientConfig.CABundle,
-		}
-		webhooks = append(webhooks, webhook)
-	}
-	return webhooks
-}
-
-func (v1beta1w *v1beta1webhookHandler) services() Services {
-	services := make(map[types.NamespacedName]struct{})
-	for _, wh := range v1beta1w.webhookConfiguration.Webhooks {
-		if wh.ClientConfig.Service == nil {
-			continue
-		}
-		services[types.NamespacedName{
-			Namespace: wh.ClientConfig.Service.Namespace,
-			Name:      wh.ClientConfig.Service.Name,
-		}] = struct{}{}
-	}
-	return services
-}
-
-func (v1beta1w *v1beta1webhookHandler) updateCABundle(caCert []byte) error {
-	for i := range v1beta1w.webhookConfiguration.Webhooks {
-		v1beta1w.webhookConfiguration.Webhooks[i].ClientConfig.CABundle = caCert
-	}
-	_, err := v1beta1w.clientset.
-		AdmissionregistrationV1beta1().
-		ValidatingWebhookConfigurations().
-		Update(v1beta1w.ctx, v1beta1w.webhookConfiguration, metav1.UpdateOptions{})
 	return err
 }


### PR DESCRIPTION
Is there any reason for us to have `v1beta1` of the admission review webhook in our code at all at this point? 
 `AdmissionReview` went `v1` in Kubernetes `v1.16,` which we don't  support any longer. I suspect we can just have v1 at this time.  It certainly cleans up the code a bit.