### PR TITLE
chore: replace quintush/helm-unittest with helm-unittest/helm-unittest

### DIFF
--- a/.buildkite/Makefile
+++ b/.buildkite/Makefile
@@ -4,7 +4,7 @@
 
 # This Makefile is used to run the buildkite agent in virtual machines when Docker access is required.
 
-CI_IMAGE               ?= docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
+CI_IMAGE               ?= docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
 ROOT_DIR               := $(CURDIR)/..
 GO_MOUNT_PATH          ?= /go/src/github.com/elastic/cloud-on-k8s
 export VAULT_ROOT_PATH = secret/ci/elastic-cloud-on-k8s

--- a/.buildkite/e2e/pipeline-gen/pipeline.tpl.yaml
+++ b/.buildkite/e2e/pipeline-gen/pipeline.tpl.yaml
@@ -33,7 +33,7 @@ steps:
       machineType: "{{ $.K8sInDockerMachineType }}"
       {{- end }}
       {{- else }}
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
       memory: "5G"
       {{- end }}
 
@@ -85,7 +85,7 @@ steps:
       diskSizeGb: 150
       {{- end }}
       {{- else }}
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
       memory: "4G"
       {{- end }}
 
@@ -121,7 +121,7 @@ steps:
         {{- if not $test.Dind }}
           - make run-deployer
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
           memory: "4G"
         {{- else }}
           - make -C .buildkite TARGET="run-deployer" ci
@@ -144,5 +144,5 @@ steps:
       - ".buildkite/e2e/reporter/*.md"
       - ".buildkite/e2e/reporter/*.yml"
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
       memory: "2G"

--- a/.buildkite/e2e/reporter/templates/notify-failures.tpl.yml
+++ b/.buildkite/e2e/reporter/templates/notify-failures.tpl.yml
@@ -4,7 +4,7 @@ steps:
   - label: "{{ .ShortFailuresCount }} failure(s)"
     command: exit {{ .ShortFailuresCount }}
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
       memory: "2G"
 
   # notify e2e tests failures for the main branch and tags
@@ -13,7 +13,7 @@ steps:
     if: build.branch == "main" || build.tag != null
     command: echo "notify"
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
       memory: "2G"
 
     notify:

--- a/.buildkite/pipeline-e2e-clusters-cleanup.yml
+++ b/.buildkite/pipeline-e2e-clusters-cleanup.yml
@@ -10,7 +10,7 @@ steps:
       - make build-deployer
       - buildkite-agent artifact upload hack/deployer/deployer
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
       memory: 2G
 
   - label: ":broom: e2e test cluster cleanup gke"
@@ -26,7 +26,7 @@ steps:
       - chmod u+x /usr/local/hack/deployer/deployer
       - /usr/local/hack/deployer/deployer cleanup --plans-file hack/deployer/config/plans.yml --cluster-prefix $${E2E_TEST_CLUSTER_PREFIX} --config-file deployer-config.yml
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
       memory: 2G
 
   - label: ":broom: e2e test cluster cleanup aks"
@@ -55,7 +55,7 @@ steps:
       - chmod u+x /usr/local/hack/deployer/deployer
       - /usr/local/hack/deployer/deployer cleanup --plans-file hack/deployer/config/plans.yml --cluster-prefix $${E2E_TEST_CLUSTER_PREFIX} --config-file deployer-config.yml
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
       memory: 2G
 
   - label: ":broom: e2e test cluster cleanup eks-arm"
@@ -71,7 +71,7 @@ steps:
       - chmod u+x /usr/local/hack/deployer/deployer
       - /usr/local/hack/deployer/deployer cleanup --plans-file hack/deployer/config/plans.yml --cluster-prefix $${E2E_TEST_CLUSTER_PREFIX} --config-file deployer-config.yml
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
       memory: 2G
 
   - label: ":broom: e2e test cluster cleanup ocp"

--- a/.buildkite/pipeline-e2e-tests.yml
+++ b/.buildkite/pipeline-e2e-tests.yml
@@ -17,7 +17,7 @@ steps:
               E2E_PROVIDER: gke
           DEF
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
           memory: "2G"
 
       # for nightly builds from main
@@ -30,7 +30,7 @@ steps:
           cd .buildkite/e2e/pipeline-gen && go build -o pipeline-gen
           cat ../nightly-main-matrix.yaml | ./pipeline-gen | buildkite-agent pipeline upload
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
           memory: "2G"
 
       # for all tags
@@ -41,5 +41,5 @@ steps:
           cd .buildkite/e2e/pipeline-gen && go build -o pipeline-gen
           cat ../release-branch-matrix.yaml | ./pipeline-gen | buildkite-agent pipeline upload
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
           memory: "2G"

--- a/.buildkite/pipeline-release-helm.yml
+++ b/.buildkite/pipeline-release-helm.yml
@@ -11,7 +11,7 @@ steps:
       - make build
       - buildkite-agent artifact upload bin/releaser
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
       memory: "2G"
 
   - label: "operator dev helm chart"
@@ -30,7 +30,7 @@ steps:
       - chmod u+x /usr/local/bin/releaser
       - releaser --env=dev --charts-dir=deploy/eck-operator
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
       memory: "2G"
 
   - label: "eck-stack dev helm charts"
@@ -49,7 +49,7 @@ steps:
       - chmod u+x /usr/local/bin/releaser
       - releaser --env=dev --charts-dir=deploy/eck-stack
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
       memory: "2G"
 
   - label: "operator prod helm chart"
@@ -65,7 +65,7 @@ steps:
       - chmod u+x /usr/local/bin/releaser
       - releaser --env=prod --charts-dir=deploy/eck-operator
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
       memory: "2G"
 
   - label: "eck-stack prod helm charts"
@@ -80,5 +80,5 @@ steps:
       - chmod u+x /usr/local/bin/releaser
       - releaser --env=prod --charts-dir=deploy/eck-stack
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
       memory: "2G"

--- a/.buildkite/pipeline-release-redhat.yml
+++ b/.buildkite/pipeline-release-redhat.yml
@@ -7,7 +7,7 @@ steps:
       - make build
       - buildkite-agent artifact upload bin/operatorhub
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
       memory: "4G"
 
   - label: ":docker: push container"
@@ -20,7 +20,7 @@ steps:
         cd hack/operatorhub
         operatorhub container push
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
       memory: "4G"
 
   - label: ":docker: preflight container check"
@@ -32,7 +32,7 @@ steps:
     commands:
       - .buildkite/scripts/release/redhat-preflight.sh
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
       memory: "4G"
 
   - label: ":docker: publish container"
@@ -47,7 +47,7 @@ steps:
         cd hack/operatorhub
         operatorhub container publish
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
       memory: "4G"
 
   - label: ":redhat: generate and create-pr"
@@ -62,5 +62,5 @@ steps:
         operatorhub generate-manifests
         operatorhub bundle create-pr
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
       memory: "4G"

--- a/.buildkite/pipeline-release.yml
+++ b/.buildkite/pipeline-release.yml
@@ -10,7 +10,7 @@ steps:
         commands:
           - .buildkite/scripts/release/k8s-manifests.sh
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
           memory: "2G"
 
       - label: "copy images to dockerhub"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,14 +9,14 @@ steps:
       - label: ":go: lint"
         command: "make lint check-local-changes"
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
           cpu: "6"
           memory: "7G"
 
       - label: ":go: generate"
         command: "make generate check-local-changes"
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
           cpu: "4"
           memory: "4G"
 
@@ -25,7 +25,7 @@ steps:
           - "make check-license-header check-predicates shellcheck reattach-pv"
           - "make -C hack/helm/release build"
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
           cpu: "4"
           memory: "4G"
 
@@ -35,28 +35,28 @@ steps:
       - label: ":go: unit-tests"
         command: "make unit-xml"
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
           cpu: "4"
           memory: "4G"
 
       - label: ":go: integration-tests"
         command: "make integration-xml"
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
           cpu: "4"
           memory: "4G"
 
       - label: ":go: manifest-gen-tests"
         command: "make manifest-gen-test"
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
           cpu: "4"
           memory: "2G"
 
       - label: ":go: helm-tests"
         command: "make helm-test"
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
           cpu: "4"
           memory: "2G"
 
@@ -112,7 +112,7 @@ steps:
           E2E_SKIP_CLEANUP: true
       DEF
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
       memory: "2G"
 
   # for PR comment
@@ -125,14 +125,14 @@ steps:
       $$(echo ./pipeline-gen $$GITHUB_PR_COMMENT_VAR_ARGS) \
         | buildkite-agent pipeline upload
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
       memory: "2G"
 
   # for the main branch (merge and nightly) and tags
   - label: ":buildkite:"
     command: buildkite-agent pipeline upload .buildkite/pipeline-e2e-tests.yml
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
       memory: "2G"
 
   # ----------
@@ -165,7 +165,7 @@ steps:
         done
       ) | buildkite-agent pipeline upload
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
       memory: "256Mi"
 
   - label: ":buildkite:"
@@ -173,5 +173,5 @@ steps:
       - "operator-image-build"
     command: buildkite-agent pipeline upload .buildkite/pipeline-release.yml
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a9130ecd
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
       memory: "2G"

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -52,12 +52,12 @@ kubectl get elastic -l "app.kubernetes.io/instance"=es-kb-quickstart -n elastic-
 
 ### ECK Helm Chart test suite
 
-[Helm UnitTest Plugin](https://github.com/quintush/helm-unittest) is used to ensure Helm Charts render properly.
+[Helm UnitTest Plugin](https://github.com/helm-unittest/helm-unittest) is used to ensure Helm Charts render properly.
 
 #### Installation
 
 ```
-helm plugin install https://github.com/quintush/helm-unittest --version 0.2.8
+helm plugin install https://github.com/helm-unittest/helm-unittest.git --version 1.0.3
 ```
 
 #### Running Test Suite

--- a/deploy/eck-operator/templates/tests/operator_test.yaml
+++ b/deploy/eck-operator/templates/tests/operator_test.yaml
@@ -29,9 +29,8 @@ tests:
         isKind:
           of: ValidatingWebhookConfiguration
       - documentIndex: 0
-        equal:
+        notExists:
           path: webhooks[0].clientConfig.caBundle
-          value: null
 
   - it: should NOT render webhook clientConfig.caBundle when certs are managed by the cert manager
     set:
@@ -44,6 +43,5 @@ tests:
         isKind:
           of: ValidatingWebhookConfiguration
       - documentIndex: 0
-        equal:
+        notExists:
           path: webhooks[0].clientConfig.caBundle
-          value: null

--- a/deploy/eck-operator/templates/tests/statefulset_test.yaml
+++ b/deploy/eck-operator/templates/tests/statefulset_test.yaml
@@ -144,9 +144,8 @@ tests:
         nameservers: "1.2.3.4"
     asserts:
       - template: statefulset.yaml
-        equal:
+        notExists:
           path: spec.template.spec.hostNetwork
-          value: null
       - template: statefulset.yaml
         equal:
           path: spec.template.spec.dnsPolicy

--- a/deploy/eck-stack/charts/eck-agent/templates/tests/elastic-agent_test.yaml
+++ b/deploy/eck-stack/charts/eck-agent/templates/tests/elastic-agent_test.yaml
@@ -23,9 +23,8 @@ tests:
       - equal:
           path: spec.version
           value: 9.3.0-SNAPSHOT
-      - equal:
+      - notExists:
           path: spec.config
-          value: null
       - equal:
           path: spec.daemonSet.podTemplate.spec.containers[0].name
           value: agent

--- a/deploy/eck-stack/charts/eck-beats/templates/tests/beats-auditbeat-example_test.yaml
+++ b/deploy/eck-stack/charts/eck-beats/templates/tests/beats-auditbeat-example_test.yaml
@@ -17,10 +17,10 @@ tests:
           path: spec.kibanaRef.name
           value: eck-kibana
       - equal:
-          path: spec.config.[auditbeat.modules][0].module
+          path: spec.config["auditbeat.modules"][0].module
           value: file_integrity
       - equal:
-          path: spec.config.[auditbeat.modules][0].paths
+          path: spec.config["auditbeat.modules"][0].paths
           value:
           - /hostfs/bin
           - /hostfs/usr/bin
@@ -28,13 +28,13 @@ tests:
           - /hostfs/usr/sbin
           - /hostfs/etc
       - equal:
-          path: spec.config.[auditbeat.modules][0].scan_at_start
+          path: spec.config["auditbeat.modules"][0].scan_at_start
           value: true
       - equal:
-          path: spec.config.[auditbeat.modules][0].recursive
+          path: spec.config["auditbeat.modules"][0].recursive
           value: true
       - equal:
-          path: spec.config.[auditbeat.modules][1].module
+          path: spec.config["auditbeat.modules"][1].module
           value: auditd
       - equal:
           path: spec.daemonSet.podTemplate.spec.hostPID

--- a/deploy/eck-stack/charts/eck-beats/templates/tests/beats-filebeat-example_test.yaml
+++ b/deploy/eck-stack/charts/eck-beats/templates/tests/beats-filebeat-example_test.yaml
@@ -17,10 +17,10 @@ tests:
           path: spec.kibanaRef.name
           value: eck-kibana
       - equal:
-          path: spec.config.[filebeat.inputs][0].type
+          path: spec.config["filebeat.inputs"][0].type
           value: filestream
       - equal:
-          path: spec.config.[filebeat.inputs][0].paths
+          path: spec.config["filebeat.inputs"][0].paths
           value:
           - /var/log/containers/*.log
       - equal:

--- a/deploy/eck-stack/charts/eck-beats/templates/tests/beats-heartbeat-example_test.yaml
+++ b/deploy/eck-stack/charts/eck-beats/templates/tests/beats-heartbeat-example_test.yaml
@@ -14,23 +14,23 @@ tests:
           path: spec.elasticsearchRef.name
           value: eck-elasticsearch
       - equal:
-          path: spec.config.[heartbeat.monitors][0].type
+          path: spec.config["heartbeat.monitors"][0].type
           value: tcp
       - equal:
-          path: spec.config.[heartbeat.monitors][0].schedule
+          path: spec.config["heartbeat.monitors"][0].schedule
           value: '@every 5s'
       - equal:
-          path: spec.config.[heartbeat.monitors][0].hosts
+          path: spec.config["heartbeat.monitors"][0].hosts
           value:
           - "elasticsearch-es-http.default.svc:9200"
       - equal:
-          path: spec.config.[heartbeat.monitors][1].type
+          path: spec.config["heartbeat.monitors"][1].type
           value: tcp
       - equal:
-          path: spec.config.[heartbeat.monitors][1].schedule
+          path: spec.config["heartbeat.monitors"][1].schedule
           value: '@every 5s'
       - equal:
-          path: spec.config.[heartbeat.monitors][1].hosts
+          path: spec.config["heartbeat.monitors"][1].hosts
           value:
           - "eck-kibana-kb-http.default.svc:5601"
       - equal:

--- a/deploy/eck-stack/charts/eck-beats/templates/tests/beats-metricbeat-example_test.yaml
+++ b/deploy/eck-stack/charts/eck-beats/templates/tests/beats-metricbeat-example_test.yaml
@@ -122,7 +122,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-beats
             clusterRole: label
-            helm.sh/chart: eck-beats-0.1.0
+            helm.sh/chart:  eck-beats-0.18.0-SNAPSHOT
             test: label
       - equal:
           path: metadata.annotations
@@ -185,7 +185,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-beats
             clusterRoleBinding: label
-            helm.sh/chart: eck-beats-0.1.0
+            helm.sh/chart:  eck-beats-0.18.0-SNAPSHOT
             test: label
       - equal:
           path: metadata.annotations
@@ -233,7 +233,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-beats
             serviceAccount: label
-            helm.sh/chart: eck-beats-0.18.0-SNAPSHOT
+            helm.sh/chart:  eck-beats-0.18.0-SNAPSHOT
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-stack/charts/eck-beats/templates/tests/beats-packetbeat-example_test.yaml
+++ b/deploy/eck-stack/charts/eck-beats/templates/tests/beats-packetbeat-example_test.yaml
@@ -17,10 +17,10 @@ tests:
           path: spec.kibanaRef.name
           value: eck-kibana
       - equal:
-          path: spec.config.[packetbeat.interfaces.device]
+          path: spec.config["packetbeat.interfaces.device"]
           value: any
       - equal:
-          path: spec.config.[packetbeat.protocols]
+          path: spec.config["packetbeat.protocols"]
           value:
           - type: dns
             ports:
@@ -34,7 +34,7 @@ tests:
             - 8080
             - 9200
       - equal:
-          path: spec.config.[packetbeat.flows]
+          path: spec.config["packetbeat.flows"]
           value:
             timeout: 30s
             period: 10s

--- a/deploy/eck-stack/charts/eck-elasticsearch/templates/tests/elasticsearch_test.yaml
+++ b/deploy/eck-stack/charts/eck-elasticsearch/templates/tests/elasticsearch_test.yaml
@@ -222,9 +222,8 @@ tests:
   - it: should render no podDisruptionBudget by default
     set:
     asserts:
-      - equal:
+      - notExists:
           path: spec.podDisruptionBudget
-          value: null
   - it: should render podDisruptionBudget properly
     set:
       podDisruptionBudget:

--- a/deploy/eck-stack/templates/tests/elastic-agent_test.yaml
+++ b/deploy/eck-stack/templates/tests/elastic-agent_test.yaml
@@ -33,9 +33,8 @@ tests:
       - equal:
           path: spec.version
           value: 9.3.0-SNAPSHOT
-      - equal:
+      - notExists:
           path: spec.elasticsearchRefs
-          value: null
       - equal:
           path: spec.kibanaRef.name
           value: kibana

--- a/dev-setup.md
+++ b/dev-setup.md
@@ -12,7 +12,7 @@ Before you start, install the following tools and packages:
 * [kubebuilder](https://github.com/kubernetes-sigs/kubebuilder) (>= 2.0.0)
 * [docker](https://docs.docker.com/) (>= 19.0.0 with optional `buildx` extension for multi-arch builds)
 * [helm](https://helm.sh/docs/intro/install/) (>= 3.2.0, preferably 3.9.x)
-* [helm unittest](https://github.com/quintush/helm-unittest#install) (only needed if developing helm charts) `helm plugin install https://github.com/quintush/helm-unittest --version 0.2.8`
+* [helm unittest](https://github.com/helm-unittest/helm-unittest?tab=readme-ov-file#install) (only needed if developing helm charts) `helm plugin install https://github.com/helm-unittest/helm-unittest.git --version 1.0.3`
 * Kubernetes distribution such as [minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) or [kind](https://kind.sigs.k8s.io), or access to a hosted Kubernetes service such as [GKE](https://cloud.google.com/kubernetes-engine) or [AKS](https://azure.microsoft.com/en-us/services/kubernetes-service/)
 
 ### Get sources

--- a/hack/helm/test.sh
+++ b/hack/helm/test.sh
@@ -32,7 +32,7 @@ check() {
     fi
 
     if [[ -d templates/tests ]]; then
-        helm unittest -3 -f 'templates/tests/*.yaml' --with-subchart=false .
+        helm unittest -f 'templates/tests/*.yaml' --with-subchart=false .
     fi
 
     cd -


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to Elastic Cloud on Kubernetes!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

## Overview

This PR migrates from the deprecated `quintush/helm-unittest` plugin to the official `helm-unittest/helm-unittest` repository and updates all test files to use the new syntax requirements.

## Changes

### Repository Migration

- **Updated plugin installation** from `quintush/helm-unittest` v0.2.8 to `helm-unittest/helm-unittest` v1.0.3
- **Updated documentation** in:
  - `deploy/README.md`
  - `dev-setup.md`
- **Updated all GitHub links** to point to the new repository location

### Test Syntax Updates

Updated all test files to comply with the new JsonPath syntax for keys containing dots:

**Before:**
```yaml
path: spec.config.[packetbeat.interfaces.device]
```

**After:**
```yaml
path: spec.config["packetbeat.interfaces.device"]
```

This change affects all Beat configuration tests:
- Auditbeat: `auditbeat.modules`
- Filebeat: `filebeat.inputs`
- Heartbeat: `heartbeat.monitors`
- Metricbeat: configuration keys
- Packetbeat: `packetbeat.interfaces.device`, `packetbeat.protocols`, `packetbeat.flows`

### Improved Assertions

Replaced `equal` assertions checking for `null` values with the more semantically correct `notExists` assertion:

**Before:**
```yaml
- equal:
    path: spec.config
    value: null
```

**After:**
```yaml
- notExists:
    path: spec.config
```

### Command Updates

- Removed the `-3` flag from `helm unittest` commands in `hack/helm/test.sh` (Helm 3 is now the default)

## Testing

All existing helm unit tests continue to pass with the updated syntax. You may run `make helm-test` to validate this PR ([respective BK step](https://buildkite.com/elastic/cloud-on-k8s-operator/builds/12015#019a6d86-aa91-46bf-a982-769b9eb0458a/65-67)) 

## Breaking Changes

None for end users. This only affects the development environment setup - developers will need to reinstall the helm-unittest plugin using the new repository.

