### PR TITLE
Do not log error since we are already returning it

### DIFF
--- a/pkg/controller/common/reconciler/reconciler.go
+++ b/pkg/controller/common/reconciler/reconciler.go
@@ -118,7 +118,6 @@ func ReconcileResource(params Params) error {
 	if err != nil && apierrors.IsNotFound(err) {
 		return create()
 	} else if err != nil {
-		log.Error(err, fmt.Sprintf("Generic GET for %s %s/%s failed with error", kind, namespace, name))
 		return fmt.Errorf("failed to get %s %s/%s: %w", kind, namespace, name, err)
 	}
 


### PR DESCRIPTION
In this line of code, we are returning and error and also logging it as an error. 

In several services using this library we do a classification of the errors returned by the logic underneath to decide if we consider them transient or not in order to log the errors or not. However, we can't prevent logging this error.



<!--
Thank you for your interest in contributing to Elastic Cloud on Kubernetes!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

