### PR TITLE
Skip Autoops e2e tests temporarily

### DIFF
--- a/test/e2e/autoops/autoops_test.go
+++ b/test/e2e/autoops/autoops_test.go
@@ -18,6 +18,9 @@ import (
 )
 
 func TestAutoOpsAgentPolicy(t *testing.T) {
+	// https://github.com/elastic/cloud-on-k8s/issues/9027
+	t.Skip("Skipping AutoOpsAgentPolicy test")
+
 	// only execute this test if we have a test license to work with
 	if test.Ctx().TestLicense == "" {
 		t.SkipNow()


### PR DESCRIPTION
See https://github.com/elastic/cloud-on-k8s/issues/9027 for context.