### PR TITLE
Temporarily disable collecting agent diagnostics on e2e test failures

### DIFF
--- a/test/e2e/test/diagnostics.go
+++ b/test/e2e/test/diagnostics.go
@@ -63,6 +63,6 @@ func maybeRunECKDiagnostics(ctx context.Context, testName string, step Step) {
 		"-r", strings.Join(otherNS, ","),
 		// NOTE: Temporarily disable this as it is causing eck-diagnostics to exceed the 20 minutes threshold of context
 		// which results in corrupted diagnostics archives
-		//"--run-agent-diagnostics",
+		// "--run-agent-diagnostics",
 	)
 }


### PR DESCRIPTION
## Problem

When e2e tests fail, we collect diagnostics using `eck-diagnostics` to help identify the root cause of failures. However, `eck-diagnostics` is currently hanging and exceeding its timeout threshold when attempting to collect diagnostics from elastic-agent pods. This results in corrupted or incomplete diagnostics archives, **preventing us from debugging the actual test failures**. [BK link](https://buildkite.com/elastic/cloud-on-k8s-operator-nightly/builds/1163)

### Root Cause

Investigation revealed that `elastic-agent diagnostics` hangs, which causes the entire eck-diagnostics run to exceed its 20-minute context timeout, resulting in corrupted archives.

## Changes

This PR temporarily disables agent diagnostics collection by commenting out the `--run-agent-diagnostics` flag in the eck-diagnostics command invocation.

## Temporary Solution

By disabling agent diagnostics collection, we can hopefully:
- Allow eck-diagnostics to complete successfully within the timeout window
- Get uncorrupted diagnostics archives that contain other valuable diagnostic information
- **Unblock our ability to debug actual e2e test failures**

## Long-term Solution

This is a **temporary workaround**. The proper fixes should be:
- Time-box the agent diagnostics collection part inside eck-diagnostics
- Parallelize the agent diagnostics collection inside eck-diagnostics
- Potentially increase CPU resources for agent pods in e2e tests if this slowdown is deemed to be driven by overly strict CPU limits (Related: #9064)

Relates https://github.com/elastic/eck-diagnostics/issues/369