### PR TITLE
Also add epr to e2e scheme

### DIFF
--- a/test/e2e/test/k8s_client.go
+++ b/test/e2e/test/k8s_client.go
@@ -35,6 +35,7 @@ import (
 	entv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/enterprisesearch/v1"
 	kbv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/kibana/v1"
 	logstashv1alpha1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/logstash/v1alpha1"
+	eprv1alpha1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/packageregistry/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/agent"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/apmserver"
 	beatcommon "github.com/elastic/cloud-on-k8s/v3/pkg/controller/beat/common"
@@ -100,6 +101,9 @@ func CreateClient() (k8s.Client, error) {
 		return nil, err
 	}
 	if err := logstashv1alpha1.AddToScheme(scheme.Scheme); err != nil {
+		return nil, err
+	}
+	if err := eprv1alpha1.AddToScheme(scheme.Scheme); err != nil {
 		return nil, err
 	}
 	client, err := k8sclient.New(cfg, k8sclient.Options{Scheme: scheme.Scheme})


### PR DESCRIPTION
Fixes https://buildkite.com/elastic/cloud-on-k8s-operator/builds/12430/annotations
```
=== RUN   TestSamples
    samples_test.go:38: 
        	Error Trace:	/go/src/github.com/elastic/cloud-on-k8s/test/e2e/samples_test.go:129
        	            				/go/src/github.com/elastic/cloud-on-k8s/test/e2e/samples_test.go:38
        	Error:      	Received unexpected error:
        	            	failed to decode YAML: no kind "PackageRegistry" is registered for version "packageregistry.k8s.elastic.co/v1alpha1" in scheme "pkg/runtime/scheme.go:110"
        	Test:       	TestSamples
        	Messages:   	Failed to create builders
```