### PR TITLE
[3.2] Test against OCP 4.20.4 (#8911)

### DIFF
--- a/.buildkite/e2e/release-branch-matrix.yaml
+++ b/.buildkite/e2e/release-branch-matrix.yaml
@@ -63,7 +63,7 @@
   fixed:
     E2E_PROVIDER: ocp
   mixed:
-    - DEPLOYER_CLIENT_VERSION: "4.19.2"
+    - DEPLOYER_CLIENT_VERSION: "4.20.4"
 
 - label: eks-arm
   fixed:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Current features:
 Supported versions:
 
 *  Kubernetes 1.30-1.34
-*  OpenShift 4.15-4.19
+*  OpenShift 4.15-4.20
 *  Elasticsearch, Kibana, APM Server: 7.17+, 8+, 9+
 *  Enterprise Search: 7.7+, 8+
 *  Beats: 7.17+, 8+, 9+

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -93,7 +93,7 @@ plans:
 - id: ocp-ci
   operation: create
   clusterName: ci
-  clientVersion: 4.19.14
+  clientVersion: 4.20.4
   provider: ocp
   machineType: n1-standard-8
   serviceAccount: true
@@ -103,7 +103,7 @@ plans:
 - id: ocp-dev
   operation: create
   clusterName: dev
-  clientVersion: 4.19.14
+  clientVersion: 4.20.4
   provider: ocp
   machineType: n1-standard-8
   serviceAccount: true

--- a/hack/operatorhub/templates/csv.tpl
+++ b/hack/operatorhub/templates/csv.tpl
@@ -286,7 +286,7 @@ spec:
 
     * Kubernetes 1.30-1.34
 
-    * OpenShift 4.15-4.19
+    * OpenShift 4.15-4.20
 
     * Google Kubernetes Engine (GKE), Azure Kubernetes Service (AKS), and Amazon Elastic Kubernetes Service (EKS)
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.2`:
 - [Test against OCP 4.20.1 (#8911)](https://github.com/elastic/cloud-on-k8s/pull/8911)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)