### PR TITLE
Handle server side default for TrafficDistribution

### DIFF
--- a/pkg/controller/common/service_control.go
+++ b/pkg/controller/common/service_control.go
@@ -162,6 +162,11 @@ func applyServerSideValues(expected, reconciled *corev1.Service) {
 	if expected.Spec.AllocateLoadBalancerNodePorts == nil {
 		expected.Spec.AllocateLoadBalancerNodePorts = reconciled.Spec.AllocateLoadBalancerNodePorts
 	}
+
+	// TrafficDistribution may be defaulted by the API server starting K8s v1.31
+	if expected.Spec.TrafficDistribution == nil {
+		expected.Spec.TrafficDistribution = reconciled.Spec.TrafficDistribution
+	}
 }
 
 // hasNodePort returns for a given service type, if the service ports have a NodePort or not.

--- a/pkg/controller/common/service_control_test.go
+++ b/pkg/controller/common/service_control_test.go
@@ -668,6 +668,30 @@ func Test_applyServerSideValues(t *testing.T) {
 				ClusterIP: "1.2.3.4",
 			}},
 		},
+		{
+			name: "Reconciled TrafficDistribution is used if the expected one is nil",
+			args: args{
+				expected: corev1.Service{Spec: corev1.ServiceSpec{}},
+				reconciled: corev1.Service{Spec: corev1.ServiceSpec{
+					TrafficDistribution: ptr.To(corev1.ServiceTrafficDistributionPreferClose),
+				}},
+			},
+			want: corev1.Service{Spec: corev1.ServiceSpec{
+				TrafficDistribution: ptr.To(corev1.ServiceTrafficDistributionPreferClose),
+			}},
+		},
+		{
+			name: "Expected TrafficDistribution is used if not nil",
+			args: args{
+				expected: corev1.Service{Spec: corev1.ServiceSpec{
+					TrafficDistribution: ptr.To(corev1.ServiceTrafficDistributionPreferClose),
+				}},
+				reconciled: corev1.Service{Spec: corev1.ServiceSpec{}},
+			},
+			want: corev1.Service{Spec: corev1.ServiceSpec{
+				TrafficDistribution: ptr.To(corev1.ServiceTrafficDistributionPreferClose),
+			}},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This PR fixes a bug related to the `TrafficDistribution` field that was added to the Kubernetes Service spec (https://github.com/kubernetes/api/commit/0a84c1bf1aaab375496e22d6aafb2bd88c645f89).

If the API server defaults `TrafficDistribution` to `PreferClose` on `Service`s, this can cause issues since ECK doesn't currently preserve this server-side defaulted value in its reconciliation logic. If ECK removes it and the API server then adds it back, ECK could get into an infinite reconciliation loop.

I confirmed that manually patching the Service – ECK does remove the `trafficDistribution` field.

Fixes: https://github.com/elastic/cloud-on-k8s/issues/8812