### PR TITLE
[CI] Create fixed size volumes

### DIFF
--- a/hack/deployer/config/local-disks-aks/aks-pv-size-patch.yaml
+++ b/hack/deployer/config/local-disks-aks/aks-pv-size-patch.yaml
@@ -1,0 +1,15 @@
+# AKS: fewer, larger PVs (6×10 GiB) so we fit on the temp disk without over-provisioning.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: local-volume-provisioner
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: disk-mounts
+          env:
+            - name: PV_SIZE_GB
+              value: "10"
+            - name: PV_COUNT
+              value: "6"

--- a/hack/deployer/config/local-disks-aks/aks-pv-size-patch.yaml
+++ b/hack/deployer/config/local-disks-aks/aks-pv-size-patch.yaml
@@ -1,4 +1,4 @@
-# AKS: fewer, larger PVs (6×10 GiB) so we fit on the temp disk without over-provisioning.
+# AKS: fewer PVs (6×10 GiB) so we fit on the temp disk without over-provisioning.
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/hack/deployer/config/local-disks-aks/kustomization.yaml
+++ b/hack/deployer/config/local-disks-aks/kustomization.yaml
@@ -1,0 +1,10 @@
+# AKS: same as local-disks (non-AWS patch) plus smaller PV_SIZE_GB for AKS temp disk.
+resources:
+  - ../local-disks
+patches:
+  - target:
+      group: apps
+      version: v1
+      kind: DaemonSet
+      name: local-volume-provisioner
+    path: aks-pv-size-patch.yaml

--- a/hack/deployer/config/local-disks/ssd-provisioner.yaml
+++ b/hack/deployer/config/local-disks/ssd-provisioner.yaml
@@ -83,6 +83,11 @@ data:
     set -e
     PV_SIZE_GB="${PV_SIZE_GB:-11}"
     PV_COUNT="${PV_COUNT:-10}"
+    loop=""
+    # On mkfs or mount failure (set -e), detach the current loop device so a DaemonSet pod restart
+    # does not see a stale attachment. We set loop= before each losetup; the trap runs when a
+    # command fails (shell ERR) and runs losetup -d on that device if it is still a block device.
+    trap 'if [ -n "$loop" ] && [ -b "$loop" ]; then losetup -d "$loop" 2>/dev/null || true; fi' ERR
     # When format.sh is skipped (GKE/AKS kustomize overlay), ssd0 does not exist; pvs is created by the loop.
     mkdir -p /mnt/disks/ssd0
     for i in $(seq 1 $PV_COUNT); do

--- a/hack/deployer/config/local-disks/ssd-provisioner.yaml
+++ b/hack/deployer/config/local-disks/ssd-provisioner.yaml
@@ -155,7 +155,6 @@ spec:
         - |
           apk update \
             && apk add e2fsprogs losetup mount util-linux \
-            && apk --purge del apk-tools wolfi-base \
             && /bin/entrypoint.sh
         env:
         - name: PV_SIZE_GB

--- a/hack/deployer/config/local-disks/ssd-provisioner.yaml
+++ b/hack/deployer/config/local-disks/ssd-provisioner.yaml
@@ -77,9 +77,14 @@ data:
     # free (e.g. 110Gi for default 10x11Gi). No runtime check is performed; use instance types
     # with sufficient NVMe capacity (e.g. c5d.2xlarge has 200GB).
     # PV_SIZE_GB is the backing file size; usable space is ~10Gi after ext4 metadata (default 11G).
+    # IMPORTANT: truncate creates sparse files: they report size PV_SIZE_GB but do not allocate that much
+    # on disk upfront. Actual disk usage grows only as data is written (via the loop-mounted
+    # ext4). So e.g. 10×11G can fit on a 64G volume (e.g. Azure temp disk) until usage grows.
     set -e
     PV_SIZE_GB="${PV_SIZE_GB:-11}"
     PV_COUNT="${PV_COUNT:-10}"
+    # When format.sh is skipped (GKE/AKS kustomize overlay), ssd0 does not exist; pvs is created by the loop.
+    mkdir -p /mnt/disks/ssd0
     for i in $(seq 1 $PV_COUNT); do
       img="/mnt/disks/ssd0/disk-$i.img"
       mount_point="/mnt/disks/pvs/pv-$i"

--- a/hack/deployer/config/local-disks/ssd-provisioner.yaml
+++ b/hack/deployer/config/local-disks/ssd-provisioner.yaml
@@ -100,10 +100,12 @@ data:
         loop=$(losetup -f --show "${img}")
         echo "Formatting ${loop} as ext4"
         mkfs.ext4 -m 0 -F "${loop}"
+        # Flush ext4 superblock to the backing file before detach so the kernel sees it on reattach.
+        sync
         losetup -d "${loop}"
       fi
       loop=$(losetup -f --show "${img}")
-      mount -o defaults,noatime,nobarrier "${loop}" "${mount_point}"
+      mount -t ext4 -o defaults,noatime,nobarrier "${loop}" "${mount_point}"
       echo "Mounted ${loop} at ${mount_point}"
     done
 ---
@@ -139,13 +141,17 @@ spec:
             name: e2e-default
             mountPropagation: Bidirectional
       - name: disk-mounts
-        image: alpine:3.22
+        image: cgr.dev/chainguard/wolfi-base:latest
         securityContext:
           privileged: true
         command:
         - sh
         - -c
-        - "apk add --no-cache e2fsprogs util-linux && /bin/entrypoint.sh"
+        - |
+          apk update \
+            && apk add e2fsprogs losetup mount util-linux \
+            && apk --purge del apk-tools wolfi-base \
+            && /bin/entrypoint.sh
         env:
         - name: PV_SIZE_GB
           value: "11"

--- a/hack/deployer/config/local-disks/ssd-provisioner.yaml
+++ b/hack/deployer/config/local-disks/ssd-provisioner.yaml
@@ -71,18 +71,35 @@ data:
     echo "NVMe SSD provisioning is done"
   entrypoint.sh: |-
     #!/bin/sh
-    for i in $(seq 1 10);
-    do
-    disk_name="/mnt/disks/ssd0/disk-$i"
-    mount_point="/mnt/disks/pvs/pv-$i"
-    echo "Creating pv-$i"
-    mkdir -p "${disk_name}" "${mount_point}"
-    if mountpoint -q -- "${mount_point}"; then
-      echo "${mount_point} already mounted"
-    else
-      echo "Binding ${disk_name} to ${mount_point}"
-      mount --bind "${disk_name}" "${mount_point}"
-    fi
+    # Each PV is a fixed-size (default 10Gi) loop-backed ext4 filesystem so that df (and thus
+    # "remaining space" as seen by Pods) reflects the constraint, not the whole disk.
+    # Requires the first NVMe instance store device to have at least (PV_COUNT * PV_SIZE_GB) GiB
+    # free (e.g. 110Gi for default 10x11Gi). No runtime check is performed; use instance types
+    # with sufficient NVMe capacity (e.g. c5d.2xlarge has 200GB).
+    # PV_SIZE_GB is the backing file size; usable space is ~10Gi after ext4 metadata (default 11G).
+    set -e
+    PV_SIZE_GB="${PV_SIZE_GB:-11}"
+    PV_COUNT="${PV_COUNT:-10}"
+    for i in $(seq 1 $PV_COUNT); do
+      img="/mnt/disks/ssd0/disk-$i.img"
+      mount_point="/mnt/disks/pvs/pv-$i"
+      echo "Setting up pv-$i (${PV_SIZE_GB}Gi per PV)"
+      mkdir -p "${mount_point}"
+      if mountpoint -q -- "${mount_point}"; then
+        echo "${mount_point} already mounted"
+        continue
+      fi
+      if [ ! -f "${img}" ]; then
+        echo "Creating sparse file ${img} size ${PV_SIZE_GB}G"
+        truncate -s "${PV_SIZE_GB}G" "${img}"
+        loop=$(losetup -f --show "${img}")
+        echo "Formatting ${loop} as ext4"
+        mkfs.ext4 -m 0 -F "${loop}"
+        losetup -d "${loop}"
+      fi
+      loop=$(losetup -f --show "${img}")
+      mount -o defaults,noatime,nobarrier "${loop}" "${mount_point}"
+      echo "Mounted ${loop} at ${mount_point}"
     done
 ---
 apiVersion: apps/v1
@@ -117,18 +134,27 @@ spec:
             name: e2e-default
             mountPropagation: Bidirectional
       - name: disk-mounts
-        image: busybox
+        image: alpine:3.22
         securityContext:
           privileged: true
         command:
-        - "/bin/entrypoint.sh"
+        - sh
+        - -c
+        - "apk add --no-cache e2fsprogs util-linux && /bin/entrypoint.sh"
+        env:
+        - name: PV_SIZE_GB
+          value: "11"
+        - name: PV_COUNT
+          value: "10"
         volumeMounts:
           - mountPath: /bin/entrypoint.sh
             name: setup-disks
             subPath: entrypoint.sh
-          - mountPath:  /mnt/disks
+          - mountPath: /mnt/disks
             name: e2e-default
             mountPropagation: Bidirectional
+          - mountPath: /dev
+            name: host-dev
       containers:
         - image: "k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0"
           imagePullPolicy: "Always"
@@ -161,6 +187,10 @@ spec:
           configMap:
             defaultMode: 0700
             name: setup-disks
+        - name: host-dev
+          hostPath:
+            path: /dev
+            type: Directory
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -73,7 +73,8 @@ plans:
   machineType: Standard_D8s_v3
   serviceAccount: true
   enforceSecurityPolicies: true
-  diskSetup: kubectl apply -k hack/deployer/config/local-disks
+  # AKS overlay: local-disks tuned for AKS temp disk.
+  diskSetup: kubectl apply -k hack/deployer/config/local-disks-aks
   aks:
     nodeCount: 3
     location: westeurope


### PR DESCRIPTION
# Create fixed-size local volumes for local SSD provisioner

## Summary

Updates the local SSD provisioner so that each PersistentVolume is backed by its own **fixed-size** storage instead of sharing one filesystem. Each PV is now a loop-backed ext4 filesystem with a configurable size (default 11Gi per PV, 10 PVs).

This provisioner is used by the deployer for **EKS** (full manifest with NVMe formatting), **GKE**, and **AKS** (same manifest via kustomize, with the AWS NVMe init container removed). The fixed-size volume behaviour applies in all environments.

## Motivation

We need volumes that **expose their real size** to the workload, not volumes that all sit on the same filesystem and therefore report the same total capacity as the underlying disk.

**Elasticsearch stateless** sizes its cache based on the **observed capacity** of the volume. When multiple PVCs share one filesystem, they all see the full disk size, so ES would over-allocate cache. With fixed-size volumes, each PV reports only its own capacity (e.g. ~10Gi), so Elasticsearch can correctly size its cache per volume.

## What changed

- **Before:** Subdirectories under `/mnt/disks/ssd0` were bind-mounted to `/mnt/disks/pvs/pv-*`. All PVs shared the same filesystem, so `df` showed the full NVMe device size for every mount.
- **After:** Each PV is backed by a sparse file (`disk-$i.img`) on the first NVMe device, formatted as ext4 and mounted via a loop device. `df` on each PV shows only that PV's size (configurable via `PV_SIZE_GB`, default 11G; usable ~10Gi after ext4 metadata).

Config:

- `PV_SIZE_GB` – size of each backing file in GiB (default: 11).
- `PV_COUNT` – number of PVs to create (default: 10).

On EKS (where the NVMe init container runs), the first instance store device must have at least `PV_COUNT * PV_SIZE_GB` GiB (e.g. 110Gi for defaults). Use instance types with enough NVMe capacity (e.g. `c5d.2xlarge` has 200GB). On GKE and AKS, the platform provides the backing disk; the kustomize overlay omits the NVMe formatting step.

## Testing

- [x] EKS ✅ 
- [x] GKE ✅ 
- [x] AKS ✅  