### PR TITLE
Add codeowners file.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@elastic/cloud-k8s-operator


### PR DESCRIPTION
This adds a codeowners file that has the primary `elastic/cloud-k8s-operator` group.