### PR TITLE
Bump resources for TestFleetMode test.

### DIFF
--- a/test/e2e/agent/config_test.go
+++ b/test/e2e/agent/config_test.go
@@ -162,6 +162,8 @@ func TestFleetMode(t *testing.T) {
 			WithFleetMode().
 			WithKibanaRef(kbBuilder.Ref()).
 			WithFleetServerRef(fleetServerBuilder.Ref()).
+			// Override the default resources, as we are seeing instances where 'elastic-agent diagnostics'
+			// is not completing on test failures, which is causing eck-diagnostics to not complete as well.
 			WithResources(corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("1000m"),


### PR DESCRIPTION
We are seeing instances where `elastic-agent diagnostics` is not completing on test failures, specifically OCP, which is causing eck-diagnostics to not complete as well. Upon inspection, cpu defaults of `200m` is not sufficient to allow the diagnostics to complete, as cpu for the agent pod runs at ~100% of its limit for ages.