### PR TITLE
[docs] applies_to syntax refactoring

### DIFF
--- a/docs/reference/api-reference/3_0_0.md
+++ b/docs/reference/api-reference/3_0_0.md
@@ -1,14 +1,14 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-api-reference.html
-navigation_title: 3.0.0
+navigation_title: 3.0
 applies_to:
   deployment:
-    eck: ga 3.0.0
+    eck: ga =3.0
 ---
 % Generated documentation. Please do not edit.
 
-# {{eck}} API Reference for 3.0.0 [k8s-api-reference-3.0.0]
+# {{eck}} API Reference for 3.0 [k8s-api-reference-3.0.0]
 
 ## Packages
 * [agent.k8s.elastic.co/v1alpha1](#agentk8selasticcov1alpha1)

--- a/docs/reference/api-reference/3_1_0.md
+++ b/docs/reference/api-reference/3_1_0.md
@@ -1,14 +1,14 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-api-reference.html
-navigation_title: 3.1.0
+navigation_title: 3.1
 applies_to:
   deployment:
-    eck: ga 3.1.0
+    eck: ga =3.1
 ---
 % Generated documentation. Please do not edit.
 
-# {{eck}} API Reference for 3.1.0 [k8s-api-reference-3.1.0]
+# {{eck}} API Reference for 3.1 [k8s-api-reference-3.1.0]
 
 ## Packages
 * [agent.k8s.elastic.co/v1alpha1](#agentk8selasticcov1alpha1)

--- a/docs/reference/api-reference/3_2_0.md
+++ b/docs/reference/api-reference/3_2_0.md
@@ -1,14 +1,14 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-api-reference.html
-navigation_title: 3.2.0
+navigation_title: 3.2
 applies_to:
   deployment:
-    eck: ga 3.2.0
+    eck: ga =3.2
 ---
 % Generated documentation. Please do not edit.
 
-# {{eck}} API Reference for 3.2.0 [k8s-api-reference-3.2.0]
+# {{eck}} API Reference for 3.2 [k8s-api-reference-3.2.0]
 
 ## Packages
 * [agent.k8s.elastic.co/v1alpha1](#agentk8selasticcov1alpha1)

--- a/docs/reference/third-party-dependencies/3_0_0.md
+++ b/docs/reference/third-party-dependencies/3_0_0.md
@@ -1,16 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-dependencies.html
-navigation_title: 3.0.0
+navigation_title: 3.0
 applies_to:
   deployment:
-    eck: ga 3.0.0
+    eck: ga =3.0
 ---
 % Generated documentation. Please do not edit.
 
-# Third-party dependencies for Elastic Cloud on Kubernetes[k8s-dependencies]
+# Third-party dependencies for Elastic Cloud on Kubernetes 3.0 [k8s-dependencies]
 
-This page lists the third-party dependencies used to build {{eck}} 3.0.0.
+This page lists the third-party dependencies used to build {{eck}} 3.0.
 
 ## Direct dependencies [k8s-dependencies-direct]
 

--- a/docs/reference/third-party-dependencies/3_1_0.md
+++ b/docs/reference/third-party-dependencies/3_1_0.md
@@ -1,16 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-dependencies.html
-navigation_title: 3.1.0
+navigation_title: 3.1
 applies_to:
   deployment:
-    eck: ga 3.1.0
+    eck: ga =3.1
 ---
 % Generated documentation. Please do not edit.
 
-# Third-party dependencies for Elastic Cloud on Kubernetes[k8s-dependencies]
+# Third-party dependencies for Elastic Cloud on Kubernetes 3.1 [k8s-dependencies]
 
-This page lists the third-party dependencies used to build {{eck}} 3.1.0.
+This page lists the third-party dependencies used to build {{eck}} 3.1.
 
 ## Direct dependencies [k8s-dependencies-direct]
 

--- a/docs/reference/third-party-dependencies/3_2_0.md
+++ b/docs/reference/third-party-dependencies/3_2_0.md
@@ -1,16 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-dependencies.html
-navigation_title: 3.2.0
+navigation_title: 3.2
 applies_to:
   deployment:
-    eck: ga 3.2.0
+    eck: ga =3.2
 ---
 % Generated documentation. Please do not edit.
 
-# Third-party dependencies for Elastic Cloud on Kubernetes[k8s-dependencies]
+# Third-party dependencies for Elastic Cloud on Kubernetes 3.2[k8s-dependencies]
 
-This page lists the third-party dependencies used to build {{eck}} 3.2.0.
+This page lists the third-party dependencies used to build {{eck}} 3.2.
 
 ## Direct dependencies [k8s-dependencies-direct]
 


### PR DESCRIPTION
Docs changes to reflect [new syntax](https://elastic.slack.com/archives/C0JF80CJZ/p1767896636757219) introduced to the docs site

using the following model: 

```
stack: ga 9.1           # 9.1+ (default - greater than or equal)
stack: ga 9.1+          # 9.1+ (explicit)
stack: preview 9.0-9.2  # Version range
stack: beta =9.1        # Exact version only
```

most changes related to specifying that the api reference pages and 3p dependency pages only apply to a specific version of ECK