### PR TITLE
Add missing closing dropdown tag to fix known issues page

### DIFF
--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -57,6 +57,7 @@ spec:
             - name: FLEET_FORCE
               value: "true"
 ```
+:::
 
 ## 3.1.0 [elastic-cloud-kubernetes-310-known-issues]
 


### PR DESCRIPTION
There is a `:::` missing to close the dropdown section at https://github.com/elastic/cloud-on-k8s/pull/8844/files#diff-30afc7e6ff1580c73ef66adaddc840df18c2c28b7b9b4835cdf8104d3fd2b31cR60. This PR adds the closing tag so the known issues page renders properly.

Current version (https://www.elastic.co/docs/release-notes/cloud-on-k8s/known-issues)

<img width="1036" height="562" alt="image" src="https://github.com/user-attachments/assets/30e3d065-9a0a-4d4f-a549-07ae143d586d" />

With the fix, each release renders with separate dropdowns:

<img width="1325" height="979" alt="image" src="https://github.com/user-attachments/assets/be9d699c-4370-4bc3-9117-943abfa1b06a" />
