### PR TITLE
[3.3] Fix operatorhub preflight step (#9100)

### DIFF
--- a/.buildkite/scripts/release/redhat-preflight.sh
+++ b/.buildkite/scripts/release/redhat-preflight.sh
@@ -35,7 +35,7 @@ main() {
 
     vault read -format=json -field=data "$VAULT_ROOT_PATH/operatorhub-release-preflight" > "$tmpDir/auth.json"
     
-    preflight check container "quay.io/redhat-isv-containers/$PROJECT_ID:$ECK_VERSION" --pyxis-api-token="$API_KEY" --certification-project-id="$PROJECT_ID" --submit -d "$tmpDir/auth.json"
+    preflight check container "quay.io/redhat-isv-containers/$PROJECT_ID:$ECK_VERSION" --pyxis-api-token="$API_KEY" --certification-component-id="$PROJECT_ID" --submit -d "$tmpDir/auth.json"
     
     echo "Preflight submitted ✅"
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.3`:
 - [Fix operatorhub preflight step (#9100)](https://github.com/elastic/cloud-on-k8s/pull/9100)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)