### PR TITLE
[3.3] fix: TestKibanaAssociationWithNonExistentEPR by waiting ES became green (#9019)

### DIFF
--- a/test/e2e/kb/association_test.go
+++ b/test/e2e/kb/association_test.go
@@ -218,6 +218,8 @@ func TestKibanaAssociationWithNonExistentEPR(t *testing.T) {
 	steps := test.StepList{}
 	steps = steps.WithSteps(esBuilder.InitTestSteps(k))
 	steps = steps.WithSteps(esBuilder.CreationTestSteps(k))
+	steps = steps.WithSteps(esBuilder.CheckK8sTestSteps(k))
+	steps = steps.WithSteps(esBuilder.CheckStackTestSteps(k))
 	steps = steps.WithSteps(kbBuilder.InitTestSteps(k))
 	steps = steps.WithSteps(kbBuilder.CreationTestSteps(k))
 	steps = steps.WithStep(test.Step{


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.3`:
 - [fix: TestKibanaAssociationWithNonExistentEPR by waiting ES became green (#9019)](https://github.com/elastic/cloud-on-k8s/pull/9019)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)