### PR TITLE
[3.3] Fix operatorhub preflight step

### DIFF
--- a/.buildkite/scripts/release/redhat-preflight.sh
+++ b/.buildkite/scripts/release/redhat-preflight.sh
@@ -35,7 +35,7 @@ main() {
 
     vault read -format=json -field=data "$VAULT_ROOT_PATH/operatorhub-release-preflight" > "$tmpDir/auth.json"
     
-    preflight check container "quay.io/redhat-isv-containers/$PROJECT_ID:$ECK_VERSION" --pyxis-api-token="$API_KEY" --certification-project-id="$PROJECT_ID" --submit -d "$tmpDir/auth.json"
+    preflight check container "quay.io/redhat-isv-containers/$PROJECT_ID:$ECK_VERSION" --pyxis-api-token="$API_KEY" --certification-component-id="$PROJECT_ID" --submit -d "$tmpDir/auth.json"
     
     echo "Preflight submitted ✅"
 }


### PR DESCRIPTION
# Overview

Operatorhub release - preflight step is broken with the latest update to the preflight version, as they have introduced a breaking change changing `--certification-project-id` to `--certification-component-id`.

https://buildkite.com/elastic/cloud-on-k8s-operator-redhat-release/builds/193/steps/canvas?sid=019c2500-b755-4cb8-8bfa-32152bbba15e

```
$ ./.buildkite/scripts/release/redhat-preflight.sh
Error: unknown flag: --certification-project-id
Usage:
  preflight check container [flags]
Examples:
  preflight check container quay.io/repo-name/container-name:version
Flags:
      --certification-component-id string   Certification component ID from connect.redhat.com/component/view/{certification-component-id}/images
                                            URL paramater. This value may differ from the component PID on the overview page. (env: PFLT_CERTIFICATION_COMPONENT_ID)
  -h, --help                                help for container
      --insecure                            Use insecure protocol for the registry. Default is False. Cannot be used with submit.
      --offline                             Intended to be used in disconnected environments and will tar artifacts used for submission,
                                            enabling other Red Hat managed tools/process to submit these artifacts at a later time.
                                            Cannot be used with submit.
      --platform string                     Architecture of image to pull. Defaults to runtime platform. (default "amd64")
      --pyxis-api-token string              API token for Pyxis authentication (env: PFLT_PYXIS_API_TOKEN)
      --pyxis-env string                    Env to use for Pyxis submissions. (default "prod")
      --pyxis-host string                   Host to use for Pyxis submissions. This will override Pyxis Env. Only set this if you know what you are doing.
                                            If you do set it, it should include just the host, and the URI path. (env: PFLT_PYXIS_HOST)
  -s, --submit                              submit check container results to Red Hat
Global Flags:
      --artifacts string       Where check-specific artifacts will be written. (env: PFLT_ARTIFACTS)
      --config string          A preflight config file. The default is config.yaml (env: PFLT_CONFIG)
  -d, --docker-config string   Path to docker config.json file. This value is optional for publicly accessible images.
                               However, it is strongly encouraged for public Docker Hub images,
                               due to the rate limit imposed for unauthenticated requests. (env: PFLT_DOCKERCONFIG)
      --logfile string         Where the execution logfile will be written. (env: PFLT_LOGFILE)
      --loglevel string        The verbosity of the preflight tool itself. Ex. warn, debug, trace, info, error. (env: PFLT_LOGLEVEL)
2026/02/03 19:39:13 unknown flag: --certification-project-id
🚨 Error: The command exited with status 1
user command error: exit status 1
```