### PR TITLE
Allow elasticsearchRef.secretName for eck-stack/Kibana

### DIFF
--- a/deploy/eck-stack/charts/eck-agent/values.yaml
+++ b/deploy/eck-stack/charts/eck-agent/values.yaml
@@ -63,6 +63,18 @@ elasticsearchRefs:
   # will be assumed.
   #
   # namespace: default
+  #
+  # Optional secretName referencing an existing Kubernetes secret that contains connection information
+  # for associating an Agent instance to a remote Elasticsearch instance not managed by ECK.
+  # The referenced secret must contain the following:
+  # - `url`: the URL to reach the Elastic resource
+  # - `username`: the username of the user to be authenticated to the Elastic resource
+  # - `password`: the password of the user to be authenticated to the Elastic resource
+  # - `ca.crt`: the CA certificate in PEM format (optional)
+  # - `api-key`: the key to authenticate against the Elastic resource instead of a username and password
+  # This field cannot be used in combination with the other fields name, namespace or serviceName.
+  #
+  # secretName: my-remote-es-credentials
 
 # Reference to ECK-managed Fleet Server instance.
 #
@@ -108,7 +120,7 @@ fleetServerEnabled: false
 
 # policyID determines into which Agent Policy this Agent will be enrolled.
 # policyID: eck-agent
-  
+
 # DaemonSet, StatefulSet, or Deployment specification for Agent.
 # At least one is required of [daemonSet, deployment, statefulSet].
 # No default is currently set, refer to https://github.com/elastic/cloud-on-k8s/issues/7429.
@@ -201,7 +213,7 @@ clusterRole:
   - apiGroups: ["extensions"]
     resources:
       - replicasets
-    verbs: 
+    verbs:
     - "get"
     - "list"
     - "watch"

--- a/deploy/eck-stack/charts/eck-apm-server/values.yaml
+++ b/deploy/eck-stack/charts/eck-apm-server/values.yaml
@@ -69,9 +69,20 @@ elasticsearchRef: {}
   # will be assumed.
   #
   # namespace: default
+  #
+  # Optional secretName referencing an existing Kubernetes secret that contains connection information
+  # for associating an APM Server instance to a remote Elasticsearch instance not managed by ECK.
+  # The referenced secret must contain the following:
+  # - `url`: the URL to reach the Elastic resource
+  # - `username`: the username of the user to be authenticated to the Elastic resource
+  # - `password`: the password of the user to be authenticated to the Elastic resource
+  # - `ca.crt`: the CA certificate in PEM format (optional)
+  # This field cannot be used in combination with the other fields name, namespace or serviceName.
+  #
+  # secretName: my-remote-es-credentials
 
 # Optional reference to ECK-managed Kibana resource which allows ECK to
-# automatically configure the Kibana endpoint as described in 
+# automatically configure the Kibana endpoint as described in
 # https://www.elastic.co/guide/en/apm/server/current/setup-kibana-endpoint.html
 #
 # kibanaRef:

--- a/deploy/eck-stack/charts/eck-beats/values.yaml
+++ b/deploy/eck-stack/charts/eck-beats/values.yaml
@@ -72,6 +72,18 @@ elasticsearchRef: {}
   # will be assumed.
   #
   # namespace: default
+  #
+  # Optional secretName referencing an existing Kubernetes secret that contains connection information
+  # for associating a Beat instance to a remote Elasticsearch instance not managed by ECK.
+  # The referenced secret must contain the following:
+  # - `url`: the URL to reach the Elastic resource
+  # - `username`: the username of the user to be authenticated to the Elastic resource
+  # - `password`: the password of the user to be authenticated to the Elastic resource
+  # - `ca.crt`: the CA certificate in PEM format (optional)
+  # - `api-key`: the key to authenticate against the Elastic resource instead of a username and password
+  # This field cannot be used in combination with the other fields name, namespace or serviceName.
+  #
+  # secretName: my-remote-es-credentials
 
 # Daemonset, or Deployment specification for the type of Beat specified.
 # At least one is required of [daemonSet, deployment].

--- a/deploy/eck-stack/charts/eck-enterprise-search/values.yaml
+++ b/deploy/eck-stack/charts/eck-enterprise-search/values.yaml
@@ -76,6 +76,17 @@ elasticsearchRef: {}
   # will be assumed.
   #
   # namespace: default
+  #
+  # Optional secretName referencing an existing Kubernetes secret that contains connection information
+  # for associating an Enterprise Search instance to a remote Elasticsearch instance not managed by ECK.
+  # The referenced secret must contain the following:
+  # - `url`: the URL to reach the Elastic resource
+  # - `username`: the username of the user to be authenticated to the Elastic resource
+  # - `password`: the password of the user to be authenticated to the Elastic resource
+  # - `ca.crt`: the CA certificate in PEM format (optional)
+  # This field cannot be used in combination with the other fields name, namespace or serviceName.
+  #
+  # secretName: my-remote-es-credentials
 
 # Set podTemplate to customize the pod used by Enterprise Search
 # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-customize-pods.html

--- a/deploy/eck-stack/charts/eck-fleet-server/values.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/values.yaml
@@ -65,6 +65,18 @@ elasticsearchRefs: []
   # will be assumed.
   #
   # namespace: default
+  #
+  # Optional secretName referencing an existing Kubernetes secret that contains connection information
+  # for associating a Fleet Server instance to a remote Elasticsearch instance not managed by ECK.
+  # The referenced secret must contain the following:
+  # - `url`: the URL to reach the Elastic resource
+  # - `username`: the username of the user to be authenticated to the Elastic resource
+  # - `password`: the password of the user to be authenticated to the Elastic resource
+  # - `ca.crt`: the CA certificate in PEM format (optional)
+  # - `api-key`: the key to authenticate against the Elastic resource instead of a username and password
+  # This field cannot be used in combination with the other fields name, namespace or serviceName.
+  #
+  # secretName: my-remote-es-credentials
 
 # policyID determines into which Agent Policy this Fleet Server will be enrolled.
 policyID: eck-fleet-server

--- a/deploy/eck-stack/charts/eck-kibana/templates/kibana.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/templates/kibana.yaml
@@ -12,8 +12,8 @@ metadata:
     {{- end }}
 spec:
   version: {{ required "A Kibana version is required" .Values.version }}
-  {{- /* 
-    The following templates with 'or' are to allow both .spec.field and .field to be set for backwards 
+  {{- /*
+    The following templates with 'or' are to allow both .spec.field and .field to be set for backwards
     compatibility purposes. See https://github.com/elastic/cloud-on-k8s/pull/8192 for details.
   */ -}}
   {{- with or ((.Values.spec).image) (.Values.image) }}
@@ -23,8 +23,8 @@ spec:
   count: {{ . }}
   {{- end }}
   {{- $esRef := or ((.Values.spec).elasticsearchRef) (.Values.elasticsearchRef) }}
-  {{- if not ($esRef).name }}
-  {{ fail "An elasticsearchRef is required" }}
+{{- if not (or ($esRef).name ($esRef).secretName) }}
+  {{ fail "An elasticsearchRef name or secretName is required" }}
   {{- end }}
   elasticsearchRef:
   {{- toYaml $esRef | nindent 4 }}

--- a/deploy/eck-stack/charts/eck-kibana/templates/tests/kibana_test.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/templates/tests/kibana_test.yaml
@@ -128,7 +128,21 @@ tests:
   - it: not setting elasticsearchRef should fail
     asserts:
       - failedTemplate:
-          errorMessage: "An elasticsearchRef is required"
+          errorMessage: "An elasticsearchRef name or secretName is required"
+  - it: setting elasticsearchRef.secretName should not fail
+    set:
+      spec:
+        elasticsearchRef:
+          secretName: remote-es-credentials
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: Kibana
+      - equal:
+          path: spec.elasticsearchRef
+          value:
+            secretName: remote-es-credentials
   - it: values.spec.config should render properly
     set:
       spec:

--- a/deploy/eck-stack/charts/eck-kibana/values.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/values.yaml
@@ -54,6 +54,17 @@ elasticsearchRef: {}
   # will be assumed.
   #
   # namespace: default
+  #
+  # Optional secretName referencing an existing Kubernetes secret that contains connection information
+  # for associating a Kibana instance to a remote Elasticsearch instance not managed by ECK.
+  # The referenced secret must contain the following:
+  # - `url`: the URL to reach the Elastic resource
+  # - `username`: the username of the user to be authenticated to the Elastic resource
+  # - `password`: the password of the user to be authenticated to the Elastic resource
+  # - `ca.crt`: the CA certificate in PEM format (optional)
+  # This field cannot be used in combination with the other fields name, namespace or serviceName.
+  #
+  # secretName: my-remote-es-credentials
 
 # Reference to an EnterpriseSearch running in the same Kubernetes cluster
 #

--- a/hack/helm/test.sh
+++ b/hack/helm/test.sh
@@ -23,7 +23,7 @@ check() {
 
     echo "Ensuring dependencies are updated for $(basename "${TEST_DIR}") chart."
     helm dependency update . 1>/dev/null
-
+    
     echo "Running 'helm lint' on $(basename "${TEST_DIR}") chart."
     if [[ -f "lint-values.yaml" ]]; then
         helm lint --strict -f lint-values.yaml .
@@ -32,7 +32,7 @@ check() {
     fi
 
     if [[ -d templates/tests ]]; then
-        helm unittest -f 'templates/tests/*.yaml' --with-subchart=false .
+        helm unittest -3 -f 'templates/tests/*.yaml' --with-subchart=false .
     fi
 
     cd -

--- a/hack/helm/test.sh
+++ b/hack/helm/test.sh
@@ -23,7 +23,7 @@ check() {
 
     echo "Ensuring dependencies are updated for $(basename "${TEST_DIR}") chart."
     helm dependency update . 1>/dev/null
-    
+
     echo "Running 'helm lint' on $(basename "${TEST_DIR}") chart."
     if [[ -f "lint-values.yaml" ]]; then
         helm lint --strict -f lint-values.yaml .
@@ -32,7 +32,7 @@ check() {
     fi
 
     if [[ -d templates/tests ]]; then
-        helm unittest -3 -f 'templates/tests/*.yaml' --with-subchart=false .
+        helm unittest -f 'templates/tests/*.yaml' --with-subchart=false .
     fi
 
     cd -


### PR DESCRIPTION
Resolves #8816

The helm validation in eck-stack/eck-kibana was preventing use of `elasticsearchRef.secretName`. This does the following:
1. allows `secretName` in eck-kibana
2. adds `secretName` documentation in all values files that support this.
3. ~~removed deprecated `-3` option to `helm-unittest`.~~ (this change was reverted)
4. the `api-key` option to `secretName` is only mentioned in agent and beats, where it's actually supported per our documentation.