### PR TITLE
[3.2] Consistently mount CONFIG_PATH and STATE_PATH to same directory in Fleet mode (#8856)

### DIFF
--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -148,6 +148,8 @@ func buildPodTemplate(params Params, fleetCerts *certificates.CertificatesSecret
 		if builder, err = amendBuilderForFleetMode(params, fleetCerts, fleetToken, builder, configHash); err != nil {
 			return corev1.PodTemplateSpec{}, err
 		}
+		// Point agent to static config file mounted from a secret to /etc/agent/elastic-agent.yml
+		builder = builder.WithArgs("-e", "-c", path.Join(ConfigMountPath, ConfigFileName))
 	} else if spec.StandaloneModeEnabled() {
 		// cleanup secret used in Fleet mode
 		if err := cleanupEnvVarsSecret(params); err != nil {
@@ -156,6 +158,8 @@ func buildPodTemplate(params Params, fleetCerts *certificates.CertificatesSecret
 
 		builder = builder.
 			WithResources(defaultResources).
+			WithEnv(corev1.EnvVar{Name: "STATE_PATH", Value: DataMountPath}).
+			// Point agent to static config file mounted from a secret to /etc/agent/elastic-agent.yml
 			WithArgs("-e", "-c", path.Join(ConfigMountPath, ConfigFileName))
 	}
 
@@ -191,15 +195,6 @@ func buildPodTemplate(params Params, fleetCerts *certificates.CertificatesSecret
 		)
 
 	return builder.PodTemplate, nil
-}
-
-func fleetConfigPath(v version.Version) string {
-	if v.LT(agentv1alpha1.FleetAdvancedConfigMinVersion) {
-		// default to the in-container config directory for older versions of Elastic Agent
-		// that still try to rewrite the config file in Fleet mode during enrollment.
-		return "/usr/share/elastic-agent"
-	}
-	return ConfigMountPath
 }
 
 func amendBuilderForFleetMode(params Params, fleetCerts *certificates.CertificatesSecret, fleetToken EnrollmentAPIKey, builder *defaults.PodTemplateBuilder, configHash hash.Hash) (*defaults.PodTemplateBuilder, error) {
@@ -241,7 +236,10 @@ func amendBuilderForFleetMode(params Params, fleetCerts *certificates.Certificat
 
 	builder = builder.
 		WithResources(defaultFleetResources).
-		WithEnv(corev1.EnvVar{Name: "CONFIG_PATH", Value: fleetConfigPath(params.AgentVersion)})
+		WithEnv(
+			corev1.EnvVar{Name: "STATE_PATH", Value: DataMountPath},
+			corev1.EnvVar{Name: "CONFIG_PATH", Value: DataMountPath},
+		)
 
 	return builder, nil
 }
@@ -452,7 +450,7 @@ if [[ -f %[1]s ]]; then
     %[5]s
   fi
 fi
-/usr/bin/tini -- /usr/local/bin/docker-entrypoint -e
+/usr/bin/tini -- /usr/local/bin/docker-entrypoint -e "$@"
 `, caPath, ubiSharedCAPath, ubiUpdateCmd, debianSharedCAPath, debianUpdateCmd)
 }
 

--- a/pkg/controller/agent/pod_test.go
+++ b/pkg/controller/agent/pod_test.go
@@ -82,8 +82,12 @@ func Test_amendBuilderForFleetMode(t *testing.T) {
 			wantPodSpec: generatePodSpec(func(ps corev1.PodSpec) corev1.PodSpec {
 				ps.Containers[0].Env = []corev1.EnvVar{
 					{
+						Name:  "STATE_PATH",
+						Value: "/usr/share/elastic-agent/state",
+					},
+					{
 						Name:  "CONFIG_PATH",
-						Value: "/usr/share/elastic-agent",
+						Value: "/usr/share/elastic-agent/state",
 					},
 				}
 
@@ -180,8 +184,12 @@ func Test_amendBuilderForFleetMode(t *testing.T) {
 						Value: "https://agent-agent-http.default.svc:8220",
 					},
 					{
+						Name:  "STATE_PATH",
+						Value: "/usr/share/elastic-agent/state",
+					},
+					{
 						Name:  "CONFIG_PATH",
-						Value: "/etc/agent",
+						Value: "/usr/share/elastic-agent/state",
 					},
 				}
 
@@ -275,8 +283,12 @@ func Test_amendBuilderForFleetMode(t *testing.T) {
 						Value: "https://agent-agent-http.default.svc:8220",
 					},
 					{
+						Name:  "STATE_PATH",
+						Value: "/usr/share/elastic-agent/state",
+					},
+					{
 						Name:  "CONFIG_PATH",
-						Value: "/etc/agent",
+						Value: "/usr/share/elastic-agent/state",
 					},
 				}
 
@@ -312,8 +324,12 @@ func Test_amendBuilderForFleetMode(t *testing.T) {
 			wantPodSpec: generatePodSpec(func(ps corev1.PodSpec) corev1.PodSpec {
 				ps.Containers[0].Env = []corev1.EnvVar{
 					{
+						Name:  "STATE_PATH",
+						Value: "/usr/share/elastic-agent/state",
+					},
+					{
 						Name:  "CONFIG_PATH",
-						Value: "/etc/agent",
+						Value: "/usr/share/elastic-agent/state",
 					},
 				}
 
@@ -402,8 +418,12 @@ func Test_amendBuilderForFleetMode(t *testing.T) {
 						Value: "http://agent-agent-http.default.svc:8220",
 					},
 					{
+						Name:  "STATE_PATH",
+						Value: "/usr/share/elastic-agent/state",
+					},
+					{
 						Name:  "CONFIG_PATH",
-						Value: "/etc/agent",
+						Value: "/usr/share/elastic-agent/state",
 					},
 				}
 
@@ -924,7 +944,7 @@ if [[ -f /mnt/elastic-internal/elasticsearch-association/%[1]s/elasticsearch/cer
     /usr/sbin/update-ca-certificates
   fi
 fi
-/usr/bin/tini -- /usr/local/bin/docker-entrypoint -e
+/usr/bin/tini -- /usr/local/bin/docker-entrypoint -e "$@"
 `, ns)}
 	}
 	for _, tt := range []struct {

--- a/pkg/controller/agent/reconcile.go
+++ b/pkg/controller/agent/reconcile.go
@@ -98,7 +98,6 @@ func reconcilePodVehicle(params Params, podTemplate corev1.PodTemplateSpec) (*re
 		agent:       params.Agent,
 		podTemplate: podTemplate,
 	})
-
 	if err != nil {
 		return results.WithError(err), params.Status
 	}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.2`:
 - [Consistently mount CONFIG_PATH and STATE_PATH to same directory in Fleet mode (#8856)](https://github.com/elastic/cloud-on-k8s/pull/8856)

<!--- Backport version: 9.2.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)