### PR TITLE
[3.3.1-wip] remove LicenseTestBuilder from autoops e2e test (#9125 follow-up) (#9131)

### DIFF
--- a/test/e2e/autoops/autoops_test.go
+++ b/test/e2e/autoops/autoops_test.go
@@ -18,11 +18,6 @@ import (
 )
 
 func TestAutoOpsAgentPolicy(t *testing.T) {
-	// only execute this test if we have a test license to work with
-	if test.Ctx().TestLicense == "" {
-		t.Skip("Skipping test: no test license provided")
-	}
-
 	// only execute this test with supported AutoOps versions
 	v := version.MustParse(test.Ctx().ElasticStackVersion)
 	if v.LT(version.SupportedAutoOpsAgentVersions.Min) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.3.1-wip`:
 - [remove LicenseTestBuilder from autoops e2e test (#9125 follow-up) (#9131)](https://github.com/elastic/cloud-on-k8s/pull/9131)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)