### PR TITLE
[backport] Update go to 1.25.5 (#8970)

### DIFF
--- a/.buildkite/Makefile
+++ b/.buildkite/Makefile
@@ -4,7 +4,7 @@
 
 # This Makefile is used to run the buildkite agent in virtual machines when Docker access is required.
 
-CI_IMAGE               ?= docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
+CI_IMAGE               ?= docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4b247a94
 ROOT_DIR               := $(CURDIR)/..
 GO_MOUNT_PATH          ?= /go/src/github.com/elastic/cloud-on-k8s
 export VAULT_ROOT_PATH = secret/ci/elastic-cloud-on-k8s

--- a/.buildkite/e2e/pipeline-gen/pipeline.tpl.yaml
+++ b/.buildkite/e2e/pipeline-gen/pipeline.tpl.yaml
@@ -33,7 +33,7 @@ steps:
       machineType: "{{ $.K8sInDockerMachineType }}"
       {{- end }}
       {{- else }}
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4b247a94
       memory: "5G"
       {{- end }}
 
@@ -85,7 +85,7 @@ steps:
       diskSizeGb: 150
       {{- end }}
       {{- else }}
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4b247a94
       memory: "4G"
       {{- end }}
 
@@ -121,7 +121,7 @@ steps:
         {{- if not $test.Dind }}
           - make run-deployer
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4b247a94
           memory: "4G"
         {{- else }}
           - make -C .buildkite TARGET="run-deployer" ci
@@ -144,5 +144,5 @@ steps:
       - ".buildkite/e2e/reporter/*.md"
       - ".buildkite/e2e/reporter/*.yml"
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4b247a94
       memory: "2G"

--- a/.buildkite/e2e/reporter/templates/notify-failures.tpl.yml
+++ b/.buildkite/e2e/reporter/templates/notify-failures.tpl.yml
@@ -4,7 +4,7 @@ steps:
   - label: "{{ .ShortFailuresCount }} failure(s)"
     command: exit {{ .ShortFailuresCount }}
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4b247a94
       memory: "2G"
 
   # notify e2e tests failures for the main branch and tags
@@ -13,7 +13,7 @@ steps:
     if: build.branch == "main" || build.tag != null
     command: echo "notify"
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4b247a94
       memory: "2G"
 
     notify:

--- a/.buildkite/pipeline-e2e-clusters-cleanup.yml
+++ b/.buildkite/pipeline-e2e-clusters-cleanup.yml
@@ -10,7 +10,7 @@ steps:
       - make build-deployer
       - buildkite-agent artifact upload hack/deployer/deployer
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4b247a94
       memory: 2G
 
   - label: ":broom: e2e test cluster cleanup gke"
@@ -26,7 +26,7 @@ steps:
       - chmod u+x /usr/local/hack/deployer/deployer
       - /usr/local/hack/deployer/deployer cleanup --plans-file hack/deployer/config/plans.yml --cluster-prefix $${E2E_TEST_CLUSTER_PREFIX} --config-file deployer-config.yml
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4b247a94
       memory: 2G
 
   - label: ":broom: e2e test cluster cleanup aks"
@@ -55,7 +55,7 @@ steps:
       - chmod u+x /usr/local/hack/deployer/deployer
       - /usr/local/hack/deployer/deployer cleanup --plans-file hack/deployer/config/plans.yml --cluster-prefix $${E2E_TEST_CLUSTER_PREFIX} --config-file deployer-config.yml
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4b247a94
       memory: 2G
 
   - label: ":broom: e2e test cluster cleanup eks-arm"
@@ -71,7 +71,7 @@ steps:
       - chmod u+x /usr/local/hack/deployer/deployer
       - /usr/local/hack/deployer/deployer cleanup --plans-file hack/deployer/config/plans.yml --cluster-prefix $${E2E_TEST_CLUSTER_PREFIX} --config-file deployer-config.yml
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4b247a94
       memory: 2G
 
   - label: ":broom: e2e test cluster cleanup ocp"

--- a/.buildkite/pipeline-e2e-tests.yml
+++ b/.buildkite/pipeline-e2e-tests.yml
@@ -17,7 +17,7 @@ steps:
               E2E_PROVIDER: gke
           DEF
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4b247a94
           memory: "2G"
 
       # for nightly builds from main
@@ -30,7 +30,7 @@ steps:
           cd .buildkite/e2e/pipeline-gen && go build -o pipeline-gen
           cat ../nightly-main-matrix.yaml | ./pipeline-gen | buildkite-agent pipeline upload
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4b247a94
           memory: "2G"
 
       # for all tags
@@ -41,5 +41,5 @@ steps:
           cd .buildkite/e2e/pipeline-gen && go build -o pipeline-gen
           cat ../release-branch-matrix.yaml | ./pipeline-gen | buildkite-agent pipeline upload
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4b247a94
           memory: "2G"

--- a/.buildkite/pipeline-release-helm.yml
+++ b/.buildkite/pipeline-release-helm.yml
@@ -11,7 +11,7 @@ steps:
       - make build
       - buildkite-agent artifact upload bin/releaser
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4b247a94
       memory: "2G"
 
   - label: "operator dev helm chart"
@@ -30,7 +30,7 @@ steps:
       - chmod u+x /usr/local/bin/releaser
       - releaser --env=dev --charts-dir=deploy/eck-operator
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4b247a94
       memory: "2G"
 
   - label: "eck-stack dev helm charts"
@@ -49,7 +49,7 @@ steps:
       - chmod u+x /usr/local/bin/releaser
       - releaser --env=dev --charts-dir=deploy/eck-stack
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4b247a94
       memory: "2G"
 
   - label: "operator prod helm chart"
@@ -65,7 +65,7 @@ steps:
       - chmod u+x /usr/local/bin/releaser
       - releaser --env=prod --charts-dir=deploy/eck-operator
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4b247a94
       memory: "2G"
 
   - label: "eck-stack prod helm charts"
@@ -80,5 +80,5 @@ steps:
       - chmod u+x /usr/local/bin/releaser
       - releaser --env=prod --charts-dir=deploy/eck-stack
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4b247a94
       memory: "2G"

--- a/.buildkite/pipeline-release-redhat.yml
+++ b/.buildkite/pipeline-release-redhat.yml
@@ -7,7 +7,7 @@ steps:
       - make build
       - buildkite-agent artifact upload bin/operatorhub
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4b247a94
       memory: "4G"
 
   - label: ":docker: push container"
@@ -20,7 +20,7 @@ steps:
         cd hack/operatorhub
         operatorhub container push
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4b247a94
       memory: "4G"
 
   - label: ":docker: preflight container check"
@@ -32,7 +32,7 @@ steps:
     commands:
       - .buildkite/scripts/release/redhat-preflight.sh
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4b247a94
       memory: "4G"
 
   - label: ":docker: publish container"
@@ -47,7 +47,7 @@ steps:
         cd hack/operatorhub
         operatorhub container publish
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4b247a94
       memory: "4G"
 
   - label: ":redhat: generate and create-pr"
@@ -62,5 +62,5 @@ steps:
         operatorhub generate-manifests
         operatorhub bundle create-pr
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4b247a94
       memory: "4G"

--- a/.buildkite/pipeline-release.yml
+++ b/.buildkite/pipeline-release.yml
@@ -10,7 +10,7 @@ steps:
         commands:
           - .buildkite/scripts/release/k8s-manifests.sh
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4b247a94
           memory: "2G"
 
       - label: "copy images to dockerhub"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,14 +9,14 @@ steps:
       - label: ":go: lint"
         command: "make lint check-local-changes"
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4b247a94
           cpu: "6"
           memory: "7G"
 
       - label: ":go: generate"
         command: "make generate check-local-changes"
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4b247a94
           cpu: "4"
           memory: "4G"
 
@@ -25,7 +25,7 @@ steps:
           - "make check-license-header check-predicates shellcheck reattach-pv"
           - "make -C hack/helm/release build"
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4b247a94
           cpu: "4"
           memory: "4G"
 
@@ -35,28 +35,28 @@ steps:
       - label: ":go: unit-tests"
         command: "make unit-xml"
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4b247a94
           cpu: "4"
           memory: "4G"
 
       - label: ":go: integration-tests"
         command: "make integration-xml"
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4b247a94
           cpu: "4"
           memory: "4G"
 
       - label: ":go: manifest-gen-tests"
         command: "make manifest-gen-test"
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4b247a94
           cpu: "4"
           memory: "2G"
 
       - label: ":go: helm-tests"
         command: "make helm-test"
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4b247a94
           cpu: "4"
           memory: "2G"
 
@@ -112,7 +112,7 @@ steps:
           E2E_SKIP_CLEANUP: true
       DEF
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4b247a94
       memory: "2G"
 
   # for PR comment
@@ -125,14 +125,14 @@ steps:
       $$(echo ./pipeline-gen $$GITHUB_PR_COMMENT_VAR_ARGS) \
         | buildkite-agent pipeline upload
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4b247a94
       memory: "2G"
 
   # for the main branch (merge and nightly) and tags
   - label: ":buildkite:"
     command: buildkite-agent pipeline upload .buildkite/pipeline-e2e-tests.yml
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4b247a94
       memory: "2G"
 
   # ----------
@@ -165,7 +165,7 @@ steps:
         done
       ) | buildkite-agent pipeline upload
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4b247a94
       memory: "256Mi"
 
   - label: ":buildkite:"
@@ -173,5 +173,5 @@ steps:
       - "operator-image-build"
     command: buildkite-agent pipeline upload .buildkite/pipeline-release.yml
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:6154e14d
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:4b247a94
       memory: "2G"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,113 +1,129 @@
-run:
-  timeout: 420s
-
-linters-settings:
-  exhaustive:
-    default-signifies-exhaustive: true
-
-  goheader:
-    template: |-
-      Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-      or more contributor license agreements. Licensed under the Elastic License 2.0;
-      you may not use this file except in compliance with the Elastic License 2.0.
-
-  goimports:
-    # put imports beginning with prefix after 3rd-party packages;
-    local-prefixes: github.com/elastic/cloud-on-k8s
-
-  gosec:
-    excludes:
-      - G115 # potential integer overflow when converting between integer types
-
-  nolintlint:
-    allow-leading-space: false
-    allow-unused: false
-    require-specific: true
-
-  predeclared:
-    # comma-separated list of predeclared identifiers to not report on.
-    ignore: "min,max"
-
-  revive:
-    ## Default rules from https://github.com/mgechev/revive/blob/75a8e403f52c9634546fbfe5ec5429560ca74494/defaults.toml
-    enable-all-rules: false
-    rules:
-      - name: blank-imports
-        disabled: false
-      - name: context-as-argument
-        disabled: false
-      - name: context-keys-type
-        disabled: false
-      - name: dot-imports
-        disabled: false
-      - name: empty-block
-        disabled: false
-      - name: error-naming
-        disabled: false
-      - name: error-return
-        disabled: false
-      - name: error-strings
-        disabled: false
-      - name: errorf
-        disabled: false
-      - name: exported
-        disabled: false
-      - name: increment-decrement
-        disabled: false
-      - name: indent-error-flow
-        disabled: false
-      - name: package-comments
-        disabled: false
-      - name: range
-        disabled: false
-      - name: receiver-naming
-        disabled: false
-      - name: redefines-builtin-id
-        disabled: false
-      - name: superfluous-else
-        disabled: false
-      - name: time-naming
-        disabled: false
-      - name: unexported-return
-        disabled: false
-      - name: unreachable-code
-        disabled: false
-      - name: unused-parameter
-        ## Disabled as it generates a lot of rule failures.
-        disabled: true
-      - name: var-declaration
-        disabled: false
-      - name: var-naming
-        disabled: false
-
-# Run `golangci-lint linters` to see the descriptions for the linters. 
+version: "2"
 linters:
-  disable:
-    - cyclop
-    - depguard
-    - dupl
-    - err113
-    - forbidigo
-    - funlen
-    - gci
-    - gochecknoinits
-    - gocognit
-    - goconst
-    - gocyclo
-    - godot
-    - godox
-    - gofmt
-    - gofumpt
-    - gomnd
-    - gomodguard
-    - nlreturn
-    - paralleltest
-    - rowserrcheck
-    - sqlclosecheck
-    - stylecheck
-    - testpackage
-    - wrapcheck
-    - wsl
+  settings:
+    exhaustive:
+      default-signifies-exhaustive: true
+
+    goheader:
+      template: |-
+        Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+        or more contributor license agreements. Licensed under the Elastic License 2.0;
+        you may not use this file except in compliance with the Elastic License 2.0.
+
+    gosec:
+      excludes:
+        - G115
+
+    nolintlint:
+      require-specific: true
+      allow-unused: false
+
+    predeclared:
+      ignore:
+        - min
+        - max
+
+    revive:
+      enable-all-rules: false
+      rules:
+        - name: blank-imports
+          disabled: false
+        - name: context-as-argument
+          disabled: false
+        - name: context-keys-type
+          disabled: false
+        - name: dot-imports
+          disabled: false
+        - name: empty-block
+          disabled: false
+        - name: error-naming
+          disabled: false
+        - name: error-return
+          disabled: false
+        - name: error-strings
+          disabled: false
+        - name: errorf
+          disabled: false
+        - name: exported
+          disabled: false
+        - name: increment-decrement
+          disabled: false
+        - name: indent-error-flow
+          disabled: false
+        - name: package-comments
+          disabled: false
+        - name: range
+          disabled: false
+        - name: receiver-naming
+          disabled: false
+        - name: redefines-builtin-id
+          disabled: false
+        - name: superfluous-else
+          disabled: false
+        - name: time-naming
+          disabled: false
+        - name: unexported-return
+          disabled: false
+        - name: unreachable-code
+          disabled: false
+        - name: unused-parameter
+          disabled: true
+        - name: var-declaration
+          disabled: false
+        - name: var-naming
+          disabled: false
+
+    # https://golangci-lint.run/docs/linters/configuration/#staticcheck
+    staticcheck:
+      checks:
+        # SAxxxx checks in https://staticcheck.dev/docs/configuration/options/#checks
+        # Default: ["all", "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022"]
+        - 'all'
+        - '-ST1000'
+        - '-ST1003'
+        - '-ST1016'
+        - '-ST1020'
+        - '-ST1021'
+        - '-ST1022'
+        # disabled while migrating cloud-on-k8s to v2 to avoid a lot of auto-fixes
+        - '-QF1008'
+        - '-QF1001'
+
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - gosec
+          - unparam
+        path: .*_test\.go
+      - linters:
+          - staticcheck
+        path: pkg/controller/common/tracing/apmclientgo/client.go
+        text: SA1019
+      - linters:
+          - staticcheck
+        # added exclusion until https://github.com/elastic/cloud-on-k8s/issues/8442 is implemented
+        text: 'SA1019: .* is deprecated: Consider CustomValidator instead, this only restores the old ctrl-runtime interface for bwc.'
+      - linters:
+          - staticcheck
+        # added exclusion until ElasticsearchAutoscalingSpecAnnotationName is completely removed
+        text: 'SA1019: .* is deprecated: the autoscaling annotation has been deprecated in favor of the ElasticsearchAutoscaler custom resource.'
+      - linters:
+          - revive
+        # revive naming rules are not that happy with our packages/var names in commont/utils packages
+        path: '.*/(common|utils)/.*.go'
+        text: 'var-naming: avoid (package names that conflict with Go standard library package names|meaningless package names)'
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+
+  default: none
 
   enable:
     - asciicheck
@@ -120,10 +136,8 @@ linters:
     - forcetypeassert
     - gocritic
     - goheader
-    - goimports
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - importas
     - ineffassign
@@ -140,7 +154,6 @@ linters:
     - staticcheck
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
     - unused
@@ -148,18 +161,20 @@ linters:
     - whitespace
 
 issues:
+  max-issues-per-linter: 25
+  max-same-issues: 0
   fix: true
 
-  max-issues-per-linter: 25
-
-  max-same-issues: 0
-
-  exclude-rules:
-    - path: .*_test\.go
-      linters:
-        - unparam
-        - gosec
-    - path: pkg/controller/common/tracing/apmclientgo/client.go
-      linters:
-        - staticcheck
-      text: SA1019
+formatters:
+  enable:
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/elastic/cloud-on-k8s
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/config/crds/v1/all-crds.yaml
+++ b/config/crds/v1/all-crds.yaml
@@ -11801,6 +11801,7 @@ spec:
                   type: object
                 description: |-
                   ResourcesStatuses holds the status for each resource to be configured.
+
                   Deprecated: Details is used to store the status of resources from ECK 2.11
                 type: object
             type: object

--- a/config/crds/v1/resources/stackconfigpolicy.k8s.elastic.co_stackconfigpolicies.yaml
+++ b/config/crds/v1/resources/stackconfigpolicy.k8s.elastic.co_stackconfigpolicies.yaml
@@ -386,6 +386,7 @@ spec:
                   type: object
                 description: |-
                   ResourcesStatuses holds the status for each resource to be configured.
+
                   Deprecated: Details is used to store the status of resources from ECK 2.11
                 type: object
             type: object

--- a/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
+++ b/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
@@ -11885,6 +11885,7 @@ spec:
                   type: object
                 description: |-
                   ResourcesStatuses holds the status for each resource to be configured.
+
                   Deprecated: Details is used to store the status of resources from ECK 2.11
                 type: object
             type: object

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/elastic/cloud-on-k8s/v3
 
-go 1.24.5
+go 1.25.0
+
+toolchain go1.25.5
 
 require (
 	dario.cat/mergo v1.0.2

--- a/hack/config-extractor/go.mod
+++ b/hack/config-extractor/go.mod
@@ -1,6 +1,8 @@
 module github.com/elastic/cloud-on-k8s/v3/hack/config-extractor
 
-go 1.24.5
+go 1.25.0
+
+toolchain go1.25.5
 
 require (
 	k8s.io/api v0.34.3

--- a/hack/deployer/exec/cmd.go
+++ b/hack/deployer/exec/cmd.go
@@ -140,7 +140,7 @@ func (c *Command) output() (string, error) {
 	if c.context != nil {
 		cmd = exec.CommandContext(c.context, "/usr/bin/env", "bash", "-c", c.command) // #nosec G204
 	} else {
-		cmd = exec.Command("/usr/bin/env", "bash", "-c", c.command) // #nosec G204
+		cmd = exec.Command("/usr/bin/env", "bash", "-c", c.command) //nolint:gosec,noctx
 	}
 
 	// support .env or similar files to specify environment variables

--- a/hack/helm/release/go.mod
+++ b/hack/helm/release/go.mod
@@ -1,6 +1,8 @@
 module github.com/elastic/cloud-on-k8s/hack/helm/release
 
-go 1.24.5
+go 1.25.0
+
+toolchain go1.25.5
 
 require (
 	cloud.google.com/go/storage v1.58.0

--- a/hack/operatorhub/go.mod
+++ b/hack/operatorhub/go.mod
@@ -1,6 +1,8 @@
 module github.com/elastic/cloud-on-k8s/v3/hack/operatorhub
 
-go 1.24.5
+go 1.25.0
+
+toolchain go1.25.5
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0

--- a/hack/upgrade-test-harness/go.mod
+++ b/hack/upgrade-test-harness/go.mod
@@ -1,6 +1,8 @@
 module github.com/elastic/cloud-on-k8s/v3/hack/upgrade-test-harness
 
-go 1.24.5
+go 1.25.0
+
+toolchain go1.25.5
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/pkg/apis/elasticsearch/v1/elasticsearch_types.go
+++ b/pkg/apis/elasticsearch/v1/elasticsearch_types.go
@@ -37,6 +37,7 @@ const (
 	// for debugging purposes.
 	SuspendAnnotation = "eck.k8s.elastic.co/suspend"
 	// ElasticsearchAutoscalingSpecAnnotationName is the name of the annotation used to store the autoscaling specification.
+	//
 	// Deprecated: the autoscaling annotation has been deprecated in favor of the ElasticsearchAutoscaler custom resource.
 	ElasticsearchAutoscalingSpecAnnotationName = "elasticsearch.alpha.elastic.co/autoscaling-spec"
 
@@ -485,6 +486,7 @@ func (es *Elasticsearch) ElasticServiceAccount() (commonv1.ServiceAccountName, e
 }
 
 // IsAutoscalingAnnotationSet returns true if there is an autoscaling configuration in the annotations.
+//
 // Deprecated: the autoscaling annotation has been deprecated in favor of the ElasticsearchAutoscaler custom resource.
 func (es Elasticsearch) IsAutoscalingAnnotationSet() bool {
 	_, ok := es.Annotations[ElasticsearchAutoscalingSpecAnnotationName]

--- a/pkg/apis/stackconfigpolicy/v1alpha1/stackconfigpolicy_types.go
+++ b/pkg/apis/stackconfigpolicy/v1alpha1/stackconfigpolicy_types.go
@@ -181,6 +181,7 @@ type IndexTemplates struct {
 
 type StackConfigPolicyStatus struct {
 	// ResourcesStatuses holds the status for each resource to be configured.
+	//
 	// Deprecated: Details is used to store the status of resources from ECK 2.11
 	ResourcesStatuses map[string]ResourcePolicyStatus `json:"resourcesStatuses,omitempty"`
 	// Details holds the status details for each resource to be configured.
@@ -341,9 +342,11 @@ func (s *StackConfigPolicyStatus) Update() {
 			// Resource status can be for Kibana or Elasticsearch resources
 			resourcePhase := status.Phase
 
-			if resourcePhase == ReadyPhase {
+			//nolint:exhaustive
+			switch resourcePhase {
+			case ReadyPhase:
 				s.Ready++
-			} else if resourcePhase == ErrorPhase {
+			case ErrorPhase:
 				s.Errors++
 			}
 			// update phase if that of the resource status is worse

--- a/pkg/controller/autoscaling/elasticsearch/status/events.go
+++ b/pkg/controller/autoscaling/elasticsearch/status/events.go
@@ -23,8 +23,7 @@ func EmitEvents(elasticsearch esv1.Elasticsearch, recorder record.EventRecorder,
 
 func emitEventForAutoscalingPolicy(elasticsearch esv1.Elasticsearch, recorder record.EventRecorder, status v1alpha1.AutoscalingPolicyStatus) {
 	for _, event := range status.PolicyStates {
-		//nolint:exhaustive
-		switch event.Type {
+		switch event.Type { //nolint:exhaustive
 		case v1alpha1.VerticalScalingLimitReached, v1alpha1.HorizontalScalingLimitReached, v1alpha1.MemoryRequired, v1alpha1.StorageRequired, v1alpha1.UnexpectedNodeStorageCapacity:
 			recorder.Event(&elasticsearch, corev1.EventTypeWarning, string(event.Type), strings.Join(event.Messages, ". "))
 		}

--- a/pkg/controller/common/volume/pvc_expansion_test.go
+++ b/pkg/controller/common/volume/pvc_expansion_test.go
@@ -16,7 +16,6 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/scheme"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -481,7 +480,7 @@ func Test_recreateStatefulSets(t *testing.T) {
 		label.StatefulSetNameLabelName: sset1.Name,
 	}}}
 	pod1WithOwnerRef := pod1.DeepCopy()
-	require.NoError(t, controllerutil.SetOwnerReference(es(), pod1WithOwnerRef, scheme.Scheme))
+	require.NoError(t, controllerutil.SetOwnerReference(es(), pod1WithOwnerRef, clientgoscheme.Scheme))
 
 	sset2 := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "sset2", UID: "sset2-uid"}}
 	sset2Bytes, _ := json.Marshal(sset2)
@@ -619,10 +618,10 @@ var (
 
 func init() {
 	controllerscheme.SetupScheme()
-	if err := controllerutil.SetOwnerReference(&sampleEs, &pod1WithOwnerRef, scheme.Scheme); err != nil {
+	if err := controllerutil.SetOwnerReference(&sampleEs, &pod1WithOwnerRef, clientgoscheme.Scheme); err != nil {
 		panic(err)
 	}
-	if err := controllerutil.SetOwnerReference(&sampleEs, &pod2WithOwnerRef, scheme.Scheme); err != nil {
+	if err := controllerutil.SetOwnerReference(&sampleEs, &pod2WithOwnerRef, clientgoscheme.Scheme); err != nil {
 		panic(err)
 	}
 }

--- a/pkg/controller/common/webhook/admission/validator.go
+++ b/pkg/controller/common/webhook/admission/validator.go
@@ -14,6 +14,7 @@ type Warnings []string
 // Validator defines functions for validating an operation.
 // The custom resource kind which implements this interface can validate itself.
 // To validate the custom resource with another specific struct, use CustomValidator instead.
+//
 // Deprecated: Consider CustomValidator instead, this only restores the old ctrl-runtime interface for bwc.
 type Validator interface {
 	runtime.Object

--- a/pkg/controller/kibana/stackmon/sidecar.go
+++ b/pkg/controller/kibana/stackmon/sidecar.go
@@ -39,7 +39,7 @@ const (
 func Metricbeat(ctx context.Context, client k8s.Client, kb kbv1.Kibana, basePath string, meta metadata.Metadata) (stackmon.BeatSidecar, error) {
 	if !kb.Spec.ElasticsearchRef.IsDefined() {
 		// should never happen because of the pre-creation validation
-		return stackmon.BeatSidecar{}, errors.New(validations.InvalidKibanaElasticsearchRefForStackMonitoringMsg)
+		return stackmon.BeatSidecar{}, errors.New(validations.InvalidKibanaElasticsearchRefForStackMonitoringMsg) //nolint:staticcheck
 	}
 	associatedEsNsn := kb.Spec.ElasticsearchRef.NamespacedName()
 	if associatedEsNsn.Namespace == "" {

--- a/pkg/controller/logstash/driver.go
+++ b/pkg/controller/logstash/driver.go
@@ -9,8 +9,6 @@ import (
 	"fmt"
 	"hash/fnv"
 
-	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/metadata"
-
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -22,6 +20,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/events"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/expectations"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/keystore"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/metadata"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/operator"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/statefulset"
@@ -32,7 +31,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/logstash/stackmon"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/logstash/volume"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
-	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/log"
 	ulog "github.com/elastic/cloud-on-k8s/v3/pkg/utils/log"
 )
 
@@ -80,7 +78,7 @@ func (p *Params) GetPodTemplate() corev1.PodTemplateSpec {
 
 // Logger returns the configured logger for use during reconciliation.
 func (p *Params) Logger() logr.Logger {
-	return log.FromContext(p.Context)
+	return ulog.FromContext(p.Context)
 }
 
 func newStatus(logstash logstashv1alpha1.Logstash) logstashv1alpha1.LogstashStatus {

--- a/pkg/controller/remotecluster/watches.go
+++ b/pkg/controller/remotecluster/watches.go
@@ -8,12 +8,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/remotecluster/keystore"
-
-	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/label"
-
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -26,6 +21,8 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/watches"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/certificates/remoteca"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/certificates/transport"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/label"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/remotecluster/keystore"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/maps"
 )
 
@@ -59,14 +56,14 @@ func addWatches(mgr manager.Manager, c controller.Controller, r *ReconcileRemote
 	//  * Remote certificate authorities managed by this controller.
 	//  * API keys
 	if err := c.Watch(
-		source.Kind(mgr.GetCache(), &v1.Secret{},
-			handler.TypedEnqueueRequestsFromMapFunc[*v1.Secret, reconcile.Request](newRequestsFromMatchedLabels()),
+		source.Kind(mgr.GetCache(), &corev1.Secret{},
+			handler.TypedEnqueueRequestsFromMapFunc[*corev1.Secret, reconcile.Request](newRequestsFromMatchedLabels()),
 		)); err != nil {
 		return err
 	}
 
 	// Dynamically watches the certificate authorities involved in a cluster relationship
-	if err := c.Watch(source.Kind(mgr.GetCache(), &v1.Secret{}, r.watches.Secrets)); err != nil {
+	if err := c.Watch(source.Kind(mgr.GetCache(), &corev1.Secret{}, r.watches.Secrets)); err != nil {
 		return err
 	}
 
@@ -82,8 +79,8 @@ func addWatches(mgr manager.Manager, c controller.Controller, r *ReconcileRemote
 
 // newRequestsFromMatchedLabels creates a watch handler function that creates reconcile requests based on the
 // labels set on a Secret which contains the remote CA.
-func newRequestsFromMatchedLabels() handler.TypedMapFunc[*v1.Secret, reconcile.Request] {
-	return func(ctx context.Context, obj *v1.Secret) []reconcile.Request {
+func newRequestsFromMatchedLabels() handler.TypedMapFunc[*corev1.Secret, reconcile.Request] {
+	return func(ctx context.Context, obj *corev1.Secret) []reconcile.Request {
 		labels := obj.GetLabels()
 		if maps.ContainsKeys(labels, RemoteClusterNameLabelName, RemoteClusterNamespaceLabelName, commonv1.TypeLabelName) {
 			// Remote cluster CA

--- a/pkg/controller/stackconfigpolicy/controller_test.go
+++ b/pkg/controller/stackconfigpolicy/controller_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/watches"
 	esclient "github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/client"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/filesettings"
-	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/label"
 	eslabel "github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/net"
@@ -102,7 +101,7 @@ func getEsPod(namespace string, annotations map[string]string) *corev1.Pod {
 			Name:      "test-es-default-0",
 			Namespace: namespace,
 			Labels: map[string]string{
-				label.ClusterNameLabelName: "test-es",
+				eslabel.ClusterNameLabelName: "test-es",
 			},
 			Annotations: annotations,
 		},

--- a/pkg/utils/net/port.go
+++ b/pkg/utils/net/port.go
@@ -10,7 +10,7 @@ import (
 
 // GetRandomPort returns a random port chosen by the OS by binding to :0 and checking what port was bound.
 func GetRandomPort() (string, error) {
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0") //nolint:noctx
 	if err != nil {
 		return "", err
 	}

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -1,5 +1,5 @@
 # Docker image for the E2E tests runner
-FROM docker.io/library/golang:1.24.5
+FROM docker.io/library/golang:1.25.5
 
 ARG GO_TAGS
 ARG ARCH

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -332,10 +332,7 @@ func (h *helper) createRoles() error {
 func (h *helper) installOperatorUnderTest() error {
 	log.Info("Installing the operator under test")
 
-	installCRDs := false
-	if h.monitoringSecrets == "" {
-		installCRDs = true
-	}
+	installCRDs := h.monitoringSecrets == ""
 
 	manifestFile := filepath.Join(h.scratchDir, "operator-under-test.yaml")
 
@@ -488,7 +485,7 @@ func (h *helper) runTestsLocally() error {
 	log.Info("Running local test script", "timeout", h.testTimeout.String())
 	ctx, cancelFunc := context.WithTimeout(context.Background(), h.testTimeout)
 
-	cmd := exec.Command("test/e2e/run.sh", "-run", os.Getenv("TESTS_MATCH"), "-args", "-testContextPath", h.testContextOutPath) //nolint:gosec
+	cmd := exec.Command("test/e2e/run.sh", "-run", os.Getenv("TESTS_MATCH"), "-args", "-testContextPath", h.testContextOutPath) //nolint:gosec,noctx
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 	// we need to set a process group ID to be able to terminate all child processes and not just the test.sh script later if the timeout is exceeded
@@ -834,7 +831,7 @@ func (h *helper) runECKDiagnostics() {
 	operatorNS := h.testContext.Operator.Namespace
 	// include the default namespace to have diagnostics on the local disk provisioner used in some environments
 	otherNS := append([]string{h.testContext.E2ENamespace, "default"}, h.testContext.Operator.ManagedNamespaces...)
-	cmd := exec.Command("eck-diagnostics", "-o", operatorNS, "-r", strings.Join(otherNS, ","), "--run-agent-diagnostics")
+	cmd := exec.Command("eck-diagnostics", "-o", operatorNS, "-r", strings.Join(otherNS, ","), "--run-agent-diagnostics") //nolint:noctx
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {

--- a/test/e2e/test/apmserver/http_client.go
+++ b/test/e2e/test/apmserver/http_client.go
@@ -193,7 +193,8 @@ func (c *ApmClient) IntakeV2Events(ctx context.Context, rum bool, payload []byte
 	if rum {
 		path = rumIntakePath
 	}
-	request, err := http.NewRequest(
+	request, err := http.NewRequestWithContext(
+		ctx,
 		http.MethodPost,
 		stringsutil.Concat(c.endpoint, path),
 		bytes.NewBuffer(payload),

--- a/test/e2e/test/elasticsearch/checks_es.go
+++ b/test/e2e/test/elasticsearch/checks_es.go
@@ -359,7 +359,7 @@ func canCompareCgroupLimits(nodeStats client.NodeStats, nodeVersion string) (boo
 		return false, nil
 	}
 	// nok: cgroup is nil but we are on a version that should correctly be able to parse the cgroup data
-	return false, fmt.Errorf("Unexpected: no cgroup information in node stats response")
+	return false, fmt.Errorf("unexpected: no cgroup information in node stats response")
 }
 
 // compareCgroupMemoryLimit compares the memory limit specified in a nodeSet with the limit set in the memory control group at the OS level

--- a/test/e2e/test/elasticsearch/checks_transport.go
+++ b/test/e2e/test/elasticsearch/checks_transport.go
@@ -34,7 +34,7 @@ func CheckTransportCACertificate(es esv1.Elasticsearch, ca *x509.Certificate) er
 	if test.Ctx().AutoPortForwarding {
 		conn, err = portforward.NewForwardingDialer().DialContext(context.Background(), "tcp", host)
 	} else {
-		conn, err = net.Dial("tcp", host)
+		conn, err = net.Dial("tcp", host) //nolint:noctx
 	}
 	if err != nil {
 		return err
@@ -64,7 +64,7 @@ func CheckTransportCACertificate(es esv1.Elasticsearch, ca *x509.Certificate) er
 	client := tls.Client(conn, &config)
 	// handshake can fail if the test client is not presenting the right certificates
 	// but we are only interested in the peer certificates
-	err = client.Handshake()
+	err = client.Handshake() //nolint:noctx
 	if correctCertsPresented {
 		return nil
 	}

--- a/test/e2e/test/enterprisesearch/http_client.go
+++ b/test/e2e/test/enterprisesearch/http_client.go
@@ -127,7 +127,7 @@ type CredentialsCollection struct {
 func (a AppSearchClient) GetAPIKey() (string, error) {
 	url := a.endpoint + "/as/credentials/collection"
 
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil) //nolint:noctx
 	if err != nil {
 		return "", err
 	}
@@ -172,7 +172,7 @@ func (a AppSearchClient) CreateEngine(name string) error {
 	url := a.endpoint + "/api/as/v1/engines"
 	body := []byte(fmt.Sprintf(`{"name": "%s"}`, name))
 
-	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(body))
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(body)) //nolint:noctx
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
* ci: update go to 1.25.5

* ci: update buildkite-agent

* ci: migrate to golangci v2

* fix: adjust //nolint comments

* fix: separate Deprecated note to a different paragraph

* fix: pass ctx to http request

* fix: remove duplicate imports

* fix: simplify bool assignment

* fix: start error with lowercase

* ci: set go 1.25.0 and toolchain at go1.25.5

(cherry picked from commit a587c4438f92f42b46c80387e239488bc862298e)
