### PR TITLE
Revert GKE version to 1.33

### DIFF
--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -3,7 +3,7 @@ plans:
   operation: create
   clusterName: ci
   provider: gke
-  kubernetesVersion: 1.34
+  kubernetesVersion: 1.33
   machineType: n1-standard-8
   serviceAccount: true
   enforceSecurityPolicies: true
@@ -18,7 +18,7 @@ plans:
   operation: create
   clusterName: ci-autopilot
   provider: gke
-  kubernetesVersion: 1.34
+  kubernetesVersion: 1.33
   serviceAccount: true
   enforceSecurityPolicies: true
   # this is disabled in autopilot: container provisioner is privileged; not allowed in Autopilot
@@ -31,7 +31,7 @@ plans:
   operation: create
   clusterName: dev
   provider: gke
-  kubernetesVersion: 1.34
+  kubernetesVersion: 1.33
   machineType: n1-standard-8
   serviceAccount: false
   enforceSecurityPolicies: true
@@ -58,7 +58,7 @@ plans:
   operation: create
   clusterName: dev-autopilot
   provider: gke
-  kubernetesVersion: 1.34
+  kubernetesVersion: 1.33
   serviceAccount: false
   enforceSecurityPolicies: true
   gke:


### PR DESCRIPTION
Reverting GKE to 1.33 as 1.34 is not yet available on "stable" channel.

Same as https://github.com/elastic/cloud-on-k8s/pull/8860/commits/84bbc2af83f41ef5e91b1c893cff8224b572dba7