### PR TITLE
Add EKS documentation for deployer.

### DIFF
--- a/hack/deployer/README.md
+++ b/hack/deployer/README.md
@@ -40,7 +40,7 @@ Deployer is the provisioning tool that aims to be the interface to multiple Kube
     make switch-eks bootstrap-cloud
     ```
 
-  * If wanting to use a different region (default us eu-west-2), set `overrides.eks.region` in `hack/deployer/config/deployer-config-eks.yml`
+  * If wanting to use a different region (default is eu-west-2), set `overrides.eks.region` in `hack/deployer/config/deployer-config-eks.yml`
 
 * Kind
   * No need to install the Kind CLI. Deployer will do that for you and run Kind inside a Docker container without changing the host system.


### PR DESCRIPTION
While debugging an EKS/AWS issue, I found the documentation for the EKS deployer to be missing. This simply updates the documentation with the common options needed to deploy an EKS cluster.