### PR TITLE
Use standard k8s labels and helm labels on ECK Operator pod

### DIFF
--- a/deploy/eck-operator/templates/statefulset.yaml
+++ b/deploy/eck-operator/templates/statefulset.yaml
@@ -25,13 +25,17 @@ spec:
       annotations:
         # Rename the fields "error" to "error.message" and "source" to "event.source"
         # This is to avoid a conflict with the ECS "error" and "source" documents.
-        "co.elastic.logs/raw": "[{\"type\":\"filestream\",\"enabled\":true,\"id\":\"eck-container-logs-${data.kubernetes.container.id}\",\"paths\":[\"/var/log/containers/*${data.kubernetes.container.id}.log\"],\"parsers\":[{\"container\":{}},{\"ndjson\":{\"keys_under_root\":true}}],\"prospector.scanner.symlinks\":true,\"processors\":[{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"error\",\"to\":\"_error\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_error\",\"to\":\"error.message\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"source\",\"to\":\"_source\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_source\",\"to\":\"event.source\"}]}}]}]" 
+        "co.elastic.logs/raw": "[{\"type\":\"filestream\",\"enabled\":true,\"id\":\"eck-container-logs-${data.kubernetes.container.id}\",\"paths\":[\"/var/log/containers/*${data.kubernetes.container.id}.log\"],\"parsers\":[{\"container\":{}},{\"ndjson\":{\"keys_under_root\":true}}],\"prospector.scanner.symlinks\":true,\"processors\":[{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"error\",\"to\":\"_error\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_error\",\"to\":\"error.message\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"source\",\"to\":\"_source\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_source\",\"to\":\"event.source\"}]}}]}]"
         "checksum/config": {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
+        {{- if .Values.global.manifestGen }}
         {{- include "eck-operator.selectorLabels" . | nindent 8 }}
+        {{- else }}
+        {{- include "eck-operator.labels" . | nindent 8 }}
+        {{- end }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -98,7 +102,7 @@ spec:
             - containerPort: {{ .Values.webhook.port }}
               name: https-webhook
               protocol: TCP
-            {{- end }}  
+            {{- end }}
           {{- end }}
           volumeMounts:
             - mountPath: "/conf"
@@ -113,7 +117,7 @@ spec:
             - mountPath: "/tmp/k8s-metrics-server/serving-certs"
               name: tls-certificate
               readOnly: true
-            {{- end }} 
+            {{- end }}
             {{- with .Values.volumeMounts }}
               {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/deploy/eck-operator/templates/tests/statefulset_test.yaml
+++ b/deploy/eck-operator/templates/tests/statefulset_test.yaml
@@ -62,6 +62,8 @@ tests:
         key1: value1
       statefulsetLabels:
         key2: value2
+      podLabels:
+        key3: value3
     asserts:
       - template: statefulset.yaml
         equal:
@@ -78,6 +80,16 @@ tests:
             app.kubernetes.io/version: 3.2.0-SNAPSHOT
             helm.sh/chart: eck-operator-3.2.0-SNAPSHOT
             key2: value2
+      - template: statefulset.yaml
+        equal:
+          path: spec.template.metadata.labels
+          value:
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: elastic-operator
+            app.kubernetes.io/version: 3.2.0-SNAPSHOT
+            helm.sh/chart: eck-operator-3.2.0-SNAPSHOT
+            key3: value3
   - it: should use the specified webhook secret name
     set:
       webhook:


### PR DESCRIPTION
Picking back up #8278 .
Resolves #8584

This sets some common labels on the ECK operator pod when installed via Helm:

```
# with change
❯ kc get pod -n elastic-system elastic-operator-0 -o yaml | yq '.metadata.labels'
app.kubernetes.io/instance: elastic-operator
app.kubernetes.io/managed-by: Helm
app.kubernetes.io/name: elastic-operator
app.kubernetes.io/version: 3.2.0-SNAPSHOT
apps.kubernetes.io/pod-index: "0"
controller-revision-hash: elastic-operator-66cb484647
helm.sh/chart: eck-operator-3.2.0-SNAPSHOT
statefulset.kubernetes.io/pod-name: elastic-operator-0

# without change
❯ kc get pod -n elastic-system elastic-operator-0 -o yaml | yq '.metadata.labels'
app.kubernetes.io/instance: elastic-operator
app.kubernetes.io/name: elastic-operator
apps.kubernetes.io/pod-index: "0"
controller-revision-hash: elastic-operator-7b8ff75c49
statefulset.kubernetes.io/pod-name: elastic-operator-0
```

It avoids the previous behavior in #8278 where they are also included in generation:

```
❯ make generate > /dev/null 2>&1 && cat config/operator.yaml | grep -i helm
# no output
```