### PR TITLE
Optimize memory usage of clone operation in operatorhub tool

### DIFF
--- a/hack/operatorhub/internal/github/github.go
+++ b/hack/operatorhub/internal/github/github.go
@@ -204,7 +204,7 @@ func (c *Client) cloneAndCreate(repo githubRepository) error {
 	}
 	log.Println("✓")
 
-	err = c.syncFork(orgRepo, r, remote)
+	err = c.syncFork(r)
 	if err != nil {
 		return fmt.Errorf("while syncing fork with upstream: %w", err)
 	}
@@ -233,6 +233,7 @@ func (c *Client) cloneAndCreate(repo githubRepository) error {
 	err = w.Checkout(&git.CheckoutOptions{
 		Branch: plumbing.NewBranchReferenceName(branchName),
 		Create: true,
+		Force:  true, // allow checkout with dirty worktree (e.g. after shallow clone)
 	})
 	if err != nil {
 		log.Println("ⅹ")


### PR DESCRIPTION
See: https://buildkite.com/elastic/cloud-on-k8s-operator-redhat-release/builds/196/annotations?sid=019c256b-6ff8-4a7f-af4f-7c1976837193. We are using all memory assigned to the agent during the operatorhub release operation, and causing an OOM.

The clone operations for the 2x repositories we work with are consuming a large amount of ram. There are multiples issues [1](https://github.com/go-git/go-git/issues/1673) [2](https://github.com/go-git/go-git/issues/315) concerning this, and there was some recent [work](https://github.com/go-git/go-git/pull/1776) done to optimize this, but they specifically mention performing some optimizations to the `git clone` operation. This path was attempted, but it did little to change memory utilization. Moving to the `git` binary did make a large difference.

## testing 

The initial testing with optimizations was done locally to finish the 3.3 release and seems to at least minimally reduce the memory usage, but certainly reduces the amount of data transferred.

The subsequent testing using `git` binary showed about 50% memory decrease (4GB->2GB).