### PR TITLE
Rework CA comparison in Test_buildCAFromSecret to prevent flakiness

### DIFF
--- a/pkg/controller/common/certificates/ca_reconcile_test.go
+++ b/pkg/controller/common/certificates/ca_reconcile_test.go
@@ -149,7 +149,7 @@ func Test_canReuseCA(t *testing.T) {
 func privateKeysEqual(t *testing.T, actual, expected crypto.Signer) {
 	t.Helper()
 	if reflect.TypeOf(actual) != reflect.TypeOf(expected) {
-		t.Errorf("unexpected RSA private key, got %T, want %T", actual, expected)
+		t.Fatalf("unexpected RSA private key, got %T, want %T", actual, expected)
 	}
 	switch epk := expected.(type) {
 	case *rsa.PrivateKey:
@@ -157,7 +157,7 @@ func privateKeysEqual(t *testing.T, actual, expected crypto.Signer) {
 	case *ecdsa.PrivateKey:
 		require.True(t, epk.Equal(actual), "private keys should match")
 	default:
-		t.Errorf("unexpected RSA private key, got %T, want %T", actual, expected)
+		t.Fatalf("unexpected RSA private key, got %T, want %T", actual, expected)
 	}
 }
 

--- a/pkg/controller/common/certificates/ca_reconcile_test.go
+++ b/pkg/controller/common/certificates/ca_reconcile_test.go
@@ -153,9 +153,9 @@ func privateKeysEqual(t *testing.T, actual, expected crypto.Signer) {
 	}
 	switch epk := expected.(type) {
 	case *rsa.PrivateKey:
-		require.True(t, epk.Equal(expected))
+		require.True(t, epk.Equal(actual), "private keys should match")
 	case *ecdsa.PrivateKey:
-		require.True(t, epk.Equal(expected))
+		require.True(t, epk.Equal(actual), "private keys should match")
 	default:
 		t.Errorf("unexpected RSA private key, got %T, want %T", actual, expected)
 	}
@@ -413,9 +413,9 @@ func Test_buildCAFromSecret(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ca := BuildCAFromSecret(context.Background(), tt.internalSecret)
 			if tt.wantCa == nil {
-				assert.Nil(t, ca)
+				require.Nil(t, ca)
 			} else {
-				assert.NotNil(t, ca)
+				require.NotNil(t, ca)
 				assert.True(t, ca.Cert.Equal(tt.wantCa.Cert), "certificates should be equal")
 				privateKeysEqual(t, ca.PrivateKey, tt.wantCa.PrivateKey)
 			}

--- a/pkg/controller/common/certificates/ca_reconcile_test.go
+++ b/pkg/controller/common/certificates/ca_reconcile_test.go
@@ -412,8 +412,12 @@ func Test_buildCAFromSecret(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ca := BuildCAFromSecret(context.Background(), tt.internalSecret)
-			if !reflect.DeepEqual(ca, tt.wantCa) {
-				t.Errorf("CaFromSecrets() got = %v, want %v", ca, tt.wantCa)
+			if tt.wantCa == nil {
+				assert.Nil(t, ca)
+			} else {
+				assert.NotNil(t, ca)
+				assert.True(t, ca.Cert.Equal(tt.wantCa.Cert), "certificates should be equal")
+				privateKeysEqual(t, ca.PrivateKey, tt.wantCa.PrivateKey)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
`Test_buildCAFromSecret` was flaky (~1% failure rate - I did run this 100 times) because it used `reflect.DeepEqual` to compare CA structs after PEM serialization/deserialization.

### Root Cause
The `rsa.PrecomputedValues` struct contains an unexported [`fips` pointer field](https://github.com/golang/go/blob/master/src/crypto/rsa/rsa.go#L219) to internal FIPS-related state. When a key is generated vs parsed from PEM, this internal state can differ. These differences are irrelevant for cryptographic equality but cause `reflect.DeepEqual` to return false (as happened in this [recent CI run](https://buildkite.com/elastic/cloud-on-k8s-operator/builds/13084))

### Fix
  Replace `reflect.DeepEqual` with proper value comparison:
  - `cert.Equal()` for certificate comparison
  - `privateKeysEqual()` helper for private key comparison
  These methods compare the actual cryptographic values rather than internal struct pointers.

  Fixes #8758