### PR TITLE
Do not write elasticsearch.k8s.elastic.co/managed-remote-clusters when not necessary

### DIFF
--- a/pkg/controller/elasticsearch/remotecluster/annotations.go
+++ b/pkg/controller/elasticsearch/remotecluster/annotations.go
@@ -59,7 +59,12 @@ func annotateWithCreatedRemoteClusters(ctx context.Context, c k8s.Client, es esv
 	}
 
 	sort.Strings(annotation)
-	es.Annotations[ManagedRemoteClustersAnnotationName] = strings.Join(annotation, ",")
+	expected := strings.Join(annotation, ",")
+	current, ok := es.Annotations[ManagedRemoteClustersAnnotationName]
 
-	return c.Update(ctx, &es)
+	if !ok || current != expected {
+		es.Annotations[ManagedRemoteClustersAnnotationName] = expected
+		return c.Update(ctx, &es)
+	}
+	return nil
 }


### PR DESCRIPTION
This PR fixes unnecessary calls to the K8s API, discovered while investigating https://github.com/elastic/cloud-on-k8s/issues/8781, when remote clusters are set in the ES specification.