### PR TITLE
renovate: add postUpgradeTasks for `make generate` and disable automerge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -60,7 +60,6 @@
         "digest"
       ],
       "enabled": true,
-      "automerge": true,
       "postUpdateOptions": [
         "gomodTidy"
       ],
@@ -74,7 +73,6 @@
         "major"
       ],
       "enabled": true,
-      "automerge": false,
       "postUpdateOptions": [
         "gomodTidy"
       ],
@@ -89,7 +87,6 @@
         "pin"
       ],
       "enabled": true,
-      "automerge": true,
       "postUpdateOptions": [
         "gomodTidy"
       ],
@@ -132,7 +129,5 @@
       "groupName": "go"
     }
   ],
-  "automergeStrategy": "squash",
-  "automergeType": "branch",
   "separateMajorMinor": true
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,6 +8,12 @@
   "schedule": [
     "after 1am on monday"
   ],
+  "postUpgradeTasks": {
+    "commands": [
+      "make generate"
+    ],
+    "executionMode": "branch"
+  },
   "packageRules": [
     {
       "groupName": "k8s",


### PR DESCRIPTION
## Summary
  This PR improves the Renovate configuration by:
  1. Adding `postUpgradeTasks` to automatically run `make generate` after dependency updates
  2. Disabling automerge to align with security best practices for public repositories
  ## Problem
  Currently, some Renovate PRs require manual intervention because:
  - After Renovate updates dependencies, `make generate` needs to be run to regenerate derived files (NOTICE.txt, API docs, CRD manifests, etc.)
  - CI fails with "dirty local changes" if these files aren't committed
  - A human must checkout the branch, run `make generate`, and push the changes
  ## Solution
  ### 1. `postUpgradeTasks` for automatic file generation
  Configure Renovate to run `make generate` after dependency updates via `postUpgradeTasks`. This ensures PRs arrive with all derived files already regenerated and CI
   passing.
  **Note:**  `make generate` is already supported in the Renovate runner configuration ([elastic/renovate-workflows-base#66](https://github.com/elastic/renovate-workflows-base/pull/66)) but we could run into stuff like missing specific env vars or similar on the Renovate runner container.

  ### 2. Disable automerge
  Remove all automerge settings (`automerge`, `automergeType`, `automergeStrategy`). This aligns with how other Elastic open-source repositories handle Renovate:
  - **elastic/kibana**: No automerge configured, requires human review for all dependency updates
  - **elastic/elasticsearch**: No automerge configured, dependencies disabled by default with explicit opt-in
  #### Why automerge is disabled
  With the introduction of `postUpgradeTasks`, Renovate now executes `make generate` which invokes various tools during the dependency update process:
  - `go mod tidy` / `go mod download`
  - `controller-gen` for CRD generation
  - `go run` for config extraction
  - Third-party tools like `go-licence-detector` and `crd-ref-docs`
  
If a compromised dependency contains malicious code, that code could execute during these build steps. With automerge enabled, any files modified during this execution would be automatically committed and merged without human review. Disabling automerge ensures a human reviews the changes before they are merged, providing an opportunity to detect unexpected modifications.

  ## Future Considerations
  If we want to explore automerging Renovate PRs in the future, the recommended approach would be to introduce a GitHub Action that:
  1. Triggers on Renovate PRs (`pull_request_target` for security)
  2. Verifies the PR author is the Renovate bot
  3. Applies additional checks (e.g., only specific file paths changed, no executable code modified)
  4. Auto-approves and merges if all criteria pass

This is similar to the pattern used in `elastic/kibana`, which has separate auto-approve workflows for specific trusted scenarios (backports, API docs, bundled packages) rather than blanket automerge through Renovate itself. This approach provides more granular control and auditability compared to Renovate's built-in automerge.

## Changes
  - Add `postUpgradeTasks` with `make generate` command
  - Remove `automerge: true` from package rules
  - Remove `automergeStrategy` and `automergeType` global settings