### PR TITLE
Skip Beats recipes that contain fingerprint identity on older versions

### DIFF
--- a/test/e2e/beat/recipes_test.go
+++ b/test/e2e/beat/recipes_test.go
@@ -36,6 +36,8 @@ const (
 )
 
 func TestFilebeatNoAutodiscoverRecipe(t *testing.T) {
+	skipIfFingerprintIdentityNotSupported(t)
+
 	name := "fb-no-autodiscover"
 	pod, loggedString := loggingTestPod(name)
 	customize := func(builder beat.Builder) beat.Builder {
@@ -49,6 +51,8 @@ func TestFilebeatNoAutodiscoverRecipe(t *testing.T) {
 }
 
 func TestFilebeatAutodiscoverRecipe(t *testing.T) {
+	skipIfFingerprintIdentityNotSupported(t)
+
 	name := "fb-autodiscover"
 	pod, loggedString := loggingTestPod(name)
 	customize := func(builder beat.Builder) beat.Builder {
@@ -63,6 +67,8 @@ func TestFilebeatAutodiscoverRecipe(t *testing.T) {
 }
 
 func TestFilebeatAutodiscoverByMetadataRecipe(t *testing.T) {
+	skipIfFingerprintIdentityNotSupported(t)
+
 	name := "fb-autodiscover-meta"
 	podBad, badLog := loggingTestPod(name + "-bad")
 	podLabel, goodLog := loggingTestPod(name + "-label")
@@ -100,6 +106,8 @@ func TestMetricbeatHostsRecipe(t *testing.T) {
 }
 
 func TestMetricbeatStackMonitoringRecipe(t *testing.T) {
+	skipIfFingerprintIdentityNotSupported(t)
+
 	name := "fb-autodiscover"
 	pod, loggedString := loggingTestPod(name)
 	customize := func(builder beat.Builder) beat.Builder {
@@ -260,6 +268,12 @@ func runBeatRecipe(
 	}
 
 	helper.RunFile(t, filePath, namespace, suffix, additionalObjects, transformationsWrapped)
+}
+
+func skipIfFingerprintIdentityNotSupported(t *testing.T) {
+	if !SupportsFingerprintIdentity(version.MustParse(test.Ctx().ElasticStackVersion)) {
+		t.Skipf("Skipping test %s because fingerprint identity is not supported for stack version %s", t.Name(), test.Ctx().ElasticStackVersion)
+	}
 }
 
 // isStackIncompatible returns true iff Beat version is higher than tested Stack version


### PR DESCRIPTION
Found during testing of the release candidate for ECK 3.2

> These test failures are caused by the newer filestream configuration introduced in https://github.com/elastic/cloud-on-k8s/pull/8455 and https://github.com/elastic/cloud-on-k8s/pull/8456/files which does not seem to be supported on older versions of Beats.