### PR TITLE
fix: TestKibanaAssociationWithNonExistentEPR by waiting ES to become green

### DIFF
--- a/test/e2e/kb/association_test.go
+++ b/test/e2e/kb/association_test.go
@@ -218,6 +218,8 @@ func TestKibanaAssociationWithNonExistentEPR(t *testing.T) {
 	steps := test.StepList{}
 	steps = steps.WithSteps(esBuilder.InitTestSteps(k))
 	steps = steps.WithSteps(esBuilder.CreationTestSteps(k))
+	steps = steps.WithSteps(esBuilder.CheckK8sTestSteps(k))
+	steps = steps.WithSteps(esBuilder.CheckStackTestSteps(k))
 	steps = steps.WithSteps(kbBuilder.InitTestSteps(k))
 	steps = steps.WithSteps(kbBuilder.CreationTestSteps(k))
 	steps = steps.WithStep(test.Step{


### PR DESCRIPTION
## Summary

  This PR fixes the flaky `TestKibanaAssociationWithNonExistentEPR` test by ensuring Elasticsearch becomes ready before proceeding to deletion

  ## Problem

  The test was creating an Elasticsearch cluster and then immediately proceeding to test EPR association failure and cleanup. This could trigger the timing issue described in #9020.

  ## Solution

  Wait for Elasticsearch to become fully ready (pods running, cluster green) before proceeding.

##  Notes

  This PR addresses the test flakiness caused by the edge case in #9020 but does not fix the underlying timing issue.

## Related
  - Relates #9020