### PR TITLE
[3.3] Require 9.2.1 for autoops agent for 3.3 release. (#9007)

### DIFF
--- a/pkg/controller/autoops/configmap_test.go
+++ b/pkg/controller/autoops/configmap_test.go
@@ -166,7 +166,7 @@ func mkPolicy() autoopsv1alpha1.AutoOpsAgentPolicy {
 			Namespace: "default",
 		},
 		Spec: autoopsv1alpha1.AutoOpsAgentPolicySpec{
-			Version: "9.1.0",
+			Version: "9.2.1",
 		},
 	}
 }

--- a/pkg/controller/autoops/expected_test.go
+++ b/pkg/controller/autoops/expected_test.go
@@ -33,7 +33,7 @@ func TestReconcileAutoOpsAgentPolicy_deploymentParams(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: autoopsv1alpha1.AutoOpsAgentPolicySpec{
-			Version: "9.1.0-SNAPSHOT",
+			Version: "9.2.1",
 			AutoOpsRef: autoopsv1alpha1.AutoOpsRef{
 				SecretName: "autoops-secret",
 			},

--- a/pkg/controller/autoops/gc_test.go
+++ b/pkg/controller/autoops/gc_test.go
@@ -89,7 +89,7 @@ func TestGarbageCollector_DoGarbageCollection(t *testing.T) {
 				Namespace: namespace,
 			},
 			Spec: autoopsv1alpha1.AutoOpsAgentPolicySpec{
-				Version: "9.1.0",
+				Version: "9.2.1",
 			},
 		}
 	}

--- a/pkg/controller/autoops/reconcile_test.go
+++ b/pkg/controller/autoops/reconcile_test.go
@@ -76,7 +76,7 @@ func TestAutoOpsAgentPolicyReconciler_internalReconcile(t *testing.T) {
 					Namespace: "ns-1",
 				},
 				Spec: autoopsv1alpha1.AutoOpsAgentPolicySpec{
-					Version: "9.1.0",
+					Version: "9.2.1",
 					AutoOpsRef: autoopsv1alpha1.AutoOpsRef{
 						SecretName: "invalid-secret",
 					},
@@ -107,7 +107,7 @@ func TestAutoOpsAgentPolicyReconciler_internalReconcile(t *testing.T) {
 					Namespace: "ns-1",
 				},
 				Spec: autoopsv1alpha1.AutoOpsAgentPolicySpec{
-					Version: "9.1.0",
+					Version: "9.2.1",
 					AutoOpsRef: autoopsv1alpha1.AutoOpsRef{
 						SecretName: "config-secret",
 					},
@@ -148,7 +148,7 @@ func TestAutoOpsAgentPolicyReconciler_internalReconcile(t *testing.T) {
 					Namespace: "ns-1",
 				},
 				Spec: autoopsv1alpha1.AutoOpsAgentPolicySpec{
-					Version: "9.1.0",
+					Version: "9.2.1",
 					AutoOpsRef: autoopsv1alpha1.AutoOpsRef{
 						SecretName: "config-secret",
 					},
@@ -184,7 +184,7 @@ func TestAutoOpsAgentPolicyReconciler_internalReconcile(t *testing.T) {
 					Namespace: "ns-1",
 				},
 				Spec: autoopsv1alpha1.AutoOpsAgentPolicySpec{
-					Version: "9.1.0",
+					Version: "9.2.1",
 					AutoOpsRef: autoopsv1alpha1.AutoOpsRef{
 						SecretName: "config-secret",
 					},
@@ -234,7 +234,7 @@ func TestAutoOpsAgentPolicyReconciler_internalReconcile(t *testing.T) {
 					Namespace: "ns-1",
 				},
 				Spec: autoopsv1alpha1.AutoOpsAgentPolicySpec{
-					Version: "9.1.0",
+					Version: "9.2.1",
 					AutoOpsRef: autoopsv1alpha1.AutoOpsRef{
 						SecretName: "config-secret",
 					},
@@ -291,7 +291,7 @@ func TestAutoOpsAgentPolicyReconciler_internalReconcile(t *testing.T) {
 					Namespace: "ns-1",
 				},
 				Spec: autoopsv1alpha1.AutoOpsAgentPolicySpec{
-					Version: "9.1.0",
+					Version: "9.2.1",
 					AutoOpsRef: autoopsv1alpha1.AutoOpsRef{
 						SecretName: "config-secret",
 					},
@@ -362,7 +362,7 @@ func TestAutoOpsAgentPolicyReconciler_internalReconcile(t *testing.T) {
 					Namespace: "ns-1",
 				},
 				Spec: autoopsv1alpha1.AutoOpsAgentPolicySpec{
-					Version: "9.1.0",
+					Version: "9.2.1",
 					AutoOpsRef: autoopsv1alpha1.AutoOpsRef{
 						SecretName: "config-secret",
 					},
@@ -452,7 +452,7 @@ func TestAutoOpsAgentPolicyReconciler_internalReconcile(t *testing.T) {
 					Namespace: "ns-1",
 				},
 				Spec: autoopsv1alpha1.AutoOpsAgentPolicySpec{
-					Version: "9.1.0",
+					Version: "9.2.1",
 					AutoOpsRef: autoopsv1alpha1.AutoOpsRef{
 						SecretName: "config-secret",
 					},
@@ -722,7 +722,7 @@ func TestAutoOpsAgentPolicyReconciler_selectorChangeCleanup(t *testing.T) {
 			Namespace: "ns-1",
 		},
 		Spec: autoopsv1alpha1.AutoOpsAgentPolicySpec{
-			Version: "9.1.0",
+			Version: "9.2.1",
 			AutoOpsRef: autoopsv1alpha1.AutoOpsRef{
 				SecretName: "config-secret",
 			},
@@ -938,7 +938,7 @@ func TestAutoOpsAgentPolicyReconciler_accessRevokedCleanup(t *testing.T) {
 			Namespace: "ns-1",
 		},
 		Spec: autoopsv1alpha1.AutoOpsAgentPolicySpec{
-			Version: "9.1.0",
+			Version: "9.2.1",
 			AutoOpsRef: autoopsv1alpha1.AutoOpsRef{
 				SecretName: "config-secret",
 			},

--- a/pkg/controller/common/version/version.go
+++ b/pkg/controller/common/version/version.go
@@ -39,8 +39,9 @@ var (
 	SupportedPackageRegistryVersions = MinMaxVersion{Min: From(7, 17, 8), Max: From(9, 99, 99)}
 	SupportedLogstashVersions        = MinMaxVersion{Min: From(8, 12, 0), Max: From(9, 99, 99)}
 
-	// AutoOpsAgent was introduced in 9.1.0 and is supported on all 9.x versions.
-	SupportedAutoOpsAgentVersions = MinMaxVersion{Min: MustParse("9.1.0"), Max: From(9, 99, 99)}
+	// AutoOpsAgent was introduced in 9.1.0, but 9.2.1 is now required due to both performance optimizations
+	// and the lack of the healthcheckv2 extension prior to 9.2.1 which ECK utilizes.
+	SupportedAutoOpsAgentVersions = MinMaxVersion{Min: MustParse("9.2.1"), Max: From(9, 99, 99)}
 
 	// minPreReleaseVersion is the lowest prerelease identifier as numeric prerelease takes precedence before
 	// alphanumeric ones and it can't have leading zeros.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.3`:
 - [Require 9.2.1 for autoops agent for 3.3 release. (#9007)](https://github.com/elastic/cloud-on-k8s/pull/9007)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)