### PR TITLE
Allow diverging behavior in e2e tests according to version of autoops agent

### DIFF
--- a/test/e2e/autoops/autoops_test.go
+++ b/test/e2e/autoops/autoops_test.go
@@ -44,6 +44,7 @@ func TestAutoOpsAgentPolicy(t *testing.T) {
 
 	policyBuilder := autoops.NewBuilder("autoops-policy").
 		WithNamespace(policyNamespace).
+		WithAgentVersion(test.Ctx().ElasticStackVersion).
 		WithResourceSelector(metav1.LabelSelector{
 			MatchLabels: map[string]string{
 				"autoops": "enabled",


### PR DESCRIPTION
Since https://github.com/elastic/beats/issues/47848 is now fixed in https://github.com/elastic/beats/pull/47936, which we were relying on in the autoops end-to-end tests, which caused the Agent pods to become ready even when they were internally failing, the only option I see to fix the e2e tests is to have divergent logic in the tests according to the version of the Agent that's being tested. I don't love this behavior, so any alternative options to consider would be appreciated (such as potentially just version gating to 9.3.0+) 

## Open questions
1. should the names of the test steps be adjusted to more accurately describe the behavior? It could be confusing otherwise.
2. are there better options we should consider?