### PR TITLE
Script to generate dependency changes between branches

### DIFF
--- a/hack/release-notes/dependecy-chages.sh
+++ b/hack/release-notes/dependecy-chages.sh
@@ -29,6 +29,14 @@ get_deps() {
     }
 }
 
+get_go_version() {
+    local branch=$1
+    git show "$branch:go.mod" 2>/dev/null | grep -E '^go\s+[0-9.]+' | awk '{print $2}' || {
+        echo "Error: Failed to get Go version from branch '$branch'. Does the branch exist and have a go.mod file?" >&2
+        exit 1
+    }
+}
+
 # Get dependencies for both branches
 DEPS1=$(get_deps "$BRANCH1")
 DEPS2=$(get_deps "$BRANCH2")
@@ -53,6 +61,13 @@ done <<< "$DEPS2"
 
 # Collect changes in a variable for sorting
 changes=""
+
+# Check for Go version change
+GO_VERSION1=$(get_go_version "$BRANCH1")
+GO_VERSION2=$(get_go_version "$BRANCH2")
+if [ "$GO_VERSION1" != "$GO_VERSION2" ]; then
+    changes+="go $GO_VERSION1 => $GO_VERSION2\n"
+fi
 
 # Find updated and added dependencies
 for dep in "${!deps2[@]}"; do


### PR DESCRIPTION
Renovate has been changed to group dependency updates, so for release notes listing those PRs are not very useful.

For example:
https://github.com/elastic/cloud-on-k8s/pull/8749

This PR adds a script to generate a list of dependency updates between two branches.

Example output:

```
$ hack/release-notes/dependecy-chages.sh 3.1 3.2
github.com/gkampitakis/go-snaps v0.5.13 => v0.5.15
github.com/hashicorp/vault/api v1.20.0 => v1.22.0
github.com/KimMachineGun/automemlimit => v0.7.4
github.com/prometheus/client_golang v1.22.0 => v1.23.2
github.com/prometheus/common v0.65.0 => v0.67.1
github.com/sethvargo/go-password v0.3.1 => REMOVED
github.com/spf13/cobra v1.9.1 => v1.10.1
github.com/spf13/pflag v1.0.6 => v1.0.10
github.com/spf13/viper v1.20.1 => v1.21.0
github.com/stretchr/testify v1.10.0 => v1.11.1
golang.org/x/crypto v0.40.0 => v0.43.0
k8s.io/api v0.33.2 => v0.34.1
k8s.io/apimachinery v0.33.2 => v0.34.1
k8s.io/client-go v0.33.2 => v0.34.1
k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 => v0.0.0-20250604170112-4c0f3b243397
sigs.k8s.io/controller-runtime v0.21.0 => v0.22.2
sigs.k8s.io/controller-tools v0.18.0 => v0.19.0
```