### PR TITLE
Skip OperatorHub PR creation if a PR already exists

### DIFF
--- a/hack/operatorhub/internal/github/github.go
+++ b/hack/operatorhub/internal/github/github.go
@@ -286,8 +286,8 @@ func (c *Client) pullRequestExists(repo githubRepository, branchName string) (bo
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
 
-	// Query format: /repos/{owner}/{repo}/pulls?head={user}:{branch}
-	url := fmt.Sprintf("%s/repos/%s/%s/pulls?head=%s:%s",
+	// Query format: /repos/{owner}/{repo}/pulls?head={user}:{branch}&state=open
+	url := fmt.Sprintf("%s/repos/%s/%s/pulls?head=%s:%s&state=open",
 		githubAPIURL, repo.organization, repo.repository, c.GitHubUsername, branchName)
 
 	req, err := c.createRequest(ctx, http.MethodGet, url, nil)


### PR DESCRIPTION
Releasing to OperatorHub might fail between community operators and certified operators. This PR ignores 422 errors when creating a pull request, so when a PR for community operators exists already, we'd continue with certified operators.