### PR TITLE
[3.2] disable fleet non-root tests with older stack versions (#8867)

### DIFF
--- a/test/e2e/agent/recipes_test.go
+++ b/test/e2e/agent/recipes_test.go
@@ -127,6 +127,11 @@ func TestFleetKubernetesIntegrationRecipe(t *testing.T) {
 func TestFleetKubernetesNonRootIntegrationRecipe(t *testing.T) {
 	v := version.MustParse(test.Ctx().ElasticStackVersion)
 
+	if (v.GE(version.MinFor(7, 17, 28)) && v.LT(version.MinFor(8, 0, 0))) ||
+		(v.GE(version.MinFor(8, 1, 3)) && v.LT(version.MinFor(8, 2, 0))) {
+		t.Skipf("Skipped as version %s is affected by https://github.com/elastic/kibana/pull/236788", v)
+	}
+
 	// https://github.com/elastic/cloud-on-k8s/issues/6331
 	if v.LT(version.MinFor(8, 7, 0)) && v.GE(version.MinFor(8, 6, 0)) {
 		t.SkipNow()


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.2`:
 - [disable fleet non-root tests with older stack versions (#8867)](https://github.com/elastic/cloud-on-k8s/pull/8867)

<!--- Backport version: 9.2.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)