### PR TITLE
Garbage collect Agent soft-owned secrets on deletion

### DIFF
--- a/pkg/controller/agent/controller_test.go
+++ b/pkg/controller/agent/controller_test.go
@@ -7,7 +7,6 @@ package agent
 import (
 	"context"
 	"reflect"
-	"slices"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -364,7 +363,7 @@ func TestReconcileAgent_OnDelete_GarbageCollectsSoftOwnedSecrets(t *testing.T) {
 			require.NoError(t, err)
 
 			remainingNames := make([]string, 0, len(secrets.Items))
-			for s := range slices.Values(secrets.Items) {
+			for _, s := range secrets.Items {
 				remainingNames = append(remainingNames, s.Name)
 			}
 


### PR DESCRIPTION
## Summary
Fleet Server HTTP public certificate secrets were not being cleaned up when the corresponding Agent CRD was deleted. This occurred because soft-owned secrets are not automatically garbage collected by Kubernetes (unlike hard-owned resources with `ownerReferences`). This PR adds explicit garbage collection of soft-owned secrets in the Agent controller's `onDelete` handler, following the same pattern already used by other controllers (Elasticsearch, Kibana, Beat, Logstash, etc.).

## Changes
- Call `reconciler.GarbageCollectSoftOwnedSecrets` when an Agent is deleted or marked for deletion
- Add tests to verify soft-owned secrets are properly garbage collected

Fixes #9037