### PR TITLE
fix the codeowners file pattern

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@elastic/cloud-k8s-operator
+* @elastic/cloud-k8s-operator


### PR DESCRIPTION
the Codeowners file did not have the correct format, so PRs were not being assigned to the team properly.
