### PR TITLE
fix: flip weight semantics - higher weight takes precedence

### DIFF
--- a/config/crds/v1/all-crds.yaml
+++ b/config/crds/v1/all-crds.yaml
@@ -11706,7 +11706,7 @@ spec:
                 default: 0
                 description: |-
                   Weight determines the priority of this policy when multiple policies target the same resource.
-                  Lower weight values take precedence. Defaults to 0.
+                  Higher weight values take precedence. Defaults to 0.
                 format: int32
                 type: integer
             type: object

--- a/config/crds/v1/resources/stackconfigpolicy.k8s.elastic.co_stackconfigpolicies.yaml
+++ b/config/crds/v1/resources/stackconfigpolicy.k8s.elastic.co_stackconfigpolicies.yaml
@@ -295,7 +295,7 @@ spec:
                 default: 0
                 description: |-
                   Weight determines the priority of this policy when multiple policies target the same resource.
-                  Lower weight values take precedence. Defaults to 0.
+                  Higher weight values take precedence. Defaults to 0.
                 format: int32
                 type: integer
             type: object

--- a/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
+++ b/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
@@ -11790,7 +11790,7 @@ spec:
                 default: 0
                 description: |-
                   Weight determines the priority of this policy when multiple policies target the same resource.
-                  Lower weight values take precedence. Defaults to 0.
+                  Higher weight values take precedence. Defaults to 0.
                 format: int32
                 type: integer
             type: object

--- a/docs/reference/api-reference/main.md
+++ b/docs/reference/api-reference/main.md
@@ -2214,7 +2214,7 @@ StackConfigPolicy represents a StackConfigPolicy resource in a Kubernetes cluste
 | Field | Description |
 | --- | --- |
 | *`resourceSelector`* __[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#labelselector-v1-meta)__ |  |
-| *`weight`* __integer__ | Weight determines the priority of this policy when multiple policies target the same resource.<br>Lower weight values take precedence. Defaults to 0. |
+| *`weight`* __integer__ | Weight determines the priority of this policy when multiple policies target the same resource.<br>Higher weight values take precedence. Defaults to 0. |
 | *`secureSettings`* __[SecretSource](#secretsource) array__ | Deprecated: SecureSettings only applies to Elasticsearch and is deprecated. It must be set per application instead. |
 | *`elasticsearch`* __[ElasticsearchConfigPolicySpec](#elasticsearchconfigpolicyspec)__ |  |
 | *`kibana`* __[KibanaConfigPolicySpec](#kibanaconfigpolicyspec)__ |  |

--- a/pkg/apis/stackconfigpolicy/v1alpha1/stackconfigpolicy_types.go
+++ b/pkg/apis/stackconfigpolicy/v1alpha1/stackconfigpolicy_types.go
@@ -57,7 +57,7 @@ type StackConfigPolicyList struct {
 type StackConfigPolicySpec struct {
 	ResourceSelector metav1.LabelSelector `json:"resourceSelector,omitempty"`
 	// Weight determines the priority of this policy when multiple policies target the same resource.
-	// Lower weight values take precedence. Defaults to 0.
+	// Higher weight values take precedence. Defaults to 0.
 	// +kubebuilder:default=0
 	Weight int32 `json:"weight,omitempty"`
 	// Deprecated: SecureSettings only applies to Elasticsearch and is deprecated. It must be set per application instead.

--- a/pkg/controller/stackconfigpolicy/controller_test.go
+++ b/pkg/controller/stackconfigpolicy/controller_test.go
@@ -899,7 +899,7 @@ func TestReconcileStackConfigPolicy_MultipleStackConfigPolicies(t *testing.T) {
 		},
 	}
 
-	// Policy with weight 20 (applied second, overrides policy1)
+	// Policy with weight 10 (applied second, overrides policy1)
 	policy2 := policyv1alpha1.StackConfigPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "ns",

--- a/pkg/controller/stackconfigpolicy/controller_test.go
+++ b/pkg/controller/stackconfigpolicy/controller_test.go
@@ -879,7 +879,7 @@ func TestReconcileStackConfigPolicy_MultipleStackConfigPolicies(t *testing.T) {
 		Spec: esv1.ElasticsearchSpec{Version: "8.6.1"},
 	}
 
-	// Policy with weight 10 (applied first)
+	// Policy with weight 20 (applied first)
 	policy1 := policyv1alpha1.StackConfigPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "ns",

--- a/pkg/controller/stackconfigpolicy/controller_test.go
+++ b/pkg/controller/stackconfigpolicy/controller_test.go
@@ -1085,7 +1085,7 @@ func TestReconcileStackConfigPolicy_MultipleStackConfigPolicies(t *testing.T) {
 				owners, err = reconciler.SoftOwnerRefs(&secretMountSecret)
 				assert.NoError(t, err)
 				assert.Len(t, owners, 1, "secretMountSecret should be owned by 1 policy")
-				// Verify only policy-high is the owner
+				// Verify only policy-low is the owner
 				assert.Contains(t, owners, reconciler.SoftOwnerRef{Namespace: "ns", Name: "policy-low", Kind: policyv1alpha1.Kind}, "policy-low should be an owner of secretMountSecret")
 			},
 		},

--- a/pkg/controller/stackconfigpolicy/stackconfigpolicy.go
+++ b/pkg/controller/stackconfigpolicy/stackconfigpolicy.go
@@ -96,7 +96,7 @@ func merge[T any](
 
 // getConfigPolicyForElasticsearch builds a merged stack config policy for the given Elasticsearch cluster.
 // It processes all provided policies, filtering those that target the Elasticsearch cluster, and merges them
-// in order of their weight (highest to lowest), with higher weight values taking precedence as they are
+// in order of their weight (lowest to highest), with higher weight values taking precedence as they are
 // merged last. Policies with the same weight are flagged as conflicts.
 // Returns a configPolicy containing the merged configuration and any error occurred during merging.
 func getConfigPolicyForElasticsearch(es *esv1.Elasticsearch, allPolicies []policyv1alpha1.StackConfigPolicy, params operator.Parameters) (*configPolicy[policyv1alpha1.ElasticsearchConfigPolicySpec], error) {

--- a/pkg/controller/stackconfigpolicy/stackconfigpolicy.go
+++ b/pkg/controller/stackconfigpolicy/stackconfigpolicy.go
@@ -160,7 +160,7 @@ func mergeElasticsearchSpecs(dst, src *policyv1alpha1.ElasticsearchConfigPolicyS
 
 // getConfigPolicyForKibana builds a merged stack config policy for the given Kibana instance.
 // It processes all provided policies, filtering those that target the Kibana instance, and merges them
-// in order of their weight (highest to lowest), with higher weight values taking precedence as they are
+// in order of their weight (lowest to highest), with higher weight values taking precedence as they are
 // merged last. Policies with the same weight are flagged as conflicts.
 // Returns a configPolicy containing the merged configuration and any error occurred during merging.
 func getConfigPolicyForKibana(kbn *kbv1.Kibana, allPolicies []policyv1alpha1.StackConfigPolicy, params operator.Parameters) (*configPolicy[policyv1alpha1.KibanaConfigPolicySpec], error) {

--- a/pkg/controller/stackconfigpolicy/stackconfigpolicy.go
+++ b/pkg/controller/stackconfigpolicy/stackconfigpolicy.go
@@ -46,7 +46,7 @@ type configPolicy[T any] struct {
 }
 
 // merge processes all provided policies, filters those targeting the given object, and merges them
-// in order of their weight (highest weight first). Policies with the same weight are flagged as conflicts.
+// in order of their weight (lowest weight first). Policies with the same weight are flagged as conflicts.
 // The merge operation is customized through the configPolicy's extractFunc and mergeFunc callbacks.
 func merge[T any](
 	c *configPolicy[T],

--- a/pkg/controller/stackconfigpolicy/stackconfigpolicy.go
+++ b/pkg/controller/stackconfigpolicy/stackconfigpolicy.go
@@ -81,7 +81,7 @@ func merge[T any](
 	}
 
 	slices.SortFunc(c.PolicyRefs, func(p1, p2 policyv1alpha1.StackConfigPolicy) int {
-		return cmp.Compare(p2.Spec.Weight, p1.Spec.Weight)
+		return cmp.Compare(p1.Spec.Weight, p2.Spec.Weight)
 	})
 
 	for _, p := range c.PolicyRefs {
@@ -96,7 +96,7 @@ func merge[T any](
 
 // getConfigPolicyForElasticsearch builds a merged stack config policy for the given Elasticsearch cluster.
 // It processes all provided policies, filtering those that target the Elasticsearch cluster, and merges them
-// in order of their weight (highest to lowest), with lower weight values taking precedence as they are
+// in order of their weight (highest to lowest), with higher weight values taking precedence as they are
 // merged last. Policies with the same weight are flagged as conflicts.
 // Returns a configPolicy containing the merged configuration and any error occurred during merging.
 func getConfigPolicyForElasticsearch(es *esv1.Elasticsearch, allPolicies []policyv1alpha1.StackConfigPolicy, params operator.Parameters) (*configPolicy[policyv1alpha1.ElasticsearchConfigPolicySpec], error) {
@@ -160,7 +160,7 @@ func mergeElasticsearchSpecs(dst, src *policyv1alpha1.ElasticsearchConfigPolicyS
 
 // getConfigPolicyForKibana builds a merged stack config policy for the given Kibana instance.
 // It processes all provided policies, filtering those that target the Kibana instance, and merges them
-// in order of their weight (highest to lowest), with lower weight values taking precedence as they are
+// in order of their weight (highest to lowest), with higher weight values taking precedence as they are
 // merged last. Policies with the same weight are flagged as conflicts.
 // Returns a configPolicy containing the merged configuration and any error occurred during merging.
 func getConfigPolicyForKibana(kbn *kbv1.Kibana, allPolicies []policyv1alpha1.StackConfigPolicy, params operator.Parameters) (*configPolicy[policyv1alpha1.KibanaConfigPolicySpec], error) {

--- a/pkg/controller/stackconfigpolicy/stackconfigpolicy_test.go
+++ b/pkg/controller/stackconfigpolicy/stackconfigpolicy_test.go
@@ -53,7 +53,7 @@ func Test_getStackPolicyConfigForElasticsearch(t *testing.T) {
 						ResourceSelector: metav1.LabelSelector{
 							MatchLabels: map[string]string{"test": "test"},
 						},
-						Weight: 1,
+						Weight: 10,
 						SecureSettings: []commonv1.SecretSource{
 							{
 								SecretName: "policy1-deprecated-secure-setting",
@@ -133,7 +133,7 @@ func Test_getStackPolicyConfigForElasticsearch(t *testing.T) {
 						ResourceSelector: metav1.LabelSelector{
 							MatchLabels: map[string]string{"test": "test"},
 						},
-						Weight: 10,
+						Weight: 1,
 						SecureSettings: []commonv1.SecretSource{
 							{
 								SecretName: "policy2-deprecated-secure-setting",
@@ -341,7 +341,7 @@ func Test_getStackPolicyConfigForElasticsearch(t *testing.T) {
 						ResourceSelector: metav1.LabelSelector{
 							MatchLabels: map[string]string{"test": "test"},
 						},
-						Weight: 1,
+						Weight: 10,
 						SecureSettings: []commonv1.SecretSource{
 							{
 								SecretName: "policy1-deprecated-secure-setting",
@@ -421,7 +421,7 @@ func Test_getStackPolicyConfigForElasticsearch(t *testing.T) {
 						ResourceSelector: metav1.LabelSelector{
 							MatchLabels: map[string]string{"test": "test"},
 						},
-						Weight: 10,
+						Weight: 1,
 						SecureSettings: []commonv1.SecretSource{
 							{
 								SecretName: "policy2-deprecated-secure-setting",
@@ -768,7 +768,7 @@ func Test_getStackPolicyConfigForElasticsearch(t *testing.T) {
 				},
 			},
 			stackConfigPolicies: []policyv1alpha1.StackConfigPolicy{
-				// Policy 1 with lower weight - should be merged first
+				// Policy 1 with lower weight - attempts to define the same secret as Policy 2, should conflict
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace:       "test",
@@ -790,7 +790,7 @@ func Test_getStackPolicyConfigForElasticsearch(t *testing.T) {
 						},
 					},
 				},
-				// Policy 2 with higher weight - attempts to define the same secret, should conflict
+				// Policy 2 with higher weight - should be merged first
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace:       "test",
@@ -827,7 +827,7 @@ func Test_getStackPolicyConfigForElasticsearch(t *testing.T) {
 				},
 			},
 			stackConfigPolicies: []policyv1alpha1.StackConfigPolicy{
-				// Policy 1 with lower weight - should be merged first
+				// Policy 1 with lower weight - attempts to use the same mount path, should conflict
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace:       "test",
@@ -849,7 +849,7 @@ func Test_getStackPolicyConfigForElasticsearch(t *testing.T) {
 						},
 					},
 				},
-				// Policy 2 with higher weight - attempts to use the same mount path, should conflict
+				// Policy 2 with higher weight - should be merged first
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace:       "test",
@@ -1125,7 +1125,7 @@ func Test_getPolicyConfigForKibana(t *testing.T) {
 			},
 		},
 		{
-			name: "merges Kibana configs with overwrites - lower weight wins",
+			name: "merges Kibana configs with overwrites - higher weight wins",
 			targetKibana: &kbv1.Kibana{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-kb",
@@ -1165,7 +1165,7 @@ func Test_getPolicyConfigForKibana(t *testing.T) {
 						ResourceSelector: metav1.LabelSelector{
 							MatchLabels: map[string]string{"env": "prod"},
 						},
-						Weight: 20,
+						Weight: 2,
 						Kibana: policyv1alpha1.KibanaConfigPolicySpec{
 							Config: &commonv1.Config{Data: map[string]any{
 								"logging.root.level": "debug", // Override from policy with weight 10

--- a/test/e2e/es/stackconfigpolicy_test.go
+++ b/test/e2e/es/stackconfigpolicy_test.go
@@ -360,14 +360,14 @@ func TestStackConfigPolicyMultipleWeights(t *testing.T) {
 
 	namespace := test.Ctx().ManagedNamespace(0)
 
-	// Policy with weight 20 (lower priority) - sets cluster.name
+	// Policy with weight 10 (lower priority) - sets cluster.name
 	lowPriorityPolicy := policyv1alpha1.StackConfigPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      fmt.Sprintf("low-priority-scp-%s", rand.String(4)),
 		},
 		Spec: policyv1alpha1.StackConfigPolicySpec{
-			Weight: 20,
+			Weight: 10,
 			ResourceSelector: metav1.LabelSelector{
 				MatchLabels: map[string]string{"app": "elasticsearch"},
 			},
@@ -388,14 +388,14 @@ func TestStackConfigPolicyMultipleWeights(t *testing.T) {
 		},
 	}
 
-	// Policy with weight 10 (higher priority) - should override cluster.name and settings
+	// Policy with weight 20 (higher priority) - should override cluster.name and settings
 	highPriorityPolicy := policyv1alpha1.StackConfigPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      fmt.Sprintf("high-priority-scp-%s", rand.String(4)),
 		},
 		Spec: policyv1alpha1.StackConfigPolicySpec{
-			Weight: 10,
+			Weight: 20,
 			ResourceSelector: metav1.LabelSelector{
 				MatchLabels: map[string]string{"app": "elasticsearch"},
 			},
@@ -420,14 +420,14 @@ func TestStackConfigPolicyMultipleWeights(t *testing.T) {
 		},
 	}
 
-	// Policy with same weight 20 but different selector (should not conflict)
+	// Policy with same weight 10 but different selector (should not conflict)
 	nonConflictingPolicy := policyv1alpha1.StackConfigPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      fmt.Sprintf("non-conflicting-scp-%s", rand.String(4)),
 		},
 		Spec: policyv1alpha1.StackConfigPolicySpec{
-			Weight: 20,
+			Weight: 10,
 			ResourceSelector: metav1.LabelSelector{
 				MatchLabels: map[string]string{"app": "kibana"}, // Different selector
 			},

--- a/test/e2e/kb/stackconfigpolicy_test.go
+++ b/test/e2e/kb/stackconfigpolicy_test.go
@@ -144,14 +144,14 @@ func TestStackConfigPolicyKibanaMultipleWeights(t *testing.T) {
 
 	kbPodListOpts := test.KibanaPodListOptions(kbBuilder.Kibana.Namespace, kbBuilder.Kibana.Name)
 
-	// Policy with weight 20 (lower priority)
+	// Policy with weight 10 (lower priority)
 	lowPriorityPolicy := policyv1alpha1.StackConfigPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      fmt.Sprintf("low-priority-kb-scp-%s", rand.String(4)),
 		},
 		Spec: policyv1alpha1.StackConfigPolicySpec{
-			Weight: 20,
+			Weight: 10,
 			ResourceSelector: metav1.LabelSelector{
 				MatchLabels: map[string]string{"app": "kibana"},
 			},
@@ -171,14 +171,14 @@ func TestStackConfigPolicyKibanaMultipleWeights(t *testing.T) {
 		},
 	}
 
-	// Policy with weight 10 (higher priority) - should override lower priority settings
+	// Policy with weight 20 (higher priority) - should override lower priority settings
 	highPriorityPolicy := policyv1alpha1.StackConfigPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      fmt.Sprintf("high-priority-kb-scp-%s", rand.String(4)),
 		},
 		Spec: policyv1alpha1.StackConfigPolicySpec{
-			Weight: 10,
+			Weight: 20,
 			ResourceSelector: metav1.LabelSelector{
 				MatchLabels: map[string]string{"app": "kibana"},
 			},
@@ -198,14 +198,14 @@ func TestStackConfigPolicyKibanaMultipleWeights(t *testing.T) {
 		},
 	}
 
-	// Policy with same weight 20 but different selector (should not conflict)
+	// Policy with same weight 10 but different selector (should not conflict)
 	nonConflictingPolicy := policyv1alpha1.StackConfigPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      fmt.Sprintf("non-conflicting-kb-scp-%s", rand.String(4)),
 		},
 		Spec: policyv1alpha1.StackConfigPolicySpec{
-			Weight: 20,
+			Weight: 10,
 			ResourceSelector: metav1.LabelSelector{
 				MatchLabels: map[string]string{"app": "elasticsearch"}, // Different selector
 			},


### PR DESCRIPTION
This PR flips the semantics of weight property of `StackConfigPolicy` and now policies with higher weight take precedence. Follow up of [this comment](https://github.com/elastic/docs-content/pull/4675/changes#r2699411653)