### PR TITLE
Ensure eck-package-registry stack chart is disabled by default

### DIFF
--- a/deploy/eck-stack/values.yaml
+++ b/deploy/eck-stack/values.yaml
@@ -53,3 +53,8 @@ eck-enterprise-search:
 #
 eck-autoops-agent-policy:
   enabled: false
+
+# If enabled, will use the eck-package-registry chart and deploy a Package Registry resource.
+#
+eck-package-registry:
+  enabled: false


### PR DESCRIPTION
While testing another issue, I found that the eck-package-registry eck-stack Helm chart is being installed by default when installing using the `eck-stack` chart itself:

```
# Can be replicated with the following command:
❯ helm upgrade -i eck-stack . -n elastic-stack --create-namespace -f deploy/eck-stack/examples/apm-server/basic.yaml

❯ kc get pod -n elastic-stack
NAME                                                  READY   STATUS    RESTARTS   AGE
eck-stack-eck-package-registry-epr-865cb758f4-np7bj   1/1     Running   0          6m58s
elasticsearch-es-default-0                            1/1     Running   0          6m58s
elasticsearch-es-default-1                            1/1     Running   0          6m58s
elasticsearch-es-default-2                            1/1     Running   0          6m58s
kibana-kb-7b684467fd-68tff                            1/1     Running   0          6m57s
```

This adds the stanza to disable it by default, same as all of the other eck-stack charts.