### PR TITLE
Update gclb recipe for new requirements.

### DIFF
--- a/config/recipes/gclb/02-ingress.yaml
+++ b/config/recipes/gclb/02-ingress.yaml
@@ -8,6 +8,9 @@ metadata:
   annotations:
     # Issue certificates for TLS hosts automatically
     cert-manager.io/cluster-issuer: "selfsigning-issuer"
+    # GCP/GKE requires a domain name or the certificate will fail
+    # to parse with sslCertificateCouldNotParseCert.
+    cert-manager.io/common-name: test.com
     # Disable HTTP traffic
     kubernetes.io/ingress.allow-http: "false"
 spec:
@@ -20,8 +23,8 @@ spec:
     - host: "elasticsearch.hulk"
       http:
         paths:
-          - path: "/*"
-            pathType: Exact
+          - path: "/"
+            pathType: Prefix
             backend:
               service:
                 name: hulk-es-http
@@ -30,8 +33,8 @@ spec:
     - host: "kibana.hulk"
       http:
         paths:
-          - path: "/*"
-            pathType: Exact
+          - path: "/"
+            pathType: Prefix
             backend:
               service:
                 name: hulk-kb-http


### PR DESCRIPTION
While testing #8779 I found some new requirements for loadbalancing in GKE clusters, notably:

1: A domain name is required when using cert-manager to generate the certificates to be used for the GCP loadbalancer, as GCP tooling now attempts to parse the certificate and fails without it.
2: The `/*` path no longer works for the `Exact` type of ingress.