### PR TITLE
Also remove support for Enterprise search 7.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Supported versions:
 *  Kubernetes 1.31-1.35
 *  OpenShift 4.16-4.20
 *  Elasticsearch, Kibana, APM Server: 8+, 9+
-*  Enterprise Search: 7.7+, 8+
+*  Enterprise Search: 8+
 *  Beats: 8+, 9+
 *  Elastic Agent: 8+, 9+ (Fleet, Standalone)
 *  Elastic Maps Server: 8+, 9+

--- a/hack/operatorhub/templates/csv.tpl
+++ b/hack/operatorhub/templates/csv.tpl
@@ -292,7 +292,7 @@ spec:
 
     * Elasticsearch, Kibana, APM Server: 8+, 9+
 
-    * Enterprise Search: 7.7+, 8+
+    * Enterprise Search: 8+
 
     * Beats: 8+, 9+
 


### PR DESCRIPTION
Follow up from https://github.com/elastic/cloud-on-k8s/pull/9038. Enterprise Search 7.x support is also EOL, and should be removed.