### PR TITLE
[3.2] Do not set credentials label on Kibana config secret. (#8852)

### DIFF
--- a/pkg/controller/kibana/config_reconcile.go
+++ b/pkg/controller/kibana/config_reconcile.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	kbv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/kibana/v1"
-	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/metadata"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/tracing"
@@ -62,7 +61,7 @@ func ReconcileConfigSecret(
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:   kb.Namespace,
 			Name:        kbv1.ConfigSecret(kb.Name),
-			Labels:      labels.AddCredentialsLabel(maps.Clone(meta.Labels)),
+			Labels:      maps.Clone(meta.Labels),
 			Annotations: meta.Annotations,
 		},
 		Data: data,

--- a/pkg/controller/kibana/config_reconcile_test.go
+++ b/pkg/controller/kibana/config_reconcile_test.go
@@ -53,6 +53,8 @@ func TestReconcileConfigSecret(t *testing.T) {
 			assertions: func(secrets corev1.SecretList) error {
 				require.Equal(t, 1, len(secrets.Items))
 				assert.NotNil(t, secrets.Items[0].Data[SettingsFilename])
+				// The Kibana config secret previously contained the 'credentials' label. It should now not exist.
+				assert.Empty(t, secrets.Items[0].ObjectMeta.Labels["eck.k8s.elastic.co/credentials"])
 				return nil
 			},
 		},

--- a/test/e2e/test/kibana/checks_k8s.go
+++ b/test/e2e/test/kibana/checks_k8s.go
@@ -38,8 +38,7 @@ func CheckSecrets(b Builder, k *test.K8sClient) test.Step {
 				Keys:         []string{"kibana.yml"},
 				OptionalKeys: []string{"telemetry.yml"},
 				Labels: map[string]string{
-					"eck.k8s.elastic.co/credentials": "true",
-					"kibana.k8s.elastic.co/name":     kbName,
+					"kibana.k8s.elastic.co/name": kbName,
 				},
 			},
 		}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.2`:
 - [Do not set credentials label on Kibana config secret. (#8852)](https://github.com/elastic/cloud-on-k8s/pull/8852)

<!--- Backport version: 9.2.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)