### PR TITLE
Suppress client-go warnings.

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -628,6 +628,10 @@ func startOperator(ctx context.Context) error {
 		CertDir: webhookCertDir,
 	})
 
+	// Suppress client-go warnings.
+	// See https://github.com/elastic/cloud-on-k8s/issues/8797
+	cfg.WarningHandler = rest.NoWarnings{}
+
 	mgr, err := ctrl.NewManager(cfg, opts)
 	if err != nil {
 		log.Error(err, "Failed to create controller manager")


### PR DESCRIPTION
Resolves #8797

This adds the option to suppress the client-go warnings we are seeing such as:

```
"message":"unknown field \"spec.transport.service.metadata.creationTimestamp\""
```

## Questions
1. Do we want to do this "globally"? I didn't initially see a way to target these specific warnings. (Probably directed towards @pebrc from his comments in 8797)
2. Do we want to add an option to the operator flags to control this behavior?