### PR TITLE
feat(crd): Enable strategic merge patch for spec.nodeSets

### DIFF
--- a/pkg/apis/elasticsearch/v1/elasticsearch_types.go
+++ b/pkg/apis/elasticsearch/v1/elasticsearch_types.go
@@ -97,6 +97,8 @@ type ElasticsearchSpec struct {
 
 	// NodeSets allow specifying groups of Elasticsearch nodes sharing the same configuration and Pod templates.
 	// +kubebuilder:validation:MinItems=1
+    // +listType=map
+    // +listMapKey=name
 	NodeSets []NodeSet `json:"nodeSets"`
 
 	// UpdateStrategy specifies how updates to the cluster should be performed.


### PR DESCRIPTION
This PR adds strategic merge annotations (`x-kubernetes-list-type: map` `and x-kubernetes-list-map-keys: [name]`) to the `spec.nodeSets` field in the Elasticsearch CRD.

This allows users to reliably patch individual NodeSet items using `kubectl patch --type=merge` or Kustomize strategic merge patches, rather than replacing the entire list.

Note: Kustomize doesn't support these annotation for the moment an issue for this is tracked in [kubernetes-sigs/kustomize/issues/5878](https://github.com/kubernetes-sigs/kustomize/issues/5878).