### PR TITLE
[3.2] add missing closing dropdown tag (#8885)

### DIFF
--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -57,6 +57,7 @@ spec:
             - name: FLEET_FORCE
               value: "true"
 ```
+:::
 
 ## 3.1.0 [elastic-cloud-kubernetes-310-known-issues]
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.2`:
 - [add missing closing dropdown tag (#8885)](https://github.com/elastic/cloud-on-k8s/pull/8885)

<!--- Backport version: 9.2.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)