### PR TITLE
fix GKE cluster deletion failing when cluster operations are in progress

### DIFF
--- a/hack/deployer/runner/gke.go
+++ b/hack/deployer/runner/gke.go
@@ -426,8 +426,7 @@ func (d *GKEDriver) waitForClusterOperations() error {
 func (d *GKEDriver) delete() error {
 	// Retry deletion up to 3 times to handle transient failures. GKE cluster deletion can fail
 	// due to race conditions where new operations start between our check and delete attempt,
-	// or due to temporary API errors. A 30-second delay between retries allows time for
-	// short-lived operations to complete.
+	// or due to temporary API errors.
 	const maxDeleteAttempts = 3
 	var lastErr error
 


### PR DESCRIPTION
## Summary
  Fixes GKE cluster deletion failures in CI when cluster operations are in progress.
  - Add `waitForClusterOperations()` to wait for running operations (auto-upgrades, auto-repairs, node pool modifications) to complete before deletion
  - Add retry logic (up to 3 attempts with 30s delay) to handle race conditions and transient API errors
  ## Problem
  Cluster deletion was failing with:

```
  ERROR: (gcloud.beta.container.clusters.delete) Some requests did not succeed:
  - ResponseError: code=400, message=Cluster is running incompatible operation operation-...
```