### PR TITLE
[3.3] fix: add missing verbs for persistentvolumes in e2e rbac role

### DIFF
--- a/config/e2e/rbac.yaml
+++ b/config/e2e/rbac.yaml
@@ -127,6 +127,8 @@ rules:
     resources:
       - persistentvolumes
     verbs:
+      - get # for elastic-agent kubernetes integration
+      - watch # for elastic-agent kubernetes integration
       - list # for ECK Diagnostics
   - apiGroups:
       - "security.openshift.io"


### PR DESCRIPTION
This is a backport of [this PR](https://github.com/elastic/cloud-on-k8s/pull/9009)