### PR TITLE
[3.3.1-wip] Remove AutoOps enterprise check. (#9125)

### DIFF
--- a/deploy/eck-stack/charts/eck-autoops-agent-policy/templates/autoopsagentpolicy.yaml
+++ b/deploy/eck-stack/charts/eck-autoops-agent-policy/templates/autoopsagentpolicy.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "autoops.labels" . | nindent 4 }}
   annotations:
-    eck.k8s.elastic.co/license: enterprise
     {{- with .Values.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/pkg/controller/autoops/controller.go
+++ b/pkg/controller/autoops/controller.go
@@ -27,7 +27,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common"
 	commonesclient "github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/esclient"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/events"
-	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/license"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/operator"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/tracing"
@@ -58,7 +57,6 @@ func newReconciler(mgr manager.Manager, accessReviewer rbac.AccessReviewer, para
 		Client:           k8sClient,
 		accessReviewer:   accessReviewer,
 		recorder:         mgr.GetEventRecorderFor(controllerName),
-		licenseChecker:   license.NewLicenseChecker(k8sClient, params.OperatorNamespace),
 		params:           params,
 		dynamicWatches:   watches.NewDynamicWatches(),
 		esClientProvider: commonesclient.NewClient,
@@ -127,7 +125,6 @@ type AgentPolicyReconciler struct {
 	k8s.Client
 	accessReviewer   rbac.AccessReviewer
 	recorder         record.EventRecorder
-	licenseChecker   license.Checker
 	params           operator.Parameters
 	dynamicWatches   watches.DynamicWatches
 	esClientProvider commonesclient.Provider

--- a/pkg/controller/autoops/reconcile.go
+++ b/pkg/controller/autoops/reconcile.go
@@ -7,7 +7,6 @@ package autoops
 import (
 	"context"
 	"fmt"
-	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -33,18 +32,6 @@ func (r *AgentPolicyReconciler) doReconcile(ctx context.Context, policy autoopsv
 	log.V(1).Info("Reconcile AutoOpsAgentPolicy")
 
 	results := reconciler.NewResult(ctx)
-
-	// Enterprise license check
-	enabled, err := r.licenseChecker.EnterpriseFeaturesEnabled(ctx)
-	if err != nil {
-		return results.WithError(err)
-	}
-	if !enabled {
-		msg := "AutoOpsAgentPolicy is an enterprise feature. Enterprise features are disabled"
-		log.Info(msg)
-		state.UpdateInvalidPhaseWithEvent(msg)
-		return results.WithRequeue(5 * time.Minute)
-	}
 
 	// run validation in case the webhook is disabled
 	if err := r.validate(ctx, &policy); err != nil {

--- a/pkg/controller/autoops/reconcile_test.go
+++ b/pkg/controller/autoops/reconcile_test.go
@@ -26,7 +26,6 @@ import (
 	esv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/elasticsearch/v1"
 	commonapikey "github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/apikey"
 	commonesclient "github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/esclient"
-	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/license"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/operator"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/scheme"
@@ -630,7 +629,6 @@ func TestAutoOpsAgentPolicyReconciler_internalReconcile(t *testing.T) {
 					Dialer: &fakeDialer{},
 				},
 				dynamicWatches: watches.NewDynamicWatches(),
-				licenseChecker: license.NewLicenseChecker(k8sClient, "test-namespace"),
 			}
 
 			ctx := context.Background()
@@ -777,7 +775,6 @@ func TestAutoOpsAgentPolicyReconciler_selectorChangeCleanup(t *testing.T) {
 					Dialer: &fakeDialer{},
 				},
 				dynamicWatches: watches.NewDynamicWatches(),
-				licenseChecker: license.NewLicenseChecker(k8sClient, "test-namespace"),
 			}
 
 			ctx := context.Background()
@@ -970,7 +967,6 @@ func TestAutoOpsAgentPolicyReconciler_accessRevokedCleanup(t *testing.T) {
 				Dialer: &fakeDialer{},
 			},
 			dynamicWatches: watches.NewDynamicWatches(),
-			licenseChecker: license.NewLicenseChecker(k8sClient, "test-namespace"),
 		}
 
 		ctx := context.Background()

--- a/test/e2e/autoops/autoops_test.go
+++ b/test/e2e/autoops/autoops_test.go
@@ -18,13 +18,6 @@ import (
 )
 
 func TestAutoOpsAgentPolicy(t *testing.T) {
-	// https://github.com/elastic/cloud-on-k8s/issues/9027
-	t.Skip("Skipping AutoOpsAgentPolicy test")
-
-	// only execute this test if we have a test license to work with
-	if test.Ctx().TestLicense == "" {
-		t.SkipNow()
-	}
 
 	// only execute this test with supported AutoOps versions
 	v := version.MustParse(test.Ctx().ElasticStackVersion)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.3.1-wip`:
 - [Remove AutoOps enterprise check. (#9125)](https://github.com/elastic/cloud-on-k8s/pull/9125)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)