### PR TITLE
[3.3] Ensure eck-package-registry stack chart is disabled by default (#9067)

### DIFF
--- a/deploy/eck-stack/values.yaml
+++ b/deploy/eck-stack/values.yaml
@@ -53,3 +53,8 @@ eck-enterprise-search:
 #
 eck-autoops-agent-policy:
   enabled: false
+
+# If enabled, will use the eck-package-registry chart and deploy a Package Registry resource.
+#
+eck-package-registry:
+  enabled: false


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.3`:
 - [Ensure eck-package-registry stack chart is disabled by default (#9067)](https://github.com/elastic/cloud-on-k8s/pull/9067)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)