### PR TITLE
[Test] Temporarily removed logs integration recipe version guard

### DIFF
--- a/test/e2e/agent/recipes_test.go
+++ b/test/e2e/agent/recipes_test.go
@@ -187,11 +187,11 @@ func TestFleetKubernetesNonRootIntegrationRecipe(t *testing.T) {
 }
 
 func TestFleetCustomLogsIntegrationRecipe(t *testing.T) {
-	v := version.MustParse(test.Ctx().ElasticStackVersion)
+	// v := version.MustParse(test.Ctx().ElasticStackVersion)
 
-	if v.GT(version.MinFor(8, 8, 0)) {
-		t.Skip("Disabled since 8.8.0, refer to https://github.com/elastic/cloud-on-k8s/issues/5105")
-	}
+	// if v.GT(version.MinFor(8, 8, 0)) {
+	// 	t.Skip("Disabled since 8.8.0, refer to https://github.com/elastic/cloud-on-k8s/issues/5105")
+	// }
 
 	notLoggingPod := beat.NewPodBuilder("test")
 	loggingPod := beat.NewPodBuilder("test")


### PR DESCRIPTION

Testing a skipped e2e recipe tests with recent stack versions.