### PR TITLE
Add AutoOpsAgentPolicy to e2e test YAML decoder scheme

### DIFF
--- a/test/e2e/test/helper/yaml.go
+++ b/test/e2e/test/helper/yaml.go
@@ -361,6 +361,7 @@ func transformToE2E(namespace, fullTestName, suffix string, transformers []Build
 		case *autoopsv1alpha1.AutoOpsAgentPolicy:
 			// AutoOpsAgentPolicy requires external credentials and is tested separately
 			// in test/e2e/autoops/autoops_test.go. Skip in generic sample tests.
+			continue
 		case *corev1.ServiceAccount:
 			decodedObj.Namespace = namespace
 			decodedObj.Name = decodedObj.Name + "-" + suffix


### PR DESCRIPTION
### Problem

The `TestSamples` e2e test was failing with:

```
failed to decode YAML: no kind "AutoOpsAgentPolicy" is registered for version "autoops.k8s.elastic.co/v1alpha1" in scheme
```

This occurred because the YAML decoder in the test helper didn't have `AutoOpsAgentPolicy` registered in its scheme, causing it to fail when parsing `config/samples/autoops/autoops.yaml`.

### Solution

1. **Register `AutoOpsAgentPolicy` in the YAML decoder scheme** so the decoder can parse sample files containing this resource type

2. **Skip `AutoOpsAgentPolicy` when creating test builders** - The autoops sample requires external credentials (AutoOps API key, token, etc.) that cannot be provided in a generic sample test. Instead of failing or mixing test stub creation into the decoder, we skip this resource type with a clear comment.

AutoOps functionality is already properly tested in the dedicated `test/e2e/autoops/autoops_test.go` which sets up the required credentials.

### Changes

- `test/e2e/test/helper/yaml.go`:
  - Added `autoopsv1alpha1` import
  - Registered `AutoOpsAgentPolicy` and `AutoOpsAgentPolicyList` in the scheme
  - Added case to skip `AutoOpsAgentPolicy` in `ToBuilders()` and `transformToE2E()` with explanatory comments

- `test/e2e/samples_test.go`:
  - No changes needed (autoops case removed since builders are skipped at decoder level)

> **Note**: This issue  was generated with AI assistance (Claude Opus 4.5) 

