### PR TITLE
[3.2] Version gate the CONFIG_PATH==STATE_PATH change to 8.13 and later (#8869)

### DIFF
--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -148,8 +148,10 @@ func buildPodTemplate(params Params, fleetCerts *certificates.CertificatesSecret
 		if builder, err = amendBuilderForFleetMode(params, fleetCerts, fleetToken, builder, configHash); err != nil {
 			return corev1.PodTemplateSpec{}, err
 		}
-		// Point agent to static config file mounted from a secret to /etc/agent/elastic-agent.yml
-		builder = builder.WithArgs("-e", "-c", path.Join(ConfigMountPath, ConfigFileName))
+		if params.AgentVersion.GTE(agentv1alpha1.FleetAdvancedConfigMinVersion) {
+			// Point agent to static config file mounted from a secret to /etc/agent/elastic-agent.yml for versions that support advanced configuration to be used in addition to the config coming from Fleet.
+			builder = builder.WithArgs("-e", "-c", path.Join(ConfigMountPath, ConfigFileName))
+		}
 	} else if spec.StandaloneModeEnabled() {
 		// cleanup secret used in Fleet mode
 		if err := cleanupEnvVarsSecret(params); err != nil {
@@ -197,6 +199,15 @@ func buildPodTemplate(params Params, fleetCerts *certificates.CertificatesSecret
 	return builder.PodTemplate, nil
 }
 
+func fleetConfigPath(v version.Version) string {
+	if v.LT(agentv1alpha1.FleetAdvancedConfigMinVersion) {
+		// default to the in-container config directory for older versions of Elastic Agent
+		// that still try to rewrite the config file in Fleet mode during enrollment.
+		return "/usr/share/elastic-agent"
+	}
+	return DataMountPath
+}
+
 func amendBuilderForFleetMode(params Params, fleetCerts *certificates.CertificatesSecret, fleetToken EnrollmentAPIKey, builder *defaults.PodTemplateBuilder, configHash hash.Hash) (*defaults.PodTemplateBuilder, error) {
 	esAssociation, err := getRelatedEsAssoc(params)
 	if err != nil {
@@ -238,7 +249,7 @@ func amendBuilderForFleetMode(params Params, fleetCerts *certificates.Certificat
 		WithResources(defaultFleetResources).
 		WithEnv(
 			corev1.EnvVar{Name: "STATE_PATH", Value: DataMountPath},
-			corev1.EnvVar{Name: "CONFIG_PATH", Value: DataMountPath},
+			corev1.EnvVar{Name: "CONFIG_PATH", Value: fleetConfigPath(params.AgentVersion)},
 		)
 
 	return builder, nil

--- a/pkg/controller/agent/pod_test.go
+++ b/pkg/controller/agent/pod_test.go
@@ -87,7 +87,7 @@ func Test_amendBuilderForFleetMode(t *testing.T) {
 					},
 					{
 						Name:  "CONFIG_PATH",
-						Value: "/usr/share/elastic-agent/state",
+						Value: "/usr/share/elastic-agent",
 					},
 				}
 

--- a/test/e2e/agent/config.go
+++ b/test/e2e/agent/config.go
@@ -45,7 +45,40 @@ const (
         name: system-1
       - package:
           name: kubernetes
-        name: kubernetes-1`
+        name: kubernetes-1
+        inputs:
+        - type: kubelet-kubernetes/metrics
+          enabled: false
+        - type: kube-state-metrics-kubernetes/metrics
+          enabled: false
+        - type:  kube-apiserver-kubernetes/metrics
+          enabled: false
+        - type:  kube-proxy-kubernetes/metrics
+          enabled: false
+        - type:  kube-scheduler-kubernetes/metrics
+          enabled: false
+        - type: kube-controller-manager-kubernetes/metrics
+          enabled: false
+        - type: events-kubernetes/metrics
+          enabled: false
+        - type: container-logs-filestream
+          enabled: true
+          streams:
+          - data_stream:
+              dataset: kubernetes.container_logs
+            enabled: true
+            vars:
+            - name: paths
+              value:
+              - /var/log/containers/*${kubernetes.container.id}.log
+            - name: symlinks
+              value: true
+            - name: containerParserStream
+              value: all
+            - name: containerParserFormat
+              value: auto
+        - type: audit-logs-filestream
+          enabled: false`
 
 	E2EAgentSystemIntegrationConfig = `id: 2d70a6f0-33a5-11eb-bb2f-418d0388a8cf
 revision: 2
@@ -396,4 +429,35 @@ inputs:
   securityContext:
     runAsUser: 0
 `
+	E2EAgentFleetModeHostPathPodTemplate = `spec:
+   hostNetwork: true
+   dnsPolicy: ClusterFirstWithHostNet
+   automountServiceAccountToken: true
+   securityContext:
+     runAsUser: 0
+   containers:
+   - name: agent
+     volumeMounts:
+     - mountPath: /var/lib/docker/containers
+       name: varlibdockercontainers
+     - mountPath: /var/log/containers
+       name: varlogcontainers
+     - mountPath: /var/log/pods
+       name: varlogpods
+   volumes:
+   - name: varlibdockercontainers
+     hostPath:
+       path: /var/lib/docker/containers
+   - name: varlogcontainers
+     hostPath:
+       path: /var/log/containers
+   - name: varlogpods
+     hostPath:
+       path: /var/log/pods`
+
+	E2EAgentFleetModeAdvancedConfig = `fleet:
+  enabled: true
+providers.kubernetes:
+  add_resource_metadata:
+    deployment: true`
 )


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.2`:
 - [Version gate the CONFIG_PATH==STATE_PATH change to 8.13 and later (#8869)](https://github.com/elastic/cloud-on-k8s/pull/8869)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)