### PR TITLE
[3.2] Reenable non-root agent recipe test with 9.1.5 (#8875)

### DIFF
--- a/test/e2e/agent/recipes_test.go
+++ b/test/e2e/agent/recipes_test.go
@@ -142,8 +142,8 @@ func TestFleetKubernetesNonRootIntegrationRecipe(t *testing.T) {
 		t.Skipf("Skipped as version %s is affected by https://github.com/elastic/kibana/pull/230211", v)
 	}
 
-	// TODO: see https://github.com/elastic/cloud-on-k8s/issues/8820
-	if v.GE(version.From(9, 1, 0)) {
+	// Do not test between 9.1.0 and 9.1.5 due to broken ssl settings in Kibana, see https://github.com/elastic/cloud-on-k8s/issues/8820
+	if v.GE(version.From(9, 1, 0)) && v.LT(version.From(9, 1, 5)) {
 		t.Skipf("Skipped as version %s is affected by https://github.com/elastic/kibana/issues/233780", v)
 	}
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.2`:
 - [Reenable non-root agent recipe test with 9.1.5 (#8875)](https://github.com/elastic/cloud-on-k8s/pull/8875)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)