### PR TITLE
Also test snapshot during release process with OCP.

### DIFF
--- a/.buildkite/e2e/nightly-main-matrix.yaml
+++ b/.buildkite/e2e/nightly-main-matrix.yaml
@@ -5,7 +5,7 @@
   mixed:
     - E2E_STACK_VERSION: "8.19.6"
     - E2E_STACK_VERSION: "9.1.6"
-    # current stack version 9.2.2 is tested in all other tests no need to test it again
+    # current stack version 9.2.4 is tested in all other tests no need to test it again
     - E2E_STACK_VERSION: "8.19.7-SNAPSHOT"
     - E2E_STACK_VERSION: "9.3.0-SNAPSHOT"
 
@@ -14,7 +14,7 @@
     E2E_PROVIDER: ocp
   mixed:
     ## Test the current stack version.
-    - E2E_STACK_VERSION: "9.2.2"
+    - E2E_STACK_VERSION: "9.2.4"
     ## Also test the next stack version to detect any change in the images that might not be compatible with the CRI-O runtime.
     - E2E_STACK_VERSION: "9.3.0-SNAPSHOT"
 

--- a/.buildkite/e2e/release-branch-matrix.yaml
+++ b/.buildkite/e2e/release-branch-matrix.yaml
@@ -24,7 +24,7 @@
     - E2E_STACK_VERSION: "8.19.6"
     - E2E_STACK_VERSION: "9.0.8"
     - E2E_STACK_VERSION: "9.1.6"
-    # current stack version 9.2.2 is tested in all other tests no need to test it again
+    # current stack version 9.2.4 is tested in all other tests no need to test it again
     - E2E_STACK_VERSION: "8.19.7-SNAPSHOT"
     - E2E_STACK_VERSION: "9.3.0-SNAPSHOT"
 
@@ -65,7 +65,7 @@
     E2E_PROVIDER: ocp
   mixed:
     - DEPLOYER_CLIENT_VERSION: "4.20.4"
-      E2E_STACK_VERSION: "9.2.2"
+      E2E_STACK_VERSION: "9.2.4"
     - DEPLOYER_CLIENT_VERSION: "4.20.4"
       E2E_STACK_VERSION: "9.3.0-SNAPSHOT"
 


### PR DESCRIPTION
@pebrc  and I were just discussing this. We should be testing the snapshot version in OCP during the release process as well.