### PR TITLE
fix: add missing verbs for persistentvolumes in e2e rbac role

### DIFF
--- a/config/e2e/rbac.yaml
+++ b/config/e2e/rbac.yaml
@@ -127,6 +127,8 @@ rules:
     resources:
       - persistentvolumes
     verbs:
+      - get # for elastic-agent kubernetes integration
+      - watch # for elastic-agent kubernetes integration
       - list # for ECK Diagnostics
   - apiGroups:
       - "security.openshift.io"


### PR DESCRIPTION
  ## Summary

  Fixes E2E test failures on GKE when applying the fleet-kubernetes-integration recipe.

  ## Problem

  The E2E service account was unable to create ClusterRoles defined in the fleet-kubernetes-integration recipe because it lacked the necessary `persistentvolumes` permissions. The error was ([link](https://buildkite.com/elastic/cloud-on-k8s-operator/builds/12574)):
```
user "system:serviceaccount:e2e-:e2e-" is attempting to grant RBAC permissions not currently held:
{APIGroups:[""], Resources:["persistentvolumes"], Verbs:["get" "watch"]}
```
  ## Root Cause

  PR #8999 added `persistentvolumes` permissions to the elastic-agent ClusterRole in the recipe, but the E2E ClusterRole was not updated accordingly. In Kubernetes RBAC, to create a ClusterRole granting specific permissions, the creator must already possess those permissions.

  ## Solution

  Added `get` and `watch` verbs for `persistentvolumes` resource to the E2E ClusterRole, allowing E2E tests to create the ClusterRoles defined in the recipe.