### PR TITLE
fix: TestSamples/kibana-kibana_epr e2e test

### DIFF
--- a/test/e2e/samples_test.go
+++ b/test/e2e/samples_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test/apmserver"
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test/elasticsearch"
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test/enterprisesearch"
+	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test/epr"
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test/helper"
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test/kibana"
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test/logstash"
@@ -73,6 +74,7 @@ func createBuilders(t *testing.T, decoder *helper.YAMLDecoder, sampleFile, testN
 				WithSuffix(suffix).
 				WithElasticsearchRef(tweakServiceRef(b.Kibana.Spec.ElasticsearchRef, suffix)).
 				WithEnterpriseSearchRef(tweakServiceRef(b.Kibana.Spec.EnterpriseSearchRef, suffix)).
+				WithPackageRegistryRef(tweakServiceRef(b.Kibana.Spec.PackageRegistryRef, suffix)).
 				WithRestrictedSecurityContext().
 				WithLabel(run.TestNameLabel, fullTestName).
 				WithPodLabel(run.TestNameLabel, fullTestName)
@@ -119,7 +121,12 @@ func createBuilders(t *testing.T, decoder *helper.YAMLDecoder, sampleFile, testN
 				WithLabel(run.TestNameLabel, fullTestName).
 				WithPodLabel(run.TestNameLabel, fullTestName).
 				WithTestStorageClass()
-
+		case epr.Builder:
+			return b.WithNamespace(namespace).
+				WithSuffix(suffix).
+				WithRestrictedSecurityContext().
+				WithLabel(run.TestNameLabel, fullTestName).
+				WithPodLabel(run.TestNameLabel, fullTestName)
 		default:
 			return b
 		}

--- a/test/e2e/test/helper/yaml.go
+++ b/test/e2e/test/helper/yaml.go
@@ -35,6 +35,7 @@ import (
 	entv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/enterprisesearch/v1"
 	kbv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/kibana/v1"
 	logstashv1alpha1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/logstash/v1alpha1"
+	packageregistryv1alpha1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/packageregistry/v1alpha1"
 	beatcommon "github.com/elastic/cloud-on-k8s/v3/pkg/controller/beat/common"
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/cmd/run"
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test"
@@ -43,6 +44,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test/beat"
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test/elasticsearch"
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test/enterprisesearch"
+	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test/epr"
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test/kibana"
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test/logstash"
 )
@@ -68,6 +70,7 @@ func NewYAMLDecoder() *YAMLDecoder {
 	scheme.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.ServiceAccount{}, &corev1.ServiceAccountList{})
 	scheme.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.Service{}, &corev1.ServiceList{})
 	scheme.AddKnownTypes(appsv1.SchemeGroupVersion, &appsv1.DaemonSet{})
+	scheme.AddKnownTypes(packageregistryv1alpha1.GroupVersion, &packageregistryv1alpha1.PackageRegistry{}, &packageregistryv1alpha1.PackageRegistryList{})
 	decoder := serializer.NewCodecFactory(scheme).UniversalDeserializer()
 
 	return &YAMLDecoder{decoder: decoder}
@@ -115,6 +118,10 @@ func (yd *YAMLDecoder) ToBuilders(reader *bufio.Reader, transform BuilderTransfo
 		case *logstashv1alpha1.Logstash:
 			b := logstash.NewBuilderWithoutSuffix(decodedObj.Name)
 			b.Logstash = *decodedObj
+			builder = transform(b)
+		case *packageregistryv1alpha1.PackageRegistry:
+			b := epr.NewBuilder(decodedObj.Name)
+			b.EPR = *decodedObj
 			builder = transform(b)
 		default:
 			return builders, fmt.Errorf("unexpected object type: %t", decodedObj)


### PR DESCRIPTION
More fixes for https://buildkite.com/elastic/cloud-on-k8s-operator/builds/12444

```
=== RUN   TestSamples
    samples_test.go:38: 
        	Error Trace:	/go/src/github.com/elastic/cloud-on-k8s/test/e2e/samples_test.go:129
        	            				/go/src/github.com/elastic/cloud-on-k8s/test/e2e/samples_test.go:38
        	Error:      	Received unexpected error:
        	            	failed to decode YAML: no kind "PackageRegistry" is registered for version "packageregistry.k8s.elastic.co/v1alpha1" in scheme "pkg/runtime/scheme.go:110"
        	Test:       	TestSamples
        	Messages:   	Failed to create builders
```