### PR TITLE
remove LicenseTestBuilder from autoops e2e test

### DIFF
--- a/test/e2e/autoops/autoops_test.go
+++ b/test/e2e/autoops/autoops_test.go
@@ -37,8 +37,6 @@ func TestAutoOpsAgentPolicy(t *testing.T) {
 		WithVersion(test.Ctx().ElasticStackVersion).
 		WithLabel("autoops", "enabled")
 
-	es1Withlicense := test.LicenseTestBuilder(es1Builder)
-
 	// 2nd elasticsearch cluster that should be omitted from autoops based on namespace
 	es2Builder := elasticsearch.NewBuilder("ex-es").
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources).
@@ -61,6 +59,6 @@ func TestAutoOpsAgentPolicy(t *testing.T) {
 	}).WithCloudConnectedAPIURL(mockURL).
 		WithAutoOpsOTelURL(mockURL)
 
-	test.Sequence(nil, test.EmptySteps, es1Withlicense, es2Builder, policyBuilder).
+	test.Sequence(nil, test.EmptySteps, es1Builder, es2Builder, policyBuilder).
 		RunSequential(t)
 }


### PR DESCRIPTION
  ## Summary
  Commit cf5a19814 ("Remove AutoOps enterprise check") removed the enterprise license requirement from the AutoOps controller and removed the `TestLicense == ""` skip  guard from `TestAutoOpsAgentPolicy`, but left the `LicenseTestBuilder` wrapper around the ES builder in the e2e test.

On `eks-arm`, the CI matrix explicitly sets `TEST_LICENSE: ""` (due to https://github.com/elastic/elasticsearch/issues/68083). This means `Ctx().TestLicense` is an empty string, and `LicenseTestBuilder` calls `os.ReadFile("")` which fails with:
```
  open : no such file or directory
```

Since AutoOps no longer requires an enterprise license, the e2e test doesn't need `LicenseTestBuilder` anymore. This PR removes it and passes the ES builder directly to `test.Sequence`.