### PR TITLE
Adding note about component templates when using stack policies (legacy 2.16 docs)

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/stack-config-policy.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/stack-config-policy.asciidoc
@@ -11,6 +11,8 @@ CAUTION: {role_mappings_warning}
 
 NOTE: This requires a valid Enterprise license or Enterprise trial license. Check <<{p}-licensing,the license documentation>> for more details about managing licenses.
 
+NOTE: Component templates created in configuration policies cannot be referenced from index templates created through the Elasticsearch API currently.
+
 Starting from ECK `2.6.1` and Elasticsearch `8.6.1`, Elastic Stack configuration policies allow you to configure the following settings for Elasticsearch:
 
 - link:https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html#dynamic-cluster-setting[Cluster Settings]


### PR DESCRIPTION
Bringing back a doc change we've lost during migration: https://github.com/elastic/cloud-on-k8s/pull/8457

cc: @masseyke 
