### PR TITLE
[3.3] fix: skip test stack config policy multiple weights before 8.11.0

### DIFF
--- a/test/e2e/es/certs_test.go
+++ b/test/e2e/es/certs_test.go
@@ -343,7 +343,6 @@ func TestCustomTransportCA(t *testing.T) {
 					}),
 				},
 			}
-
 		},
 		PostMutationSteps: func(k *test.K8sClient) test.StepList {
 			return test.StepList{
@@ -427,7 +426,6 @@ func TestCustomTransportCA(t *testing.T) {
 	// 3. reconfigure with correct custom certificates
 	// 4. reconfigure back to self-signed operator provided CA
 	test.RunMutations(t, []test.Builder{withBuiltinCA}, []test.Builder{withBogusCert, withCustomCert, withBuiltinCA})
-
 }
 
 func TestUpdateHTTPCertSAN(t *testing.T) {
@@ -514,7 +512,6 @@ func getCert(k *test.K8sClient, ns string, esName string) ([]byte, error) {
 }
 
 func getPodIP(k *test.K8sClient, ns string, esName string) (string, error) {
-
 	pods, err := k.GetPods(test.ESPodListOptions(ns, esName)...)
 	if err != nil {
 		return "", err

--- a/test/e2e/es/mutation_test.go
+++ b/test/e2e/es/mutation_test.go
@@ -226,7 +226,6 @@ func TestMutationAndReversal(t *testing.T) {
 	reversed := b.DeepCopy().WithMutatedFrom(&mutation)
 
 	test.RunMutations(t, []test.Builder{b}, []test.Builder{mutation, reversed})
-
 }
 
 func TestMutationNodeSetReplacementWithChangeBudget(t *testing.T) {

--- a/test/e2e/es/podtemplate_test.go
+++ b/test/e2e/es/podtemplate_test.go
@@ -31,7 +31,6 @@ import (
 // TestPodTemplateValidation simulates a cluster update with a temporary invalid pod template.
 // The invalid pod template should not prevent the update to be eventually applied.
 func TestPodTemplateValidation(t *testing.T) {
-
 	// Only execute this test on GKE > 1.15 because we know that latest versions of GKE have compatible admission webhooks.
 	if test.Ctx().Provider != "gke" {
 		t.SkipNow()

--- a/test/e2e/es/stack_monitoring_test.go
+++ b/test/e2e/es/stack_monitoring_test.go
@@ -149,7 +149,6 @@ func TestExternalESStackMonitoring(t *testing.T) {
 			test.Step{
 				Name: "Create a secret to reference the monitoring cluster",
 				Test: test.Eventually(func() error {
-
 					var monitoringHTTPPublicCertsSecret corev1.Secret
 					key := types.NamespacedName{
 						Namespace: monitoring.Elasticsearch.Namespace,

--- a/test/e2e/es/stackconfigpolicy_test.go
+++ b/test/e2e/es/stackconfigpolicy_test.go
@@ -343,9 +343,14 @@ func TestStackConfigPolicyMultipleWeights(t *testing.T) {
 		t.SkipNow()
 	}
 
-	// StackConfigPolicy is supported for ES versions with file-based settings feature
 	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
-	if !stackVersion.GTE(filesettings.FileBasedSettingsMinPreVersion) {
+	switch {
+	case stackVersion.LT(filesettings.FileBasedSettingsMinPreVersion):
+		// StackConfigPolicy is supported for ES versions with file-based settings feature
+		t.SkipNow()
+	case stackVersion.LT(version.From(8, 11, 0)):
+		// Before 8.11.0, ES has an issue with loading cluster-settings changes in file-settings
+		// of the same keys as in this test (https://github.com/elastic/elasticsearch/pull/99212)
 		t.SkipNow()
 	}
 


### PR DESCRIPTION
This is a backport of https://github.com/elastic/cloud-on-k8s/pull/9011