### PR TITLE
Set persistentVolumeClaimRetentionPolicy per default delete

### DIFF
--- a/deploy/eck-operator/templates/statefulset.yaml
+++ b/deploy/eck-operator/templates/statefulset.yaml
@@ -20,6 +20,9 @@ spec:
       {{- include "eck-operator.selectorLabels" . | nindent 6 }}
   serviceName: {{ include "eck-operator.fullname" . }}
   replicas: {{ .Values.replicaCount }}
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: {{ .Values.persistentVolumeClaimRetentionPolicy.whenDeleted  }}
+    whenScaled: {{ .Values.persistentVolumeClaimRetentionPolicy.whenScaled }}
   template:
     metadata:
       annotations:

--- a/deploy/eck-operator/values.yaml
+++ b/deploy/eck-operator/values.yaml
@@ -17,6 +17,11 @@ installCRDs: true
 # replicaCount is the number of operator pods to run.
 replicaCount: 1
 
+# the strategy what happens with pvc on the statefulset
+persistentVolumeClaimRetentionPolicy:
+  whenDeleted: Delete
+  whenScaled: Delete
+
 image:
   # repository is the container image prefixed by the registry name.
   repository: docker.elastic.co/eck/eck-operator


### PR DESCRIPTION
With this change I want to make sure that the PVC getting deleted once the StatefulSet is deleted or scaled down. In the context of our Organisation, we'd like to have a policy in place that enfoces `persistentVolumeClaimRetentionPolicy` to be set. More information about persistentVolumeClaimRetentionPolicy you can find under https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention.

I think having `whenDeleted` and `whenScaled` with the `Delete` option is the most sensible choice, since how I understood it the eck-operator does not take usage of the persistence property we would get if we have the `Retain` option. 

I've saw that https://github.com/elastic/cloud-on-k8s/issues/8478 already mentioned this issue.