### PR TITLE
3.3 bump Kibana memory for recipes used in test

### DIFF
--- a/config/recipes/beats/auditbeat_hosts.yaml
+++ b/config/recipes/beats/auditbeat_hosts.yaml
@@ -134,4 +134,13 @@ spec:
   count: 1
   elasticsearchRef:
     name: elasticsearch
+  podTemplate:
+    spec:
+      containers:
+      - name: kibana
+        resources:
+          requests:
+            memory: 1500Mi
+          limits:
+            memory: 1500Mi
 ...

--- a/config/recipes/beats/filebeat_autodiscover_by_metadata.yaml
+++ b/config/recipes/beats/filebeat_autodiscover_by_metadata.yaml
@@ -134,4 +134,13 @@ spec:
   count: 1
   elasticsearchRef:
     name: elasticsearch
+  podTemplate:
+    spec:
+      containers:
+      - name: kibana
+        resources:
+          requests:
+            memory: 1500Mi
+          limits:
+            memory: 1500Mi
 ...

--- a/config/recipes/beats/packetbeat_dns_http.yaml
+++ b/config/recipes/beats/packetbeat_dns_http.yaml
@@ -60,4 +60,13 @@ spec:
   count: 1
   elasticsearchRef:
     name: elasticsearch
+  podTemplate:
+    spec:
+      containers:
+      - name: kibana
+        resources:
+          requests:
+            memory: 1500Mi
+          limits:
+            memory: 1500Mi
 ...

--- a/config/recipes/elastic-agent/fleet-apm-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-apm-integration.yaml
@@ -55,6 +55,15 @@ spec:
           vars:
           - name: host
             value: 0.0.0.0:8200    
+  podTemplate:
+    spec:
+      containers:
+      - name: kibana
+        resources:
+          requests:
+            memory: 1500Mi
+          limits:
+            memory: 1500Mi
 ---
 apiVersion: elasticsearch.k8s.elastic.co/v1
 kind: Elasticsearch

--- a/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
@@ -48,6 +48,15 @@ spec:
       - package:
           name: kubernetes
         name: kubernetes-1
+  podTemplate:
+    spec:
+      containers:
+      - name: kibana
+        resources:
+          requests:
+            memory: 1500Mi
+          limits:
+            memory: 1500Mi
 ---
 apiVersion: elasticsearch.k8s.elastic.co/v1
 kind: Elasticsearch

--- a/config/recipes/elastic-agent/multi-output.yaml
+++ b/config/recipes/elastic-agent/multi-output.yaml
@@ -212,6 +212,15 @@ spec:
   count: 1
   elasticsearchRef:
     name: elasticsearch
+  podTemplate:
+    spec:
+      containers:
+      - name: kibana
+        resources:
+          requests:
+            memory: 1500Mi
+          limits:
+            memory: 1500Mi
 ---
 apiVersion: elasticsearch.k8s.elastic.co/v1
 kind: Elasticsearch
@@ -234,4 +243,13 @@ spec:
   count: 1
   elasticsearchRef:
     name: elasticsearch-mon
+  podTemplate:
+    spec:
+      containers:
+      - name: kibana
+        resources:
+          requests:
+            memory: 1500Mi
+          limits:
+            memory: 1500Mi
 ...


### PR DESCRIPTION
Bumping Kibana memory to 1.5GB temporarily in the release branch for the tests to pass
