### PR TITLE
[3.3] Adjust kibana memory in e2e tests in 9.3.x temporarily

### DIFF
--- a/test/e2e/test/kibana/builder.go
+++ b/test/e2e/test/kibana/builder.go
@@ -91,7 +91,7 @@ func newBuilder(name, randSuffix string) Builder {
 	// move to cgroups v2 (https://github.com/kubernetes/kubernetes/issues/118916).
 	// Also bump memory for 9.3.x as we see a spike in memory usage. (https://github.com/elastic/kibana/pull/246033, https://github.com/elastic/kibana/pull/246073)
 	ver := version.MustParse(test.Ctx().ElasticStackVersion)
-	if (ver.GTE(version.MinFor(8, 0, 0)) && ver.LT(version.MinFor(8, 2, 0))) || (ver.GTE(version.MustParse("9.3.0-SNAPSHOT")) && ver.LT(version.MinFor(9, 4, 0))) {
+	if (ver.GTE(version.MinFor(8, 0, 0)) && ver.LT(version.MinFor(8, 2, 0))) || (ver.GTE(version.MinFor(9, 3, 0)) && ver.LT(version.MinFor(9, 4, 0))) {
 		b = b.WithResources(corev1.ResourceRequirements{
 			Requests: map[corev1.ResourceName]resource.Quantity{
 				corev1.ResourceMemory: resource.MustParse("1500Mi"),


### PR DESCRIPTION
This adjusts the memory in the Kibana e2e tests temporarily *in the 3.3 branch* while https://github.com/elastic/kibana/pull/246033 and https://github.com/elastic/kibana/pull/246073 are resolved.

*Note this is merging into the `3.3` branch*