### PR TITLE
[E2E] Upgrade stack version to 8.19.3 and 8.19.4-SNAPSHOT

### DIFF
--- a/.buildkite/e2e/nightly-main-matrix.yaml
+++ b/.buildkite/e2e/nightly-main-matrix.yaml
@@ -3,9 +3,9 @@
   fixed:
     E2E_PROVIDER: gke
   mixed:
-    - E2E_STACK_VERSION: "8.19.0"
+    - E2E_STACK_VERSION: "8.19.3"
     # current stack version 9.1.2 is tested in all other tests no need to test it again
-    - E2E_STACK_VERSION: "8.19.0-SNAPSHOT"
+    - E2E_STACK_VERSION: "8.19.4-SNAPSHOT"
     - E2E_STACK_VERSION: "9.2.0-SNAPSHOT"
 
 - label: ocp


### PR DESCRIPTION
This PR is to include the following fix in Agent: https://github.com/elastic/kibana/pull/230211