### PR TITLE
[3.3] Remove support for Stack 7.17. (#9038)

### DIFF
--- a/.buildkite/e2e/release-branch-matrix.yaml
+++ b/.buildkite/e2e/release-branch-matrix.yaml
@@ -2,7 +2,6 @@
   fixed:
     E2E_PROVIDER: gke
   mixed:
-    - E2E_STACK_VERSION: "7.17.29"
     - E2E_STACK_VERSION: "8.0.1"
     - E2E_STACK_VERSION: "8.1.3"
     - E2E_STACK_VERSION: "8.2.3"

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ Supported versions:
 
 *  Kubernetes 1.31-1.35
 *  OpenShift 4.16-4.20
-*  Elasticsearch, Kibana, APM Server: 7.17+, 8+, 9+
+*  Elasticsearch, Kibana, APM Server: 8+, 9+
 *  Enterprise Search: 7.7+, 8+
-*  Beats: 7.17+, 8+, 9+
-*  Elastic Agent: 7.17+ (standalone), 7.17+, 8+, 9+ (Fleet)
-*  Elastic Maps Server: 7.17+, 8+, 9+
+*  Beats: 8+, 9+
+*  Elastic Agent: 8+, 9+ (Fleet, Standalone)
+*  Elastic Maps Server: 8+, 9+
 *  Logstash 8.12+, 9+
 
 Check the [Quickstart](https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-quickstart.html) to deploy your first cluster with ECK.

--- a/hack/operatorhub/templates/csv.tpl
+++ b/hack/operatorhub/templates/csv.tpl
@@ -290,15 +290,15 @@ spec:
 
     * Google Kubernetes Engine (GKE), Azure Kubernetes Service (AKS), and Amazon Elastic Kubernetes Service (EKS)
 
-    * Elasticsearch, Kibana, APM Server: 7.17+, 8+, 9+
+    * Elasticsearch, Kibana, APM Server: 8+, 9+
 
-    * Enterprise Search: 7.17+, 8+
+    * Enterprise Search: 7.7+, 8+
 
-    * Beats: 7.17+, 8+, 9+
+    * Beats: 8+, 9+
 
-    * Elastic Agent: 7.17+, 8+, 9+
+    * Elastic Agent: 8+, 9+
 
-    * Elastic Maps Server: 7.17+, 8+, 9+
+    * Elastic Maps Server: 8+, 9+
 
     * Logstash 8.12+, 9+
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.3`:
 - [Remove support for Stack 7.17. (#9038)](https://github.com/elastic/cloud-on-k8s/pull/9038)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)