### PR TITLE
Improve config/recipes/elastic-agent/fleet-kubernetes-integration-nonroot.yaml with drop capabilities

### DIFF
--- a/config/recipes/elastic-agent/fleet-kubernetes-integration-nonroot.yaml
+++ b/config/recipes/elastic-agent/fleet-kubernetes-integration-nonroot.yaml
@@ -155,6 +155,23 @@ spec:
       spec:
         serviceAccountName: fleet-server
         automountServiceAccountToken: true
+        ## Uncomment the following lines to run fleet-server with restricted privileges and drop capabilities.
+#        containers:
+#        - name: agent
+#          securityContext:
+#            allowPrivilegeEscalation: false
+#            readOnlyRootFilesystem: true
+#            capabilities:
+#              drop: ["ALL"]
+#          env:
+#            - name: STATE_PATH
+#              value: /usr/share/elastic-agent/state
+#            - name: CONFIG_PATH
+#              value: /usr/share/elastic-agent/state
+#          args:
+#            - -e
+#            - -c
+#            - /etc/agent/elastic-agent.yml
 ---
 apiVersion: agent.k8s.elastic.co/v1alpha1
 kind: Agent


### PR DESCRIPTION
This PR improves `config/recipes/elastic-agent/fleet-kubernetes-integration-nonroot.yaml` to explain how to run Fleet server with dropped capabilities and ro file system.

(I think ECK should ideally do that by default as it is already the case for [Elasticsearch](https://github.com/elastic/cloud-on-k8s/pull/6703) and [Kibana](https://github.com/elastic/cloud-on-k8s/pull/8086))