### PR TITLE
[3.3.1-wip] Add wiremock for ccm API and renable auto ops e2e tests (#9033)

### DIFF
--- a/test/e2e/autoops/autoops_test.go
+++ b/test/e2e/autoops/autoops_test.go
@@ -18,11 +18,16 @@ import (
 )
 
 func TestAutoOpsAgentPolicy(t *testing.T) {
+	// only execute this test if we have a test license to work with
+	if test.Ctx().TestLicense == "" {
+		t.Skip("Skipping test: no test license provided")
+	}
 
 	// only execute this test with supported AutoOps versions
 	v := version.MustParse(test.Ctx().ElasticStackVersion)
 	if v.LT(version.SupportedAutoOpsAgentVersions.Min) {
-		t.SkipNow()
+		t.Skipf("Skipping test: Elastic Stack version %s is below minimum supported version %s",
+			test.Ctx().ElasticStackVersion, version.SupportedAutoOpsAgentVersions.Min)
 	}
 
 	// Use separate namespaces for ES and policy
@@ -45,6 +50,8 @@ func TestAutoOpsAgentPolicy(t *testing.T) {
 		WithVersion(test.Ctx().ElasticStackVersion).
 		WithLabel("autoops", "enabled")
 
+	// Create the policy builder with the mock URL for cloud-connected API and OTel
+	mockURL := autoops.CloudConnectedAPIMockURL()
 	policyBuilder := autoops.NewBuilder("autoops-policy").
 		WithNamespace(policyNamespace).
 		WithResourceSelector(metav1.LabelSelector{
@@ -55,7 +62,8 @@ func TestAutoOpsAgentPolicy(t *testing.T) {
 		MatchLabels: map[string]string{
 			"kubernetes.io/metadata.name": esNamespace,
 		},
-	})
+	}).WithCloudConnectedAPIURL(mockURL).
+		WithAutoOpsOTelURL(mockURL)
 
 	test.Sequence(nil, test.EmptySteps, es1Withlicense, es2Builder, policyBuilder).
 		RunSequential(t)

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -64,6 +64,7 @@ func doRun(flags runFlags) error {
 			helper.createScratchDir,
 			helper.initTestContext,
 			helper.installCRDs,
+			helper.createE2ENamespaceAndRoleBindings,
 			helper.createRoles,
 			helper.createManagedNamespaces,
 			helper.deploySecurityConstraints,

--- a/test/e2e/test/autoops/builder.go
+++ b/test/e2e/test/autoops/builder.go
@@ -106,6 +106,26 @@ func (b Builder) WithNamespaceSelector(selector metav1.LabelSelector) Builder {
 	return b
 }
 
+// WithCloudConnectedAPIURL sets the cloud-connected-mode-api-url in the config secret.
+// This is used to point to the wiremock service for e2e testing.
+func (b Builder) WithCloudConnectedAPIURL(url string) Builder {
+	if b.ConfigSecret.StringData == nil {
+		b.ConfigSecret.StringData = make(map[string]string)
+	}
+	b.ConfigSecret.StringData["cloud-connected-mode-api-url"] = url
+	return b
+}
+
+// WithAutoOpsOTelURL sets the autoops-otel-url in the config secret.
+// This is used to point to the wiremock service for e2e testing.
+func (b Builder) WithAutoOpsOTelURL(url string) Builder {
+	if b.ConfigSecret.StringData == nil {
+		b.ConfigSecret.StringData = make(map[string]string)
+	}
+	b.ConfigSecret.StringData["autoops-otel-url"] = url
+	return b
+}
+
 func (b Builder) RuntimeObjects() []k8sclient.Object {
 	return []k8sclient.Object{
 		&b.ConfigSecret,

--- a/test/e2e/test/autoops/cloud_connected_api_mock.go
+++ b/test/e2e/test/autoops/cloud_connected_api_mock.go
@@ -1,0 +1,160 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package autoops
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	_ "embed"
+	"fmt"
+	"text/template"
+
+	"github.com/Masterminds/sprig/v3"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test"
+	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test/helper"
+)
+
+// cloudConnectedAPIMockTemplate is the embedded YAML template for the Cloud Connected API mock.
+
+//go:embed cloud_connected_api_mock.yaml
+var cloudConnectedAPIMockTemplate string
+
+// cloudConnectedAPIMockName returns the name for Cloud Connected API mock resources based on the test run name.
+func cloudConnectedAPIMockName() string {
+	return fmt.Sprintf("wiremock-%s", test.Ctx().TestRun)
+}
+
+// cloudConnectedAPIMockSelectorLabels returns the selector labels for Cloud Connected API mock resources.
+func cloudConnectedAPIMockSelectorLabels() map[string]string {
+	return map[string]string{
+		"app.kubernetes.io/name":     "wiremock-cloud-connected-api",
+		"app.kubernetes.io/instance": cloudConnectedAPIMockName(),
+	}
+}
+
+// CloudConnectedAPIMockURL returns the URL for the Cloud Connected API mock service.
+func CloudConnectedAPIMockURL() string {
+	return fmt.Sprintf("http://%s.%s.svc.cluster.local:8080", cloudConnectedAPIMockName(), test.Ctx().E2ENamespace)
+}
+
+// deployCloudConnectedAPIMock deploys the mock service for Cloud Connected API using the YAML template.
+func deployCloudConnectedAPIMock(k *test.K8sClient) error {
+	ctx := context.Background()
+
+	// Render the template
+	objects, err := renderCloudConnectedAPIMockTemplate()
+	if err != nil {
+		return fmt.Errorf("failed to render Cloud Connected API mock template: %w", err)
+	}
+
+	if len(objects) == 0 {
+		return fmt.Errorf("no objects rendered from template")
+	}
+
+	// Create or update each object
+	for i, obj := range objects {
+		if err := k.CreateOrUpdate(obj); err != nil {
+			return fmt.Errorf("failed to create/update object %d (%T, %s/%s): %w", i, obj, obj.GetNamespace(), obj.GetName(), err)
+		}
+	}
+
+	// Wait for deployment to be ready
+	return waitForCloudConnectedAPIMockReady(ctx, k, test.Ctx().E2ENamespace)
+}
+
+// deleteCloudConnectedAPIMock deletes all Cloud Connected API mock resources.
+func deleteCloudConnectedAPIMock(k *test.K8sClient) error {
+	ctx := context.Background()
+	namespace := test.Ctx().E2ENamespace
+	name := cloudConnectedAPIMockName()
+
+	// Delete Service
+	svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}
+	if err := k.Client.Delete(ctx, svc); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	// Delete Deployment
+	deploy := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}
+	if err := k.Client.Delete(ctx, deploy); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	// Delete ConfigMaps
+	mappingsCM := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: name + "-mappings", Namespace: namespace}}
+	if err := k.Client.Delete(ctx, mappingsCM); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	filesCM := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: name + "-files", Namespace: namespace}}
+	if err := k.Client.Delete(ctx, filesCM); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	return nil
+}
+
+// renderCloudConnectedAPIMockTemplate renders the embedded YAML template with test context values.
+func renderCloudConnectedAPIMockTemplate() ([]k8sclient.Object, error) {
+	// Parse and execute the embedded template
+	tmpl, err := template.New("cloud-connected-api-mock").Funcs(sprig.TxtFuncMap()).Parse(cloudConnectedAPIMockTemplate)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse template: %w", err)
+	}
+
+	var rendered bytes.Buffer
+	if err := tmpl.Execute(&rendered, test.Ctx()); err != nil {
+		return nil, fmt.Errorf("failed to execute template: %w", err)
+	}
+
+	// Decode the YAML into Kubernetes objects using helper.YAMLDecoder
+	decoder := helper.NewYAMLDecoder()
+	runtimeObjects, err := decoder.ToObjects(bufio.NewReader(&rendered))
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode YAML: %w", err)
+	}
+
+	// Convert runtime.Object to client.Object
+	objects := make([]k8sclient.Object, 0, len(runtimeObjects))
+	for _, obj := range runtimeObjects {
+		clientObj, ok := obj.(k8sclient.Object)
+		if !ok {
+			return nil, fmt.Errorf("object %T does not implement client.Object", obj)
+		}
+		objects = append(objects, clientObj)
+	}
+
+	return objects, nil
+}
+
+func waitForCloudConnectedAPIMockReady(ctx context.Context, k *test.K8sClient, namespace string) error {
+	var pods corev1.PodList
+	if err := k.Client.List(ctx, &pods,
+		k8sclient.InNamespace(namespace),
+		k8sclient.MatchingLabels(cloudConnectedAPIMockSelectorLabels()),
+	); err != nil {
+		return err
+	}
+
+	if len(pods.Items) == 0 {
+		return fmt.Errorf("no Cloud Connected API mock pods found")
+	}
+
+	for _, pod := range pods.Items {
+		if !k8s.IsPodReady(pod) {
+			return fmt.Errorf("cloud connected API mock pod %s not ready", pod.Name)
+		}
+	}
+
+	return nil
+}

--- a/test/e2e/test/autoops/cloud_connected_api_mock.yaml
+++ b/test/e2e/test/autoops/cloud_connected_api_mock.yaml
@@ -1,0 +1,273 @@
+---
+# Cloud Connected API Mock for E2E tests
+# This file contains all resources needed to deploy WireMock as a mock for the Cloud Connected API
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: wiremock-{{ .TestRun }}-mappings
+  namespace: {{ .E2ENamespace }}
+  labels:
+    app.kubernetes.io/name: wiremock-cloud-connected-api
+    app.kubernetes.io/instance: wiremock-{{ .TestRun }}
+data:
+  # Create Cluster API - Success (201)
+  create-cluster-success.json: |
+    {
+      "priority": 1,
+      "request": {
+        "method": "POST",
+        "urlPathPattern": "/api/v1/cloud-connected/clusters",
+        "bodyPatterns": [
+          {
+            "matchesJsonPath": "$.self_managed_cluster"
+          },
+          {
+            "matchesJsonPath": "$.license"
+          }
+        ]
+      },
+      "response": {
+        "status": 201,
+        "headers": {
+          "Content-Type": "application/json",
+          "ETag": "\"{{ "{{randomValue type='UUID'}}" }}\""
+        },
+        "transformers": ["response-template"],
+        "bodyFileName": "create-cluster-response.json"
+      }
+    }
+
+  # Create Cluster API - Bad Request (400) - Missing self_managed_cluster
+  create-cluster-bad-request.json: |
+    {
+      "priority": 3,
+      "request": {
+        "method": "POST",
+        "urlPathPattern": "/api/v1/cloud-connected/clusters",
+        "bodyPatterns": [
+          {
+            "doesNotMatch": ".*self_managed_cluster.*"
+          }
+        ]
+      },
+      "response": {
+        "status": 400,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "jsonBody": {
+          "errors": [
+            {
+              "message": "Missing required field: self_managed_cluster",
+              "code": "validation.required_field_missing"
+            }
+          ]
+        }
+      }
+    }
+
+  # Create Cluster API - Bad Request (400) - Missing license
+  create-cluster-missing-license.json: |
+    {
+      "priority": 3,
+      "request": {
+        "method": "POST",
+        "urlPathPattern": "/api/v1/cloud-connected/clusters",
+        "bodyPatterns": [
+          {
+            "matchesJsonPath": "$.self_managed_cluster"
+          },
+          {
+            "doesNotMatch": ".*\"license\".*"
+          }
+        ]
+      },
+      "response": {
+        "status": 400,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "jsonBody": {
+          "errors": [
+            {
+              "message": "Missing required field: license",
+              "code": "validation.required_field_missing"
+            }
+          ]
+        }
+      }
+    }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: wiremock-{{ .TestRun }}-files
+  namespace: {{ .E2ENamespace }}
+  labels:
+    app.kubernetes.io/name: wiremock-cloud-connected-api
+    app.kubernetes.io/instance: wiremock-{{ .TestRun }}
+data:
+  # Response body for create cluster (201)
+  create-cluster-response.json: |
+    {
+      "id": "{{ "{{randomValue length=32 type='ALPHANUMERIC' lowercase=true}}" }}",
+      "name": "{{ "{{jsonPath request.body '$.name' default='My Cloud Connected Cluster'}}" }}",
+      "metadata": {
+        "created_at": "{{ "{{now format=\"yyyy-MM-dd'T'HH:mm:ss.SSSXXX\"}}" }}",
+        "created_by": "1014289666002276",
+        "organization_id": "198583657190"
+      },
+      "self_managed_cluster": {
+        "id": "{{ "{{jsonPath request.body '$.self_managed_cluster.id'}}" }}",
+        "name": "{{ "{{jsonPath request.body '$.self_managed_cluster.name'}}" }}",
+        "version": "{{ "{{jsonPath request.body '$.self_managed_cluster.version'}}" }}"
+      },
+      "license": {
+        "type": "{{ "{{jsonPath request.body '$.license.type'}}" }}",
+        "uid": "{{ "{{jsonPath request.body '$.license.uid'}}" }}"
+      },
+      "services": {
+        "auto_ops": {
+          "enabled": false,
+          "support": {
+            "supported": true,
+            "valid_license_types": ["platinum", "enterprise"],
+            "minimum_stack_version": "9.2.0"
+          },
+          "config": {
+            "region_id": "aws-us-east-1"
+          },
+          "metadata": {
+            "documentation_url": "https://www.elastic.co/docs/deploy-manage/monitor/autoops/cc-autoops-as-cloud-connected",
+            "connect_url": "https://application.auto-ops.cloud.elastic.co/organizations/198583657190/connect-autoops"
+          },
+          "subscription": {
+            "required": false
+          }
+        },
+        "eis": {
+          "enabled": false,
+          "support": {
+            "supported": true,
+            "valid_license_types": ["platinum", "enterprise"],
+            "minimum_stack_version": "9.2.0"
+          },
+          "metadata": {
+            "documentation_url": "https://www.elastic.co"
+          },
+          "subscription": {
+            "required": true
+          }
+        }
+      },
+      "key": "VXNlci1JRDoxMjM0NTY3ODkwYWJjZGVmMTIzNDU2Nzg5MGFiY2RlZg=="
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wiremock-{{ .TestRun }}
+  namespace: {{ .E2ENamespace }}
+  labels:
+    app.kubernetes.io/name: wiremock-cloud-connected-api
+    app.kubernetes.io/instance: wiremock-{{ .TestRun }}
+    app.kubernetes.io/component: mock-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: wiremock-cloud-connected-api
+      app.kubernetes.io/instance: wiremock-{{ .TestRun }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: wiremock-cloud-connected-api
+        app.kubernetes.io/instance: wiremock-{{ .TestRun }}
+        app.kubernetes.io/component: mock-service
+      annotations:
+        checksum/mappings: "{{ .TestRun }}-mappings"
+        checksum/files: "{{ .TestRun }}-files"
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+{{- if not .OcpCluster }}
+        runAsUser: 1000
+{{- end }}
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: wiremock
+          image: "wiremock/wiremock:3.3.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: JAVA_OPTS
+              value: "-Xms32m -Xmx64m -XX:+UseSerialGC -XX:MaxMetaspaceSize=32m"
+          args:
+            - "--port=8080"
+            - "--global-response-templating"
+            - "--max-request-journal-entries=20"
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /__admin/health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /__admin/health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            limits:
+              memory: 128Mi
+            requests:
+              cpu: "50m"
+              memory: 64Mi
+          volumeMounts:
+            - name: mappings
+              mountPath: /home/wiremock/mappings
+              readOnly: true
+            - name: files
+              mountPath: /home/wiremock/__files
+              readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+      volumes:
+        - name: mappings
+          configMap:
+            name: wiremock-{{ .TestRun }}-mappings
+        - name: files
+          configMap:
+            name: wiremock-{{ .TestRun }}-files
+      terminationGracePeriodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: wiremock-{{ .TestRun }}
+  namespace: {{ .E2ENamespace }}
+  labels:
+    app.kubernetes.io/name: wiremock-cloud-connected-api
+    app.kubernetes.io/instance: wiremock-{{ .TestRun }}
+    app.kubernetes.io/component: mock-service
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: wiremock-cloud-connected-api
+    app.kubernetes.io/instance: wiremock-{{ .TestRun }}
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8080
+      targetPort: http

--- a/test/e2e/test/autoops/steps.go
+++ b/test/e2e/test/autoops/steps.go
@@ -34,6 +34,12 @@ func (b Builder) InitTestSteps(k *test.K8sClient) test.StepList {
 			}),
 		},
 		{
+			Name: "Deploy Cloud Connected API mock",
+			Test: test.Eventually(func() error {
+				return deployCloudConnectedAPIMock(k)
+			}),
+		},
+		{
 			Name: "Label test pods",
 			Test: test.Eventually(func() error {
 				return test.LabelTestPods(
@@ -300,6 +306,12 @@ func (b Builder) DeletionTestSteps(k *test.K8sClient) test.StepList {
 					return err
 				}
 				return nil
+			}),
+		}).
+		WithStep(test.Step{
+			Name: "Deleting Cloud Connected API mock should succeed",
+			Test: test.Eventually(func() error {
+				return deleteCloudConnectedAPIMock(k)
 			}),
 		})
 }

--- a/test/e2e/test/helper/yaml.go
+++ b/test/e2e/test/helper/yaml.go
@@ -72,7 +72,9 @@ func NewYAMLDecoder() *YAMLDecoder {
 	scheme.AddKnownTypes(rbacv1.SchemeGroupVersion, &rbacv1.ClusterRole{}, &rbacv1.ClusterRoleList{})
 	scheme.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.ServiceAccount{}, &corev1.ServiceAccountList{})
 	scheme.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.Service{}, &corev1.ServiceList{})
+	scheme.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.ConfigMap{}, &corev1.ConfigMapList{})
 	scheme.AddKnownTypes(appsv1.SchemeGroupVersion, &appsv1.DaemonSet{})
+	scheme.AddKnownTypes(appsv1.SchemeGroupVersion, &appsv1.Deployment{}, &appsv1.DeploymentList{})
 	scheme.AddKnownTypes(packageregistryv1alpha1.GroupVersion, &packageregistryv1alpha1.PackageRegistry{}, &packageregistryv1alpha1.PackageRegistryList{})
 
 	// Register ComputeClass types for Autopilot recipes.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.3.1-wip`:
 - [Add wiremock for ccm API and renable auto ops e2e tests (#9033)](https://github.com/elastic/cloud-on-k8s/pull/9033)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)