### PR TITLE
Fix misspelling in common v1 crd.

### DIFF
--- a/config/crds/v1/all-crds.yaml
+++ b/config/crds/v1/all-crds.yaml
@@ -676,7 +676,7 @@ spec:
                         properties:
                           disabled:
                             description: Disabled indicates that the provisioning
-                              of the self-signed certifcate should be disabled.
+                              of the self-signed certificate should be disabled.
                             type: boolean
                           subjectAltNames:
                             description: SubjectAlternativeNames is a list of SANs
@@ -1620,7 +1620,7 @@ spec:
                         properties:
                           disabled:
                             description: Disabled indicates that the provisioning
-                              of the self-signed certifcate should be disabled.
+                              of the self-signed certificate should be disabled.
                             type: boolean
                           subjectAltNames:
                             description: SubjectAlternativeNames is a list of SANs
@@ -3513,7 +3513,7 @@ spec:
                         properties:
                           disabled:
                             description: Disabled indicates that the provisioning
-                              of the self-signed certifcate should be disabled.
+                              of the self-signed certificate should be disabled.
                             type: boolean
                           subjectAltNames:
                             description: SubjectAlternativeNames is a list of SANs
@@ -4445,7 +4445,7 @@ spec:
                         properties:
                           disabled:
                             description: Disabled indicates that the provisioning
-                              of the self-signed certifcate should be disabled.
+                              of the self-signed certificate should be disabled.
                             type: boolean
                           subjectAltNames:
                             description: SubjectAlternativeNames is a list of SANs
@@ -7620,7 +7620,7 @@ spec:
                         properties:
                           disabled:
                             description: Disabled indicates that the provisioning
-                              of the self-signed certifcate should be disabled.
+                              of the self-signed certificate should be disabled.
                             type: boolean
                           subjectAltNames:
                             description: SubjectAlternativeNames is a list of SANs
@@ -8199,7 +8199,7 @@ spec:
                         properties:
                           disabled:
                             description: Disabled indicates that the provisioning
-                              of the self-signed certifcate should be disabled.
+                              of the self-signed certificate should be disabled.
                             type: boolean
                           subjectAltNames:
                             description: SubjectAlternativeNames is a list of SANs
@@ -8801,7 +8801,7 @@ spec:
                         properties:
                           disabled:
                             description: Disabled indicates that the provisioning
-                              of the self-signed certifcate should be disabled.
+                              of the self-signed certificate should be disabled.
                             type: boolean
                           subjectAltNames:
                             description: SubjectAlternativeNames is a list of SANs
@@ -10310,7 +10310,7 @@ spec:
                           properties:
                             disabled:
                               description: Disabled indicates that the provisioning
-                                of the self-signed certifcate should be disabled.
+                                of the self-signed certificate should be disabled.
                               type: boolean
                             subjectAltNames:
                               description: SubjectAlternativeNames is a list of SANs
@@ -11325,7 +11325,7 @@ spec:
                         properties:
                           disabled:
                             description: Disabled indicates that the provisioning
-                              of the self-signed certifcate should be disabled.
+                              of the self-signed certificate should be disabled.
                             type: boolean
                           subjectAltNames:
                             description: SubjectAlternativeNames is a list of SANs

--- a/config/crds/v1/resources/agent.k8s.elastic.co_agents.yaml
+++ b/config/crds/v1/resources/agent.k8s.elastic.co_agents.yaml
@@ -17805,7 +17805,7 @@ spec:
                         properties:
                           disabled:
                             description: Disabled indicates that the provisioning
-                              of the self-signed certifcate should be disabled.
+                              of the self-signed certificate should be disabled.
                             type: boolean
                           subjectAltNames:
                             description: SubjectAlternativeNames is a list of SANs

--- a/config/crds/v1/resources/apm.k8s.elastic.co_apmservers.yaml
+++ b/config/crds/v1/resources/apm.k8s.elastic.co_apmservers.yaml
@@ -493,7 +493,7 @@ spec:
                         properties:
                           disabled:
                             description: Disabled indicates that the provisioning
-                              of the self-signed certifcate should be disabled.
+                              of the self-signed certificate should be disabled.
                             type: boolean
                           subjectAltNames:
                             description: SubjectAlternativeNames is a list of SANs

--- a/config/crds/v1/resources/elasticsearch.k8s.elastic.co_elasticsearches.yaml
+++ b/config/crds/v1/resources/elasticsearch.k8s.elastic.co_elasticsearches.yaml
@@ -489,7 +489,7 @@ spec:
                         properties:
                           disabled:
                             description: Disabled indicates that the provisioning
-                              of the self-signed certifcate should be disabled.
+                              of the self-signed certificate should be disabled.
                             type: boolean
                           subjectAltNames:
                             description: SubjectAlternativeNames is a list of SANs

--- a/config/crds/v1/resources/enterprisesearch.k8s.elastic.co_enterprisesearches.yaml
+++ b/config/crds/v1/resources/enterprisesearch.k8s.elastic.co_enterprisesearches.yaml
@@ -504,7 +504,7 @@ spec:
                         properties:
                           disabled:
                             description: Disabled indicates that the provisioning
-                              of the self-signed certifcate should be disabled.
+                              of the self-signed certificate should be disabled.
                             type: boolean
                           subjectAltNames:
                             description: SubjectAlternativeNames is a list of SANs
@@ -9586,7 +9586,7 @@ spec:
                         properties:
                           disabled:
                             description: Disabled indicates that the provisioning
-                              of the self-signed certifcate should be disabled.
+                              of the self-signed certificate should be disabled.
                             type: boolean
                           subjectAltNames:
                             description: SubjectAlternativeNames is a list of SANs

--- a/config/crds/v1/resources/kibana.k8s.elastic.co_kibanas.yaml
+++ b/config/crds/v1/resources/kibana.k8s.elastic.co_kibanas.yaml
@@ -524,7 +524,7 @@ spec:
                         properties:
                           disabled:
                             description: Disabled indicates that the provisioning
-                              of the self-signed certifcate should be disabled.
+                              of the self-signed certificate should be disabled.
                             type: boolean
                           subjectAltNames:
                             description: SubjectAlternativeNames is a list of SANs

--- a/config/crds/v1/resources/logstash.k8s.elastic.co_logstashes.yaml
+++ b/config/crds/v1/resources/logstash.k8s.elastic.co_logstashes.yaml
@@ -9192,7 +9192,7 @@ spec:
                           properties:
                             disabled:
                               description: Disabled indicates that the provisioning
-                                of the self-signed certifcate should be disabled.
+                                of the self-signed certificate should be disabled.
                               type: boolean
                             subjectAltNames:
                               description: SubjectAlternativeNames is a list of SANs

--- a/config/crds/v1/resources/maps.k8s.elastic.co_elasticmapsservers.yaml
+++ b/config/crds/v1/resources/maps.k8s.elastic.co_elasticmapsservers.yaml
@@ -505,7 +505,7 @@ spec:
                         properties:
                           disabled:
                             description: Disabled indicates that the provisioning
-                              of the self-signed certifcate should be disabled.
+                              of the self-signed certificate should be disabled.
                             type: boolean
                           subjectAltNames:
                             description: SubjectAlternativeNames is a list of SANs

--- a/config/crds/v1/resources/packageregistry.k8s.elastic.co_packageregistries.yaml
+++ b/config/crds/v1/resources/packageregistry.k8s.elastic.co_packageregistries.yaml
@@ -474,7 +474,7 @@ spec:
                         properties:
                           disabled:
                             description: Disabled indicates that the provisioning
-                              of the self-signed certifcate should be disabled.
+                              of the self-signed certificate should be disabled.
                             type: boolean
                           subjectAltNames:
                             description: SubjectAlternativeNames is a list of SANs

--- a/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
+++ b/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
@@ -683,7 +683,7 @@ spec:
                         properties:
                           disabled:
                             description: Disabled indicates that the provisioning
-                              of the self-signed certifcate should be disabled.
+                              of the self-signed certificate should be disabled.
                             type: boolean
                           subjectAltNames:
                             description: SubjectAlternativeNames is a list of SANs
@@ -1634,7 +1634,7 @@ spec:
                         properties:
                           disabled:
                             description: Disabled indicates that the provisioning
-                              of the self-signed certifcate should be disabled.
+                              of the self-signed certificate should be disabled.
                             type: boolean
                           subjectAltNames:
                             description: SubjectAlternativeNames is a list of SANs
@@ -3548,7 +3548,7 @@ spec:
                         properties:
                           disabled:
                             description: Disabled indicates that the provisioning
-                              of the self-signed certifcate should be disabled.
+                              of the self-signed certificate should be disabled.
                             type: boolean
                           subjectAltNames:
                             description: SubjectAlternativeNames is a list of SANs
@@ -4494,7 +4494,7 @@ spec:
                         properties:
                           disabled:
                             description: Disabled indicates that the provisioning
-                              of the self-signed certifcate should be disabled.
+                              of the self-signed certificate should be disabled.
                             type: boolean
                           subjectAltNames:
                             description: SubjectAlternativeNames is a list of SANs
@@ -7676,7 +7676,7 @@ spec:
                         properties:
                           disabled:
                             description: Disabled indicates that the provisioning
-                              of the self-signed certifcate should be disabled.
+                              of the self-signed certificate should be disabled.
                             type: boolean
                           subjectAltNames:
                             description: SubjectAlternativeNames is a list of SANs
@@ -8255,7 +8255,7 @@ spec:
                         properties:
                           disabled:
                             description: Disabled indicates that the provisioning
-                              of the self-signed certifcate should be disabled.
+                              of the self-signed certificate should be disabled.
                             type: boolean
                           subjectAltNames:
                             description: SubjectAlternativeNames is a list of SANs
@@ -8864,7 +8864,7 @@ spec:
                         properties:
                           disabled:
                             description: Disabled indicates that the provisioning
-                              of the self-signed certifcate should be disabled.
+                              of the self-signed certificate should be disabled.
                             type: boolean
                           subjectAltNames:
                             description: SubjectAlternativeNames is a list of SANs
@@ -10380,7 +10380,7 @@ spec:
                           properties:
                             disabled:
                               description: Disabled indicates that the provisioning
-                                of the self-signed certifcate should be disabled.
+                                of the self-signed certificate should be disabled.
                               type: boolean
                             subjectAltNames:
                               description: SubjectAlternativeNames is a list of SANs
@@ -11402,7 +11402,7 @@ spec:
                         properties:
                           disabled:
                             description: Disabled indicates that the provisioning
-                              of the self-signed certifcate should be disabled.
+                              of the self-signed certificate should be disabled.
                             type: boolean
                           subjectAltNames:
                             description: SubjectAlternativeNames is a list of SANs

--- a/docs/reference/api-reference/main.md
+++ b/docs/reference/api-reference/main.md
@@ -725,7 +725,7 @@ SelfSignedCertificate holds configuration for the self-signed certificate genera
 | Field | Description |
 | --- | --- |
 | *`subjectAltNames`* __[SubjectAlternativeName](#subjectalternativename) array__ | SubjectAlternativeNames is a list of SANs to include in the generated HTTP TLS certificate. |
-| *`disabled`* __boolean__ | Disabled indicates that the provisioning of the self-signed certifcate should be disabled. |
+| *`disabled`* __boolean__ | Disabled indicates that the provisioning of the self-signed certificate should be disabled. |
 
 
 

--- a/pkg/apis/common/v1/common.go
+++ b/pkg/apis/common/v1/common.go
@@ -232,7 +232,7 @@ func (tls TLSOptions) Enabled() bool {
 type SelfSignedCertificate struct {
 	// SubjectAlternativeNames is a list of SANs to include in the generated HTTP TLS certificate.
 	SubjectAlternativeNames []SubjectAlternativeName `json:"subjectAltNames,omitempty"`
-	// Disabled indicates that the provisioning of the self-signed certifcate should be disabled.
+	// Disabled indicates that the provisioning of the self-signed certificate should be disabled.
 	Disabled bool `json:"disabled,omitempty"`
 }
 


### PR DESCRIPTION
There's been a misspelling in the crd docs for about 6 years, and copilot just caught it [here](https://github.com/elastic/cloud-on-k8s/pull/9039#discussion_r2695800969).

I'm moving this change to it's own PR.