### PR TITLE
Reenable non-root agent recipe test with 9.1.5

### DIFF
--- a/test/e2e/agent/recipes_test.go
+++ b/test/e2e/agent/recipes_test.go
@@ -142,8 +142,8 @@ func TestFleetKubernetesNonRootIntegrationRecipe(t *testing.T) {
 		t.Skipf("Skipped as version %s is affected by https://github.com/elastic/kibana/pull/230211", v)
 	}
 
-	// TODO: see https://github.com/elastic/cloud-on-k8s/issues/8820
-	if v.GE(version.From(9, 1, 0)) {
+	// Do not test between 9.1.0 and 9.1.5 due to broken ssl settings in Kibana, see https://github.com/elastic/cloud-on-k8s/issues/8820
+	if v.GE(version.From(9, 1, 0)) && v.LT(version.From(9, 1, 5)) {
 		t.Skipf("Skipped as version %s is affected by https://github.com/elastic/kibana/issues/233780", v)
 	}
 


### PR DESCRIPTION
Fixes #8820 

https://github.com/elastic/kibana/pull/236788 is fixed in both 9.2.0 and 9.1.5 and we should be able to test the non-root Agent recipe again.