### PR TITLE
[3.3] Skip Autoops e2e tests temporarily (#9028)

### DIFF
--- a/test/e2e/autoops/autoops_test.go
+++ b/test/e2e/autoops/autoops_test.go
@@ -18,6 +18,9 @@ import (
 )
 
 func TestAutoOpsAgentPolicy(t *testing.T) {
+	// https://github.com/elastic/cloud-on-k8s/issues/9027
+	t.Skip("Skipping AutoOpsAgentPolicy test")
+
 	// only execute this test if we have a test license to work with
 	if test.Ctx().TestLicense == "" {
 		t.SkipNow()


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.3`:
 - [Skip Autoops e2e tests temporarily (#9028)](https://github.com/elastic/cloud-on-k8s/pull/9028)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)