### PR TITLE
[3.2] fixed k3d image name (#8865)

### DIFF
--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -178,7 +178,7 @@ plans:
   kubernetesVersion: 1.34.1
   k3d:
     clientImage: ghcr.io/k3d-io/k3d:5.8.3
-    nodeImage: rancher/k3s:v1.34.1+k3s1
+    nodeImage: rancher/k3s:v1.34.1-k3s1
 - id: k3d-ci
   operation: create
   clusterName: k3d-ci
@@ -186,4 +186,4 @@ plans:
   kubernetesVersion: 1.34.1
   k3d:
     clientImage: ghcr.io/k3d-io/k3d:5.8.3
-    nodeImage: rancher/k3s:v1.34.1+k3s1
+    nodeImage: rancher/k3s:v1.34.1-k3s1


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.2`:
 - [fixed k3d image name (#8865)](https://github.com/elastic/cloud-on-k8s/pull/8865)

<!--- Backport version: 9.2.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)