### PR TITLE
[3.3] [EPR] "lite" variant of image does not exist prior to 8.15.1 (#8995)

### DIFF
--- a/pkg/controller/common/container/container.go
+++ b/pkg/controller/common/container/container.go
@@ -135,6 +135,10 @@ func getUBISuffix(ver version.Version) string {
 // images, UBI suffix goes in the tag (lite-X.Y.Z-ubi) and not at the end of the image name.
 func getPackageRegistryImage(useUBI bool, suffix string, v version.Version) string {
 	if !useUBI {
+		// Before 8.15.1, the package registry image didn't have the 'lite' variant thus fallback always to 8.15.1, this is backwards compatible.
+		if v.LT(version.From(8, 15, 1)) {
+			return fmt.Sprintf("%s/%s%s:lite-8.15.1", containerRegistry, PackageRegistryImage, suffix)
+		}
 		return fmt.Sprintf("%s/%s%s:lite-%s", containerRegistry, PackageRegistryImage, suffix, v)
 	}
 

--- a/pkg/controller/common/container/container_test.go
+++ b/pkg/controller/common/container/container_test.go
@@ -177,10 +177,16 @@ func TestImageRepository(t *testing.T) {
 			want:    testRegistry + "/elastic-maps-service/elastic-maps-server-ubi:8.16.0",
 		},
 		{
-			name:    "Package registry image",
+			name:    "Package registry image prior to 8.15.1 uses lite-8.15.1 as fallback",
 			image:   PackageRegistryImage,
-			version: "1.0.0",
-			want:    testRegistry + "/package-registry/distribution:lite-1.0.0",
+			version: "8.15.0",
+			want:    testRegistry + "/package-registry/distribution:lite-8.15.1",
+		},
+		{
+			name:    "Package registry image from 8.15.1 onwards uses lite prefix",
+			image:   PackageRegistryImage,
+			version: "8.16.0",
+			want:    testRegistry + "/package-registry/distribution:lite-8.16.0",
 		},
 		{
 			name:    "Package registry image -ubi suffix",
@@ -194,7 +200,7 @@ func TestImageRepository(t *testing.T) {
 			image:   PackageRegistryImage,
 			version: "1.0.0",
 			suffix:  "-random",
-			want:    testRegistry + "/package-registry/distribution-random:lite-1.0.0",
+			want:    testRegistry + "/package-registry/distribution-random:lite-8.15.1",
 		},
 	}
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.3`:
 - [[EPR] &quot;lite&quot; variant of image does not exist prior to 8.15.1 (#8995)](https://github.com/elastic/cloud-on-k8s/pull/8995)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)