### PR TITLE
Include matching eck-diag in e2e image

### DIFF
--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -2,12 +2,21 @@
 FROM docker.io/library/golang:1.24.5
 
 ARG GO_TAGS
+ARG ARCH
 
 WORKDIR /go/src/github.com/elastic/cloud-on-k8s
 
 ENV ECK_DIAG_VERSION=1.8.3
-RUN curl -fsSLO https://github.com/elastic/eck-diagnostics/releases/download/${ECK_DIAG_VERSION}/eck-diagnostics_${ECK_DIAG_VERSION}_Linux_x86_64.tar.gz && \
-    tar xzf eck-diagnostics_${ECK_DIAG_VERSION}_Linux_x86_64.tar.gz && \
+# Download and extract the correct eck-diagnostics binary based on the image architecture
+# ARCH is passed from drivah.toml.sh (amd64 or arm64)
+# Map to eck-diagnostics naming: x86_64 for amd64, arm64 for arm64
+RUN case "${ARCH}" in \
+      amd64) ECK_DIAG_ARCH="x86_64" ;; \
+      arm64) ECK_DIAG_ARCH="arm64" ;; \
+      *) echo "Unsupported architecture: ${ARCH}"; exit 1 ;; \
+    esac; \
+    curl -fsSLO "https://github.com/elastic/eck-diagnostics/releases/download/${ECK_DIAG_VERSION}/eck-diagnostics_${ECK_DIAG_VERSION}_Linux_${ECK_DIAG_ARCH}.tar.gz" && \
+    tar xzf "eck-diagnostics_${ECK_DIAG_VERSION}_Linux_${ECK_DIAG_ARCH}.tar.gz" && \
     mv eck-diagnostics /usr/local/bin/eck-diagnostics
 
 # create the go test cache directory

--- a/test/e2e/drivah.toml.sh
+++ b/test/e2e/drivah.toml.sh
@@ -49,6 +49,7 @@ build_context = "../../"
 
 [container.image.build_args]
 GO_TAGS = "$GO_TAGS"
+ARCH = "$ARCH"
 END
 }
 


### PR DESCRIPTION
```
fork/exec /usr/local/bin/eck-diagnostics: exec format error 
```

On `eks-arm` test runs we are without diagnostics because we always include the x86 version. This PR tries to remedy this problem by looking at the current architecture. 