### PR TITLE
[3.3] [deployer]: fix macos local kind execution (#9031)

### DIFF
--- a/hack/deployer/clients/kind/Dockerfile
+++ b/hack/deployer/clients/kind/Dockerfile
@@ -1,7 +1,7 @@
-FROM buildpack-deps:bullseye-curl as builder
+FROM buildpack-deps:bullseye-curl AS builder
 
 ARG CLIENT_VERSION
-ENV DOCKER_VERSION=24.0.6
+ENV DOCKER_VERSION=25.0.5
 
 # Docker client to build and push images
 RUN curl -fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz && \


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.3`:
 - [[deployer]: fix macos local kind execution (#9031)](https://github.com/elastic/cloud-on-k8s/pull/9031)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)