### PR TITLE
Do not set Kibana server.name

### DIFF
--- a/pkg/controller/kibana/config_settings.go
+++ b/pkg/controller/kibana/config_settings.go
@@ -283,7 +283,6 @@ func baseSettings(kb *kbv1.Kibana, ipFamily corev1.IPFamily) (map[string]interfa
 	}
 
 	conf := map[string]interface{}{
-		ServerName: kb.Name,
 		ServerHost: net.InAddrAnyFor(ipFamily).String(),
 	}
 

--- a/pkg/controller/kibana/config_settings_test.go
+++ b/pkg/controller/kibana/config_settings_test.go
@@ -28,7 +28,6 @@ var defaultConfig = []byte(`
 elasticsearch:
 server:
   host: "0.0.0.0"
-  name: "testkb"
   ssl:
     enabled: true
     key: /mnt/elastic-internal/http-certs/tls.key
@@ -48,7 +47,6 @@ var defaultConfig8 = []byte(`
 elasticsearch:
 server:
   host: "0.0.0.0"
-  name: "testkb"
   ssl:
     enabled: true
     key: /mnt/elastic-internal/http-certs/tls.key


### PR DESCRIPTION
re: #8929 

<img width="1435" height="751" alt="image" src="https://github.com/user-attachments/assets/afb76d9f-2cbc-42bc-b3a9-1d4894b760c1" />

From my local testing, this defaults properly to the pod name, which makes stack monitoring a bit more useful in the case of multiple Kibana instances.