### PR TITLE
Refactor `docker.elastic.co/eck-ci/deployer-kind` Dockerfile

### DIFF
--- a/hack/deployer/clients/kind/Dockerfile
+++ b/hack/deployer/clients/kind/Dockerfile
@@ -1,17 +1,14 @@
 FROM buildpack-deps:bullseye-curl AS builder
 
 ARG CLIENT_VERSION
-ENV DOCKER_VERSION=25.0.5
 
-# Docker client to build and push images
-RUN curl -fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz && \
-    tar xzf docker-${DOCKER_VERSION}.tgz --strip 1 -C /usr/local/bin docker/docker && \
-    rm docker-${DOCKER_VERSION}.tgz
 # Kind to run k8s cluster locally in Docker
 RUN curl -fsSLO https://github.com/kubernetes-sigs/kind/releases/download/v${CLIENT_VERSION}/kind-linux-amd64 && \
     mv kind-linux-amd64 /usr/local/bin/kind && chmod +x /usr/local/bin/kind
 
-FROM scratch
+FROM docker:28.5.2-cli
 
-COPY --from=builder /usr/local/bin/kind .
-COPY --from=builder /usr/local/bin/docker .
+COPY --from=builder /usr/local/bin/kind /usr/local/bin/kind
+
+ENTRYPOINT []
+CMD []

--- a/hack/deployer/runner/kind.go
+++ b/hack/deployer/runner/kind.go
@@ -219,9 +219,8 @@ func (k *KindDriver) cmd(args ...string) *exec.Command {
 		-v {{.SharedVolume}}:/home \
 		-v /var/run/docker.sock:` + k.dockerSocket + ` \
 		-e HOME=/home \
-		-e PATH=/ \
 		{{.KindClientImage}} \
-		/kind {{Join .Args " "}} --name {{.ClusterName}}`)
+		kind {{Join .Args " "}} --name {{.ClusterName}}`)
 	return cmd.AsTemplate(params)
 }
 


### PR DESCRIPTION
Refactor docker.elastic.co/eck-ci/deployer-kind Dockerfile:

  * Use the official [docker](https://hub.docker.com/_/docker) cli image to benefit from renovate updates.
  
