### PR TITLE
Updated operatorhub buildkite job memory

### DIFF
--- a/.buildkite/pipeline-release-redhat.yml
+++ b/.buildkite/pipeline-release-redhat.yml
@@ -8,7 +8,7 @@ steps:
       - buildkite-agent artifact upload bin/operatorhub
     agents:
       image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
-      memory: "2G"
+      memory: "4G"
 
   - label: ":docker: push container"
     key: "redhat-container-push"
@@ -21,7 +21,7 @@ steps:
         operatorhub container push
     agents:
       image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
-      memory: "2G"
+      memory: "4G"
 
   - label: ":docker: preflight container check"
     key: "redhat-preflight"
@@ -33,7 +33,7 @@ steps:
       - .buildkite/scripts/release/redhat-preflight.sh
     agents:
       image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
-      memory: "2G"
+      memory: "4G"
 
   - label: ":docker: publish container"
     key: "redhat-publish"
@@ -48,7 +48,7 @@ steps:
         operatorhub container publish
     agents:
       image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
-      memory: "2G"
+      memory: "4G"
 
   - label: ":redhat: generate and create-pr"
     key: "redhat-release"
@@ -63,4 +63,4 @@ steps:
         operatorhub bundle create-pr
     agents:
       image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
-      memory: "2G"
+      memory: "4G"


### PR DESCRIPTION
This PR bumps the memory of the OperatorHub release buildkite job.

A [recent job has failed](https://buildkite.com/elastic/cloud-on-k8s-operator-redhat-release/builds/192#019a3630-37c4-49db-ac92-7a076196f0a8), which seems to be due to low resources:

<img width="1131" height="705" alt="image" src="https://github.com/user-attachments/assets/b1adcb29-3144-405c-a3dd-fde1d5ac6936" />
