### PR TITLE
[3.3] Add missing PV/PVC RBAC permissions to fleet+k8s integration recipe (#8999)

### DIFF
--- a/config/recipes/elastic-agent/fleet-kubernetes-integration-nonroot.yaml
+++ b/config/recipes/elastic-agent/fleet-kubernetes-integration-nonroot.yaml
@@ -243,6 +243,8 @@ rules:
   - events
   - services
   - configmaps
+  - persistentvolumes
+  - persistentvolumeclaims
   verbs:
   - get
   - watch

--- a/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
@@ -185,6 +185,8 @@ rules:
   - events
   - services
   - configmaps
+  - persistentvolumes
+  - persistentvolumeclaims
   verbs:
   - get
   - watch

--- a/config/recipes/elastic-agent/kubernetes-integration.yaml
+++ b/config/recipes/elastic-agent/kubernetes-integration.yaml
@@ -137,6 +137,8 @@ rules:
   - nodes/proxy
   - nodes/stats
   - events
+  - persistentvolumes
+  - persistentvolumeclaims
   verbs:
   - get
   - watch


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.3`:
 - [Add missing PV/PVC RBAC permissions to fleet+k8s integration recipe (#8999)](https://github.com/elastic/cloud-on-k8s/pull/8999)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)