### PR TITLE
Remove Azure exception in e2e tests for disk expansion

### DIFF
--- a/test/e2e/es/volume_test.go
+++ b/test/e2e/es/volume_test.go
@@ -104,7 +104,8 @@ func TestVolumeMultiDataPath(t *testing.T) {
 							},
 						},
 					},
-				}},
+				},
+			},
 			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -214,9 +215,7 @@ func getResizeableStorageClass(k8sClient k8s.Client) (string, error) {
 		return "", err
 	}
 	for _, sc := range scs.Items {
-		// TODO https://github.com/Azure/AKS/issues/1477 azure-disk does not support resizing of "attached" disks, despite
-		// advertising it allows volume expansion. Remove the azure special case once this issue is resolved.
-		if sc.AllowVolumeExpansion != nil && *sc.AllowVolumeExpansion && sc.Provisioner != "kubernetes.io/azure-disk" {
+		if sc.AllowVolumeExpansion != nil && *sc.AllowVolumeExpansion {
 			return sc.Name, nil
 		}
 	}


### PR DESCRIPTION
resolves #4907

Azure disk expansion is fully supported (outside of multi-TB volumes), so this exception in our e2e tests makes no sense. 