### PR TITLE
Change compile-time interface checks to `(*T)(nil)`

### DIFF
--- a/hack/deployer/runner/k3d.go
+++ b/hack/deployer/runner/k3d.go
@@ -33,7 +33,7 @@ func init() {
 
 type K3dDriverFactory struct{}
 
-var _ DriverFactory = &K3dDriverFactory{}
+var _ DriverFactory = (*K3dDriverFactory)(nil)
 
 func (k K3dDriverFactory) Create(plan Plan) (Driver, error) {
 	dockerSocket, err := getDockerSocket()
@@ -196,4 +196,4 @@ func (k *K3dDriver) Cleanup(string, time.Duration) error {
 	return fmt.Errorf("unimplemented")
 }
 
-var _ Driver = &K3dDriver{}
+var _ Driver = (*K3dDriver)(nil)

--- a/hack/deployer/runner/kind.go
+++ b/hack/deployer/runner/kind.go
@@ -66,7 +66,7 @@ func init() {
 
 type KindDriverFactory struct{}
 
-var _ DriverFactory = &KindDriverFactory{}
+var _ DriverFactory = (*KindDriverFactory)(nil)
 
 func (k KindDriverFactory) Create(plan Plan) (Driver, error) {
 	dockerSocket, err := getDockerSocket()
@@ -285,4 +285,4 @@ func (k *KindDriver) Cleanup(string, time.Duration) error {
 	return fmt.Errorf("unimplemented")
 }
 
-var _ Driver = &KindDriver{}
+var _ Driver = (*KindDriver)(nil)

--- a/pkg/apis/agent/v1alpha1/agent_types.go
+++ b/pkg/apis/agent/v1alpha1/agent_types.go
@@ -259,7 +259,7 @@ type Agent struct {
 
 // +kubebuilder:object:root=true
 
-var _ commonv1.Associated = &Agent{}
+var _ commonv1.Associated = (*Agent)(nil)
 
 var FleetServerServiceAccountMinVersion = semver.MustParse("7.17.0")
 
@@ -360,7 +360,7 @@ type AgentESAssociation struct {
 	ref commonv1.ObjectSelector
 }
 
-var _ commonv1.Association = &AgentESAssociation{}
+var _ commonv1.Association = (*AgentESAssociation)(nil)
 
 func (aea *AgentESAssociation) ElasticServiceAccount() (commonv1.ServiceAccountName, error) {
 	if !aea.Spec.FleetServerEnabled {
@@ -423,7 +423,7 @@ type AgentKibanaAssociation struct {
 	*Agent
 }
 
-var _ commonv1.Association = &AgentKibanaAssociation{}
+var _ commonv1.Association = (*AgentKibanaAssociation)(nil)
 
 func (a *AgentKibanaAssociation) ElasticServiceAccount() (commonv1.ServiceAccountName, error) {
 	return "", nil
@@ -471,7 +471,7 @@ type AgentFleetServerAssociation struct {
 	*Agent
 }
 
-var _ commonv1.Association = &AgentFleetServerAssociation{}
+var _ commonv1.Association = (*AgentFleetServerAssociation)(nil)
 
 func (a *AgentFleetServerAssociation) ElasticServiceAccount() (commonv1.ServiceAccountName, error) {
 	return "", nil
@@ -515,7 +515,7 @@ func (a *AgentFleetServerAssociation) AssociationID() string {
 	return commonv1.SingletonAssociationID
 }
 
-var _ commonv1.Associated = &Agent{}
+var _ commonv1.Associated = (*Agent)(nil)
 
 // +kubebuilder:object:root=true
 

--- a/pkg/apis/agent/v1alpha1/webhook.go
+++ b/pkg/apis/agent/v1alpha1/webhook.go
@@ -31,7 +31,7 @@ var (
 
 // +kubebuilder:webhook:path=/validate-agent-k8s-elastic-co-v1alpha1-agent,mutating=false,failurePolicy=ignore,groups=agent.k8s.elastic.co,resources=agents,verbs=create;update,versions=v1alpha1,name=elastic-agent-validation-v1alpha1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1,matchPolicy=Exact
 
-var _ admission.Validator = &Agent{}
+var _ admission.Validator = (*Agent)(nil)
 
 func (a *Agent) warnings() []string {
 	if a == nil {

--- a/pkg/apis/apm/v1/apmserver_types.go
+++ b/pkg/apis/apm/v1/apmserver_types.go
@@ -210,7 +210,7 @@ type ApmEsAssociation struct {
 	*ApmServer
 }
 
-var _ commonv1.Association = &ApmEsAssociation{}
+var _ commonv1.Association = (*ApmEsAssociation)(nil)
 
 func NewApmEsAssociation(as *ApmServer) *ApmEsAssociation {
 	return &ApmEsAssociation{ApmServer: as}
@@ -254,7 +254,7 @@ func (aes *ApmEsAssociation) AssociationID() string {
 	return commonv1.SingletonAssociationID
 }
 
-var _ commonv1.Association = &ApmKibanaAssociation{}
+var _ commonv1.Association = (*ApmKibanaAssociation)(nil)
 
 // ApmServer / Kibana association helper
 type ApmKibanaAssociation struct {
@@ -307,4 +307,4 @@ func (akb *ApmKibanaAssociation) AssociationID() string {
 	return commonv1.SingletonAssociationID
 }
 
-var _ commonv1.Associated = &ApmServer{}
+var _ commonv1.Associated = (*ApmServer)(nil)

--- a/pkg/apis/apm/v1/webhook.go
+++ b/pkg/apis/apm/v1/webhook.go
@@ -46,7 +46,7 @@ var (
 
 // +kubebuilder:webhook:path=/validate-apm-k8s-elastic-co-v1-apmserver,mutating=false,failurePolicy=ignore,groups=apm.k8s.elastic.co,resources=apmservers,verbs=create;update,versions=v1,name=elastic-apm-validation-v1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1,matchPolicy=Exact
 
-var _ admission.Validator = &ApmServer{}
+var _ admission.Validator = (*ApmServer)(nil)
 
 // ValidateCreate is called by the validating webhook to validate the create operation.
 // Satisfies the webhook.Validator interface.

--- a/pkg/apis/apm/v1beta1/webhook.go
+++ b/pkg/apis/apm/v1beta1/webhook.go
@@ -40,7 +40,7 @@ var (
 
 // +kubebuilder:webhook:path=/validate-apm-k8s-elastic-co-v1beta1-apmserver,mutating=false,failurePolicy=ignore,groups=apm.k8s.elastic.co,resources=apmservers,verbs=create;update,versions=v1beta1,name=elastic-apm-validation-v1beta1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1,matchPolicy=Exact
 
-var _ admission.Validator = &ApmServer{}
+var _ admission.Validator = (*ApmServer)(nil)
 
 // ValidateCreate is called by the validating webhook to validate the create operation.
 // Satisfies the webhook.Validator interface.

--- a/pkg/apis/autoops/v1alpha1/webhook.go
+++ b/pkg/apis/autoops/v1alpha1/webhook.go
@@ -34,7 +34,7 @@ var (
 
 // +kubebuilder:webhook:path=/validate-autoops-k8s-elastic-co-v1alpha1-autoopsagentpolicies,mutating=false,failurePolicy=ignore,groups=autoops.k8s.elastic.co,resources=autoopsagentpolicies,verbs=create;update,versions=v1alpha1,name=elastic-autoops-validation-v1alpha1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1,matchPolicy=Exact
 
-var _ admission.Validator = &AutoOpsAgentPolicy{}
+var _ admission.Validator = (*AutoOpsAgentPolicy)(nil)
 
 // ValidateCreate is called by the validating webhook to validate the create operation.
 // Satisfies the webhook.Validator interface.

--- a/pkg/apis/autoscaling/v1alpha1/elasticsearch_types.go
+++ b/pkg/apis/autoscaling/v1alpha1/elasticsearch_types.go
@@ -34,7 +34,7 @@ type ElasticsearchAutoscaler struct {
 	Status v1alpha1.ElasticsearchAutoscalerStatus `json:"status,omitempty"`
 }
 
-var _ v1alpha1.AutoscalingResource = &ElasticsearchAutoscaler{}
+var _ v1alpha1.AutoscalingResource = (*ElasticsearchAutoscaler)(nil)
 
 // ElasticsearchAutoscalerSpec holds the specification of an Elasticsearch autoscaler resource.
 type ElasticsearchAutoscalerSpec struct {

--- a/pkg/apis/beat/v1beta1/beat_types.go
+++ b/pkg/apis/beat/v1beta1/beat_types.go
@@ -218,7 +218,7 @@ func (b *Beat) SetAssociationStatusMap(typ commonv1.AssociationType, status comm
 	}
 }
 
-var _ commonv1.Associated = &Beat{}
+var _ commonv1.Associated = (*Beat)(nil)
 
 func (b *Beat) ElasticServiceAccount() (commonv1.ServiceAccountName, error) {
 	return "", nil
@@ -285,7 +285,7 @@ type BeatESAssociation struct {
 	*Beat
 }
 
-var _ commonv1.Association = &BeatESAssociation{}
+var _ commonv1.Association = (*BeatESAssociation)(nil)
 
 func (b *BeatESAssociation) Associated() commonv1.Associated {
 	if b == nil {
@@ -329,7 +329,7 @@ type BeatKibanaAssociation struct {
 	*Beat
 }
 
-var _ commonv1.Association = &BeatKibanaAssociation{}
+var _ commonv1.Association = (*BeatKibanaAssociation)(nil)
 
 func (b *BeatKibanaAssociation) AssociationConf() (*commonv1.AssociationConf, error) {
 	return commonv1.GetAndSetAssociationConf(b, b.kbAssocConf)
@@ -373,7 +373,7 @@ func (b *Beat) SecureSettings() []commonv1.SecretSource {
 	return b.Spec.SecureSettings
 }
 
-var _ commonv1.Associated = &Beat{}
+var _ commonv1.Associated = (*Beat)(nil)
 
 // +kubebuilder:object:root=true
 
@@ -398,7 +398,7 @@ type BeatMonitoringAssociation struct {
 	ref commonv1.ObjectSelector
 }
 
-var _ commonv1.Association = &BeatMonitoringAssociation{}
+var _ commonv1.Association = (*BeatMonitoringAssociation)(nil)
 
 func (beatmon *BeatMonitoringAssociation) ElasticServiceAccount() (commonv1.ServiceAccountName, error) {
 	return "", nil

--- a/pkg/apis/beat/v1beta1/webhook.go
+++ b/pkg/apis/beat/v1beta1/webhook.go
@@ -28,7 +28,7 @@ var (
 
 // +kubebuilder:webhook:path=/validate-beat-k8s-elastic-co-v1beta1-beat,mutating=false,failurePolicy=ignore,groups=beat.k8s.elastic.co,resources=beats,verbs=create;update,versions=v1beta1,name=elastic-beat-validation-v1beta1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1,matchPolicy=Exact
 
-var _ admission.Validator = &Beat{}
+var _ admission.Validator = (*Beat)(nil)
 
 // ValidateCreate is called by the validating webhook to validate the create operation.
 // Satisfies the webhook.Validator interface.

--- a/pkg/apis/elasticsearch/v1/elasticsearch_types.go
+++ b/pkg/apis/elasticsearch/v1/elasticsearch_types.go
@@ -522,7 +522,7 @@ func setFromAnnotations(annotationKey string, annotations map[string]string) set
 
 // -- associations
 
-var _ commonv1.Associated = &Elasticsearch{}
+var _ commonv1.Associated = (*Elasticsearch)(nil)
 
 func (es *Elasticsearch) GetAssociations() []commonv1.Association {
 	associations := make([]commonv1.Association, 0)
@@ -555,7 +555,7 @@ type EsMonitoringAssociation struct {
 	ref commonv1.ObjectSelector
 }
 
-var _ commonv1.Association = &EsMonitoringAssociation{}
+var _ commonv1.Association = (*EsMonitoringAssociation)(nil)
 
 func (ema *EsMonitoringAssociation) Associated() commonv1.Associated {
 	if ema == nil {

--- a/pkg/apis/elasticsearch/v1beta1/webhook.go
+++ b/pkg/apis/elasticsearch/v1beta1/webhook.go
@@ -25,7 +25,7 @@ const (
 
 var eslog = ulog.Log.WithName("es-validation")
 
-var _ admission.Validator = &Elasticsearch{}
+var _ admission.Validator = (*Elasticsearch)(nil)
 
 // ValidateCreate is called by the validating webhook to validate the create operation.
 // Satisfies the webhook.Validator interface.

--- a/pkg/apis/enterprisesearch/v1/enterprisesearch_types.go
+++ b/pkg/apis/enterprisesearch/v1/enterprisesearch_types.go
@@ -165,8 +165,8 @@ func (ent *EnterpriseSearch) AssociationStatusMap(typ commonv1.AssociationType) 
 	return commonv1.AssociationStatusMap{}
 }
 
-var _ commonv1.Associated = &EnterpriseSearch{}
-var _ commonv1.Association = &EnterpriseSearch{}
+var _ commonv1.Associated = (*EnterpriseSearch)(nil)
+var _ commonv1.Association = (*EnterpriseSearch)(nil)
 
 // GetObservedGeneration will return the observedGeneration from the EnterpriseSearch's status.
 func (ent *EnterpriseSearch) GetObservedGeneration() int64 {

--- a/pkg/apis/enterprisesearch/v1/webhook.go
+++ b/pkg/apis/enterprisesearch/v1/webhook.go
@@ -41,7 +41,7 @@ var (
 
 // +kubebuilder:webhook:path=/validate-enterprisesearch-k8s-elastic-co-v1-enterprisesearch,mutating=false,failurePolicy=ignore,groups=enterprisesearch.k8s.elastic.co,resources=enterprisesearches,verbs=create;update,versions=v1,name=elastic-ent-validation-v1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1,matchPolicy=Exact
 
-var _ admission.Validator = &EnterpriseSearch{}
+var _ admission.Validator = (*EnterpriseSearch)(nil)
 
 // ValidateCreate is called by the validating webhook to validate the create operation.
 // Satisfies the webhook.Validator interface.

--- a/pkg/apis/enterprisesearch/v1beta1/enterprisesearch_types.go
+++ b/pkg/apis/enterprisesearch/v1beta1/enterprisesearch_types.go
@@ -149,8 +149,8 @@ func (ent *EnterpriseSearch) AssociationStatusMap(typ commonv1.AssociationType) 
 	return commonv1.AssociationStatusMap{}
 }
 
-var _ commonv1.Associated = &EnterpriseSearch{}
-var _ commonv1.Association = &EnterpriseSearch{}
+var _ commonv1.Associated = (*EnterpriseSearch)(nil)
+var _ commonv1.Association = (*EnterpriseSearch)(nil)
 
 // +kubebuilder:object:root=true
 

--- a/pkg/apis/enterprisesearch/v1beta1/webhook.go
+++ b/pkg/apis/enterprisesearch/v1beta1/webhook.go
@@ -40,7 +40,7 @@ var (
 
 // +kubebuilder:webhook:path=/validate-enterprisesearch-k8s-elastic-co-v1beta1-enterprisesearch,mutating=false,failurePolicy=ignore,groups=enterprisesearch.k8s.elastic.co,resources=enterprisesearches,verbs=create;update,versions=v1beta1,name=elastic-ent-validation-v1beta1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1,matchPolicy=Exact
 
-var _ admission.Validator = &EnterpriseSearch{}
+var _ admission.Validator = (*EnterpriseSearch)(nil)
 
 // ValidateCreate is called by the validating webhook to validate the create operation.
 // Satisfies the webhook.Validator interface.

--- a/pkg/apis/kibana/v1/kibana_types.go
+++ b/pkg/apis/kibana/v1/kibana_types.go
@@ -160,7 +160,7 @@ var KibanaServiceAccountMinVersion = semver.MustParse("7.17.0")
 
 // -- associations
 
-var _ commonv1.Associated = &Kibana{}
+var _ commonv1.Associated = (*Kibana)(nil)
 
 func (k *Kibana) Associated() commonv1.Associated {
 	return k
@@ -284,7 +284,7 @@ type KibanaEsAssociation struct {
 	*Kibana
 }
 
-var _ commonv1.Association = &KibanaEsAssociation{}
+var _ commonv1.Association = (*KibanaEsAssociation)(nil)
 
 func (kbes *KibanaEsAssociation) ElasticServiceAccount() (commonv1.ServiceAccountName, error) {
 	v, err := version.Parse(kbes.Spec.Version)
@@ -346,7 +346,7 @@ type KibanaEntAssociation struct {
 	*Kibana
 }
 
-var _ commonv1.Association = &KibanaEntAssociation{}
+var _ commonv1.Association = (*KibanaEntAssociation)(nil)
 
 func (kbent *KibanaEntAssociation) ElasticServiceAccount() (commonv1.ServiceAccountName, error) {
 	return "", nil
@@ -400,7 +400,7 @@ type KbMonitoringAssociation struct {
 	ref commonv1.ObjectSelector
 }
 
-var _ commonv1.Association = &KbMonitoringAssociation{}
+var _ commonv1.Association = (*KbMonitoringAssociation)(nil)
 
 func (kbmon *KbMonitoringAssociation) ElasticServiceAccount() (commonv1.ServiceAccountName, error) {
 	return "", nil
@@ -460,7 +460,7 @@ type KibanaEPRAssociation struct {
 	*Kibana
 }
 
-var _ commonv1.Association = &KibanaEPRAssociation{}
+var _ commonv1.Association = (*KibanaEPRAssociation)(nil)
 
 func (kbepr *KibanaEPRAssociation) ElasticServiceAccount() (commonv1.ServiceAccountName, error) {
 	return "", nil

--- a/pkg/apis/kibana/v1/webhook.go
+++ b/pkg/apis/kibana/v1/webhook.go
@@ -45,7 +45,7 @@ var (
 
 // +kubebuilder:webhook:path=/validate-kibana-k8s-elastic-co-v1-kibana,mutating=false,failurePolicy=ignore,groups=kibana.k8s.elastic.co,resources=kibanas,verbs=create;update,versions=v1,name=elastic-kb-validation-v1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1,matchPolicy=Exact
 
-var _ admission.Validator = &Kibana{}
+var _ admission.Validator = (*Kibana)(nil)
 
 // ValidateCreate is called by the validating webhook to validate the create operation.
 // Satisfies the webhook.Validator interface.

--- a/pkg/apis/kibana/v1beta1/webhook.go
+++ b/pkg/apis/kibana/v1beta1/webhook.go
@@ -40,7 +40,7 @@ var (
 
 // +kubebuilder:webhook:path=/validate-kibana-k8s-elastic-co-v1beta1-kibana,mutating=false,failurePolicy=ignore,groups=kibana.k8s.elastic.co,resources=kibanas,verbs=create;update,versions=v1beta1,name=elastic-kb-validation-v1beta1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1,matchPolicy=Exact
 
-var _ admission.Validator = &Kibana{}
+var _ admission.Validator = (*Kibana)(nil)
 
 // ValidateCreate is called by the validating webhook to validate the create operation.
 // Satisfies the webhook.Validator interface.

--- a/pkg/apis/logstash/v1alpha1/logstash_types.go
+++ b/pkg/apis/logstash/v1alpha1/logstash_types.go
@@ -297,7 +297,7 @@ type LogstashESAssociation struct {
 	ElasticsearchCluster
 }
 
-var _ commonv1.Association = &LogstashESAssociation{}
+var _ commonv1.Association = (*LogstashESAssociation)(nil)
 
 func (lses *LogstashESAssociation) ElasticServiceAccount() (commonv1.ServiceAccountName, error) {
 	return "", nil
@@ -353,7 +353,7 @@ type LogstashMonitoringAssociation struct {
 	ref commonv1.ObjectSelector
 }
 
-var _ commonv1.Association = &LogstashMonitoringAssociation{}
+var _ commonv1.Association = (*LogstashMonitoringAssociation)(nil)
 
 func (lsmon *LogstashMonitoringAssociation) ElasticServiceAccount() (commonv1.ServiceAccountName, error) {
 	return "", nil

--- a/pkg/apis/maps/v1alpha1/maps_types.go
+++ b/pkg/apis/maps/v1alpha1/maps_types.go
@@ -153,8 +153,8 @@ func (m *ElasticMapsServer) AssociationID() string {
 	return commonv1.SingletonAssociationID
 }
 
-var _ commonv1.Associated = &ElasticMapsServer{}
-var _ commonv1.Association = &ElasticMapsServer{}
+var _ commonv1.Associated = (*ElasticMapsServer)(nil)
+var _ commonv1.Association = (*ElasticMapsServer)(nil)
 
 // GetObservedGeneration will return the observed generation from the Elastic Maps status.
 func (m *ElasticMapsServer) GetObservedGeneration() int64 {

--- a/pkg/apis/maps/v1alpha1/webhook.go
+++ b/pkg/apis/maps/v1alpha1/webhook.go
@@ -35,7 +35,7 @@ var (
 
 // +kubebuilder:webhook:path=/validate-ems-k8s-elastic-co-v1alpha1-mapsservers,mutating=false,failurePolicy=ignore,groups=maps.k8s.elastic.co,resources=mapsservers,verbs=create;update,versions=v1alpha1,name=elastic-ems-validation-v1alpha1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1,matchPolicy=Exact
 
-var _ admission.Validator = &ElasticMapsServer{}
+var _ admission.Validator = (*ElasticMapsServer)(nil)
 
 // ValidateCreate is called by the validating webhook to validate the create operation.
 // Satisfies the webhook.Validator interface.

--- a/pkg/apis/packageregistry/v1alpha1/webhook.go
+++ b/pkg/apis/packageregistry/v1alpha1/webhook.go
@@ -34,7 +34,7 @@ var (
 
 // +kubebuilder:webhook:path=/validate-epr-k8s-elastic-co-v1alpha1-packageregistry,mutating=false,failurePolicy=ignore,groups=packageregistry.k8s.elastic.co,resources=packageregistry,verbs=create;update,versions=v1alpha1,name=elastic-epr-validation-v1alpha1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1,matchPolicy=Exact
 
-var _ admission.Validator = &PackageRegistry{}
+var _ admission.Validator = (*PackageRegistry)(nil)
 
 // ValidateCreate is called by the validating webhook to validate the create operation.
 // Satisfies the webhook.Validator interface.

--- a/pkg/apis/stackconfigpolicy/v1alpha1/webhook.go
+++ b/pkg/apis/stackconfigpolicy/v1alpha1/webhook.go
@@ -36,7 +36,7 @@ var (
 
 // +kubebuilder:webhook:path=/validate-scp-k8s-elastic-co-v1alpha1-stackconfigpolicies,mutating=false,failurePolicy=ignore,groups=stackconfigpolicy.k8s.elastic.co,resources=stackconfigpolicies,verbs=create;update,versions=v1alpha1,name=elastic-scp-validation-v1alpha1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1,matchPolicy=Exact
 
-var _ admission.Validator = &StackConfigPolicy{}
+var _ admission.Validator = (*StackConfigPolicy)(nil)
 
 // ValidateCreate is called by the validating webhook to validate the create operation.
 // Satisfies the webhook.Validator interface.

--- a/pkg/controller/agent/controller.go
+++ b/pkg/controller/agent/controller.go
@@ -127,7 +127,7 @@ func addWatches(mgr manager.Manager, c controller.Controller, r *ReconcileAgent)
 		))
 }
 
-var _ reconcile.Reconciler = &ReconcileAgent{}
+var _ reconcile.Reconciler = (*ReconcileAgent)(nil)
 
 // ReconcileAgent reconciles an Agent object
 type ReconcileAgent struct {

--- a/pkg/controller/apmserver/controller.go
+++ b/pkg/controller/apmserver/controller.go
@@ -148,7 +148,7 @@ func addWatches(mgr manager.Manager, c controller.Controller, r *ReconcileApmSer
 	return c.Watch(source.Kind(mgr.GetCache(), &corev1.Secret{}, r.dynamicWatches.Secrets))
 }
 
-var _ reconcile.Reconciler = &ReconcileApmServer{}
+var _ reconcile.Reconciler = (*ReconcileApmServer)(nil)
 
 // ReconcileApmServer reconciles an ApmServer object
 type ReconcileApmServer struct {
@@ -176,7 +176,7 @@ func (r *ReconcileApmServer) Recorder() record.EventRecorder {
 	return r.recorder
 }
 
-var _ driver.Interface = &ReconcileApmServer{}
+var _ driver.Interface = (*ReconcileApmServer)(nil)
 
 // Reconcile reads that state of the cluster for a ApmServer object and makes changes based on the state read
 // and what is in the ApmServer.Spec

--- a/pkg/controller/autoops/rbac_test.go
+++ b/pkg/controller/autoops/rbac_test.go
@@ -61,7 +61,7 @@ func (c *configurableAccessReviewer) AccessAllowed(_ context.Context, _ string, 
 	return c.defaultAllow, nil
 }
 
-var _ rbac.AccessReviewer = &configurableAccessReviewer{}
+var _ rbac.AccessReviewer = (*configurableAccessReviewer)(nil)
 
 func TestIsAutoOpsAssociationAllowed(t *testing.T) {
 	tests := []struct {

--- a/pkg/controller/autoscaling/elasticsearch/validation/webhook_test.go
+++ b/pkg/controller/autoscaling/elasticsearch/validation/webhook_test.go
@@ -690,4 +690,4 @@ func (f fakeChecker) ValidOperatorLicenseKeyType(_ context.Context) (license.Ope
 	return f.operatorLicenseType, nil
 }
 
-var _ license.Checker = &fakeChecker{}
+var _ license.Checker = (*fakeChecker)(nil)

--- a/pkg/controller/beat/controller.go
+++ b/pkg/controller/beat/controller.go
@@ -110,7 +110,7 @@ func addWatches(mgr manager.Manager, c controller.Controller, r *ReconcileBeat) 
 	return c.Watch(source.Kind(mgr.GetCache(), &corev1.Secret{}, r.dynamicWatches.Secrets))
 }
 
-var _ reconcile.Reconciler = &ReconcileBeat{}
+var _ reconcile.Reconciler = (*ReconcileBeat)(nil)
 
 // ReconcileBeat reconciles a Beat object.
 type ReconcileBeat struct {

--- a/pkg/controller/common/driver/interface.go
+++ b/pkg/controller/common/driver/interface.go
@@ -41,4 +41,4 @@ func (t TestDriver) Recorder() record.EventRecorder {
 	return t.FakeRecorder
 }
 
-var _ Interface = &TestDriver{}
+var _ Interface = (*TestDriver)(nil)

--- a/pkg/controller/common/license/check.go
+++ b/pkg/controller/common/license/check.go
@@ -153,4 +153,4 @@ func (m MockLicenseChecker) ValidOperatorLicenseKeyType(_ context.Context) (Oper
 	return LicenseTypeEnterprise, nil
 }
 
-var _ Checker = &MockLicenseChecker{}
+var _ Checker = (*MockLicenseChecker)(nil)

--- a/pkg/controller/common/license/model.go
+++ b/pkg/controller/common/license/model.go
@@ -134,4 +134,4 @@ const (
 	LicenseStatusInvalid LicenseStatus = "Invalid"
 )
 
-var _ Signable = &EnterpriseLicense{}
+var _ Signable = (*EnterpriseLicense)(nil)

--- a/pkg/controller/common/tracing/log.go
+++ b/pkg/controller/common/tracing/log.go
@@ -35,4 +35,4 @@ func (l *logAdapter) Debugf(format string, args ...any) {
 	l.log.V(1).Info(fmt.Sprintf(format, args...))
 }
 
-var _ apm.Logger = &logAdapter{}
+var _ apm.Logger = (*logAdapter)(nil)

--- a/pkg/controller/common/watches/handler.go
+++ b/pkg/controller/common/watches/handler.go
@@ -93,7 +93,7 @@ func (d *DynamicEnqueueRequest[T]) Registrations() []string {
 }
 
 // DynamicEnqueueRequest implements TypedEventHandler
-var _ handler.TypedEventHandler[client.Object, reconcile.Request] = &DynamicEnqueueRequest[client.Object]{}
+var _ handler.TypedEventHandler[client.Object, reconcile.Request] = (*DynamicEnqueueRequest[client.Object])(nil)
 
 // Create is called in response to a create event - e.g. Pod Creation.
 func (d *DynamicEnqueueRequest[T]) Create(ctx context.Context, evt event.TypedCreateEvent[T], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {

--- a/pkg/controller/common/watches/handler_test.go
+++ b/pkg/controller/common/watches/handler_test.go
@@ -39,7 +39,7 @@ func (t fakeHandler[T]) EventHandler() handler.TypedEventHandler[T, reconcile.Re
 	return t.handler
 }
 
-var _ HandlerRegistration[*corev1.Secret] = &fakeHandler[*corev1.Secret]{}
+var _ HandlerRegistration[*corev1.Secret] = (*fakeHandler[*corev1.Secret])(nil)
 
 func TestDynamicEnqueueRequest_AddHandler(t *testing.T) {
 	tests := []struct {

--- a/pkg/controller/common/watches/named_watch.go
+++ b/pkg/controller/common/watches/named_watch.go
@@ -27,7 +27,7 @@ type NamedWatch[T client.Object] struct {
 	Watcher types.NamespacedName
 }
 
-var _ handler.EventHandler = &NamedWatch[client.Object]{}
+var _ handler.EventHandler = (*NamedWatch[client.Object])(nil)
 
 func (w NamedWatch[T]) Create(_ context.Context, evt event.TypedCreateEvent[T], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 	for _, req := range w.toReconcileRequest(evt.Object) {
@@ -79,4 +79,4 @@ func (w NamedWatch[T]) toReconcileRequest(object metav1.Object) []reconcile.Requ
 	return nil
 }
 
-var _ HandlerRegistration[client.Object] = &NamedWatch[client.Object]{}
+var _ HandlerRegistration[client.Object] = (*NamedWatch[client.Object])(nil)

--- a/pkg/controller/common/watches/owner_watch.go
+++ b/pkg/controller/common/watches/owner_watch.go
@@ -32,4 +32,4 @@ func (o *OwnerWatch[T]) EventHandler() handler.TypedEventHandler[T, reconcile.Re
 	return handler.TypedEnqueueRequestForOwner[T](o.Scheme, o.Mapper, o.OwnerType, opts...)
 }
 
-var _ HandlerRegistration[client.Object] = &OwnerWatch[client.Object]{}
+var _ HandlerRegistration[client.Object] = (*OwnerWatch[client.Object])(nil)

--- a/pkg/controller/elasticsearch/client/url.go
+++ b/pkg/controller/elasticsearch/client/url.go
@@ -43,4 +43,4 @@ func (s *staticURLProvider) HasEndpoints() bool {
 	return true
 }
 
-var _ URLProvider = &staticURLProvider{}
+var _ URLProvider = (*staticURLProvider)(nil)

--- a/pkg/controller/elasticsearch/client/v7.go
+++ b/pkg/controller/elasticsearch/client/v7.go
@@ -259,4 +259,4 @@ func (c *clientV7) Equal(c2 Client) bool {
 	return c.baseClient.equal(&other.baseClient)
 }
 
-var _ Client = &clientV7{}
+var _ Client = (*clientV7)(nil)

--- a/pkg/controller/elasticsearch/client/v8.go
+++ b/pkg/controller/elasticsearch/client/v8.go
@@ -66,4 +66,4 @@ func (c *clientV8) Equal(c2 Client) bool {
 	return c.baseClient.equal(&other.baseClient)
 }
 
-var _ Client = &clientV8{}
+var _ Client = (*clientV8)(nil)

--- a/pkg/controller/elasticsearch/driver/stateful/driver.go
+++ b/pkg/controller/elasticsearch/driver/stateful/driver.go
@@ -26,7 +26,7 @@ func NewDriver(parameters driver.Parameters) driver.Driver {
 	return &Driver{BaseDriver: driver.BaseDriver{Parameters: parameters}}
 }
 
-var _ commondriver.Interface = &Driver{}
+var _ commondriver.Interface = (*Driver)(nil)
 
 // Reconcile fulfills the Driver interface and reconciles the cluster resources.
 func (d *Driver) Reconcile(ctx context.Context) *reconciler.Results {

--- a/pkg/controller/elasticsearch/driver/stateful/driver_test.go
+++ b/pkg/controller/elasticsearch/driver/stateful/driver_test.go
@@ -112,7 +112,7 @@ type fakeSecurityClient struct {
 	apiKeys                   map[string]esclient.APIKey
 }
 
-var _ esclient.SecurityClient = &fakeSecurityClient{}
+var _ esclient.SecurityClient = (*fakeSecurityClient)(nil)
 
 func (f *fakeSecurityClient) GetServiceAccountCredentials(_ context.Context, namespacedService string) (esclient.ServiceAccountCredential, error) {
 	serviceAccountCredential := f.serviceAccountCredentials[namespacedService]

--- a/pkg/controller/elasticsearch/driver/stateless/driver.go
+++ b/pkg/controller/elasticsearch/driver/stateless/driver.go
@@ -24,7 +24,7 @@ func NewDriver(parameters driver.Parameters) driver.Driver {
 	return &Driver{BaseDriver: driver.BaseDriver{Parameters: parameters}}
 }
 
-var _ commondriver.Interface = &Driver{}
+var _ commondriver.Interface = (*Driver)(nil)
 
 // Reconcile fulfills the Driver interface and reconciles the cluster resources.
 func (d *Driver) Reconcile(ctx context.Context) *reconciler.Results {

--- a/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -137,7 +137,7 @@ func addWatches(mgr manager.Manager, c controller.Controller, r *ReconcileElasti
 	return c.Watch(observer.WatchClusterHealthChange(r.esObservers))
 }
 
-var _ reconcile.Reconciler = &ReconcileElasticsearch{}
+var _ reconcile.Reconciler = (*ReconcileElasticsearch)(nil)
 
 // ReconcileElasticsearch reconciles an Elasticsearch object
 type ReconcileElasticsearch struct {

--- a/pkg/controller/elasticsearch/license/apply_test.go
+++ b/pkg/controller/elasticsearch/license/apply_test.go
@@ -351,7 +351,7 @@ func (f *fakeLicenseUpdater) StartBasic(_ context.Context) (esclient.StartBasicR
 	return esclient.StartBasicResponse{}, nil
 }
 
-var _ esclient.LicenseClient = &fakeLicenseUpdater{}
+var _ esclient.LicenseClient = (*fakeLicenseUpdater)(nil)
 
 type fakeClient struct {
 	k8s.Client
@@ -365,4 +365,4 @@ func (f *fakeClient) Get(_ context.Context, key client.ObjectKey, obj client.Obj
 	return f.Client.Get(context.Background(), key, obj)
 }
 
-var _ k8s.Client = &fakeClient{}
+var _ k8s.Client = (*fakeClient)(nil)

--- a/pkg/controller/elasticsearch/migration/migrate_data.go
+++ b/pkg/controller/elasticsearch/migration/migrate_data.go
@@ -21,7 +21,7 @@ type ShardMigration struct {
 	s  esclient.ShardLister
 }
 
-var _ shutdown.Interface = &ShardMigration{}
+var _ shutdown.Interface = (*ShardMigration)(nil)
 
 // NewShardMigration creates a new ShardMigration struct that holds no other state than the arguments to this
 // constructor function.

--- a/pkg/controller/elasticsearch/shutdown/interface.go
+++ b/pkg/controller/elasticsearch/shutdown/interface.go
@@ -63,4 +63,4 @@ func (o *observed) ShutdownStatus(ctx context.Context, podName string) (NodeShut
 	return nodeShutdownStatus, err
 }
 
-var _ Interface = &observed{}
+var _ Interface = (*observed)(nil)

--- a/pkg/controller/elasticsearch/shutdown/node.go
+++ b/pkg/controller/elasticsearch/shutdown/node.go
@@ -26,7 +26,7 @@ type NodeShutdown struct {
 	log         logr.Logger
 }
 
-var _ Interface = &NodeShutdown{}
+var _ Interface = (*NodeShutdown)(nil)
 
 // NewNodeShutdown creates a new NodeShutdown struct restricted to one type of shutdown (typ); podToNodeID is mapping from
 // K8s Pod name to Elasticsearch node ID; reason is an arbitrary bit of metadata that will be attached to each node shutdown

--- a/pkg/controller/enterprisesearch/enterprisesearch_controller.go
+++ b/pkg/controller/enterprisesearch/enterprisesearch_controller.go
@@ -112,7 +112,7 @@ func addWatches(mgr manager.Manager, c controller.Controller, r *ReconcileEnterp
 	return c.Watch(source.Kind(mgr.GetCache(), &corev1.Secret{}, r.dynamicWatches.Secrets))
 }
 
-var _ reconcile.Reconciler = &ReconcileEnterpriseSearch{}
+var _ reconcile.Reconciler = (*ReconcileEnterpriseSearch)(nil)
 
 // ReconcileEnterpriseSearch reconciles an ApmServer object
 type ReconcileEnterpriseSearch struct {
@@ -136,7 +136,7 @@ func (r *ReconcileEnterpriseSearch) Recorder() record.EventRecorder {
 	return r.recorder
 }
 
-var _ driver.Interface = &ReconcileEnterpriseSearch{}
+var _ driver.Interface = (*ReconcileEnterpriseSearch)(nil)
 
 // Reconcile reads that state of the cluster for an EnterpriseSearch object and makes changes based on the state read
 // and what is in the EnterpriseSearch.Spec.

--- a/pkg/controller/kibana/controller.go
+++ b/pkg/controller/kibana/controller.go
@@ -113,7 +113,7 @@ func addWatches(mgr manager.Manager, c controller.Controller, r *ReconcileKibana
 	return c.Watch(source.Kind(mgr.GetCache(), &corev1.Secret{}, r.dynamicWatches.Secrets))
 }
 
-var _ reconcile.Reconciler = &ReconcileKibana{}
+var _ reconcile.Reconciler = (*ReconcileKibana)(nil)
 
 // ReconcileKibana reconciles a Kibana object
 type ReconcileKibana struct {

--- a/pkg/controller/kibana/driver.go
+++ b/pkg/controller/kibana/driver.go
@@ -66,7 +66,7 @@ func (d *driver) Recorder() record.EventRecorder {
 	return d.recorder
 }
 
-var _ driver2.Interface = &driver{}
+var _ driver2.Interface = (*driver)(nil)
 
 func newDriver(
 	client k8s.Client,

--- a/pkg/controller/license/license_controller.go
+++ b/pkg/controller/license/license_controller.go
@@ -132,7 +132,7 @@ func addWatches(mgr manager.Manager, c controller.Controller, k8sClient k8s.Clie
 	return nil
 }
 
-var _ reconcile.Reconciler = &ReconcileLicenses{}
+var _ reconcile.Reconciler = (*ReconcileLicenses)(nil)
 
 // ReconcileLicenses reconciles EnterpriseLicenses with existing Elasticsearch clusters and creates ClusterLicenses for them.
 type ReconcileLicenses struct {

--- a/pkg/controller/license/trial/trial_controller.go
+++ b/pkg/controller/license/trial/trial_controller.go
@@ -274,4 +274,4 @@ func Add(mgr manager.Manager, params operator.Parameters) error {
 	return addWatches(mgr, c)
 }
 
-var _ reconcile.Reconciler = &ReconcileTrials{}
+var _ reconcile.Reconciler = (*ReconcileTrials)(nil)

--- a/pkg/controller/logstash/logstash_controller.go
+++ b/pkg/controller/logstash/logstash_controller.go
@@ -110,7 +110,7 @@ func addWatches(mgr manager.Manager, c controller.Controller, r *ReconcileLogsta
 	return c.Watch(source.Kind(mgr.GetCache(), &corev1.Secret{}, r.dynamicWatches.Secrets))
 }
 
-var _ reconcile.Reconciler = &ReconcileLogstash{}
+var _ reconcile.Reconciler = (*ReconcileLogstash)(nil)
 
 // ReconcileLogstash reconciles a Logstash object
 type ReconcileLogstash struct {

--- a/pkg/controller/maps/controller.go
+++ b/pkg/controller/maps/controller.go
@@ -115,7 +115,7 @@ func addWatches(mgr manager.Manager, c controller.Controller, r *ReconcileMapsSe
 	return c.Watch(source.Kind(mgr.GetCache(), &corev1.Secret{}, r.dynamicWatches.Secrets))
 }
 
-var _ reconcile.Reconciler = &ReconcileMapsServer{}
+var _ reconcile.Reconciler = (*ReconcileMapsServer)(nil)
 
 // ReconcileMapsServer reconciles a MapsServer object
 type ReconcileMapsServer struct {
@@ -140,7 +140,7 @@ func (r *ReconcileMapsServer) Recorder() record.EventRecorder {
 	return r.recorder
 }
 
-var _ driver.Interface = &ReconcileMapsServer{}
+var _ driver.Interface = (*ReconcileMapsServer)(nil)
 
 // Reconcile reads that state of the cluster for a MapsServer object and makes changes based on the state read and what is
 // in the MapsServer.Spec

--- a/pkg/controller/packageregistry/controller.go
+++ b/pkg/controller/packageregistry/controller.go
@@ -109,7 +109,7 @@ func addWatches(mgr manager.Manager, c controller.Controller, r *ReconcilePackag
 	return c.Watch(source.Kind(mgr.GetCache(), &corev1.Secret{}, r.dynamicWatches.Secrets))
 }
 
-var _ reconcile.Reconciler = &ReconcilePackageRegistry{}
+var _ reconcile.Reconciler = (*ReconcilePackageRegistry)(nil)
 
 // ReconcilePackageRegistry reconciles a PackageRegistry object
 type ReconcilePackageRegistry struct {
@@ -133,7 +133,7 @@ func (r *ReconcilePackageRegistry) Recorder() record.EventRecorder {
 	return r.recorder
 }
 
-var _ driver.Interface = &ReconcilePackageRegistry{}
+var _ driver.Interface = (*ReconcilePackageRegistry)(nil)
 
 // Reconcile reads that state of the cluster for a PackageRegistry object and makes changes based on the state read and what is
 // in the PackageRegistry.Spec

--- a/pkg/controller/remotecluster/controller.go
+++ b/pkg/controller/remotecluster/controller.go
@@ -70,7 +70,7 @@ func NewReconciler(mgr manager.Manager, accessReviewer rbac.AccessReviewer, para
 	}
 }
 
-var _ reconcile.Reconciler = &ReconcileRemoteClusters{}
+var _ reconcile.Reconciler = (*ReconcileRemoteClusters)(nil)
 
 // ReconcileRemoteClusters reconciles remote clusters Secrets and API Keys.
 type ReconcileRemoteClusters struct {

--- a/pkg/controller/stackconfigpolicy/controller.go
+++ b/pkg/controller/stackconfigpolicy/controller.go
@@ -148,7 +148,7 @@ func reconcileRequestForAllPolicies(clnt k8s.Client) handler.TypedEventHandler[c
 	})
 }
 
-var _ reconcile.Reconciler = &ReconcileStackConfigPolicy{}
+var _ reconcile.Reconciler = (*ReconcileStackConfigPolicy)(nil)
 
 // ReconcileStackConfigPolicy reconciles a StackConfigPolicy object
 type ReconcileStackConfigPolicy struct {

--- a/pkg/controller/webhook/admission_registration.go
+++ b/pkg/controller/webhook/admission_registration.go
@@ -43,7 +43,7 @@ func (w *Params) NewAdmissionControllerInterface(ctx context.Context, clientset 
 
 // - admissionregistration.k8s.io/v1 implementation
 
-var _ AdmissionControllerInterface = &v1webhookHandler{}
+var _ AdmissionControllerInterface = (*v1webhookHandler)(nil)
 
 type v1webhookHandler struct {
 	clientset            kubernetes.Interface

--- a/pkg/controller/webhook/webhook_certificates_controller.go
+++ b/pkg/controller/webhook/webhook_certificates_controller.go
@@ -33,7 +33,7 @@ const (
 	ControllerName = "webhook-certificates-controller"
 )
 
-var _ reconcile.Reconciler = &ReconcileWebhookResources{}
+var _ reconcile.Reconciler = (*ReconcileWebhookResources)(nil)
 
 // ReconcileWebhookResources reconciles the certificates used by the webhook server.
 type ReconcileWebhookResources struct {

--- a/pkg/dev/portforward/pod_forwarder.go
+++ b/pkg/dev/portforward/pod_forwarder.go
@@ -49,7 +49,7 @@ type PodForwarder struct {
 	dialerFunc dialerFunc
 }
 
-var _ Forwarder = &PodForwarder{}
+var _ Forwarder = (*PodForwarder)(nil)
 
 // PortForwarderFactory is a factory for port forwarders
 type PortForwarderFactory func(

--- a/pkg/dev/portforward/service_forwarder.go
+++ b/pkg/dev/portforward/service_forwarder.go
@@ -37,7 +37,7 @@ type ServiceForwarder struct {
 	podForwarderFactory ForwarderFactory
 }
 
-var _ Forwarder = &ServiceForwarder{}
+var _ Forwarder = (*ServiceForwarder)(nil)
 
 // defaultPodForwarderFactory is the default pod forwarder factory used outside of tests
 var defaultPodForwarderFactory = ForwarderFactory(func(ctx context.Context, network, addr string) (Forwarder, error) {

--- a/pkg/utils/rbac/access_review.go
+++ b/pkg/utils/rbac/access_review.go
@@ -33,7 +33,7 @@ type SubjectAccessReviewer struct {
 	client kubernetes.Interface
 }
 
-var _ AccessReviewer = &SubjectAccessReviewer{}
+var _ AccessReviewer = (*SubjectAccessReviewer)(nil)
 
 func NewSubjectAccessReviewer(client kubernetes.Interface) AccessReviewer {
 	return &SubjectAccessReviewer{
@@ -110,7 +110,7 @@ func newSubjectAccessReview(
 
 type permissiveAccessReviewer struct{}
 
-var _ AccessReviewer = &permissiveAccessReviewer{}
+var _ AccessReviewer = (*permissiveAccessReviewer)(nil)
 
 func (s *permissiveAccessReviewer) AccessAllowed(_ context.Context, _ string, _ string, _ runtime.Object) (bool, error) {
 	return true, nil

--- a/test/e2e/test/builder.go
+++ b/test/e2e/test/builder.go
@@ -95,4 +95,4 @@ func (w WrappedBuilder) SkipTest() bool {
 	return w.BuildingThis.SkipTest()
 }
 
-var _ Builder = &WrappedBuilder{}
+var _ Builder = (*WrappedBuilder)(nil)

--- a/test/e2e/test/elasticsearch/autoscaling/builder.go
+++ b/test/e2e/test/elasticsearch/autoscaling/builder.go
@@ -24,7 +24,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test"
 )
 
-var _ test.Builder = &AutoscalingBuilder{}
+var _ test.Builder = (*AutoscalingBuilder)(nil)
 
 // AutoscalingBuilder helps to build and update autoscaling policies.
 type AutoscalingBuilder struct {

--- a/test/e2e/test/elasticsearch/license_fixture.go
+++ b/test/e2e/test/elasticsearch/license_fixture.go
@@ -59,7 +59,7 @@ func (e ESLicense) Version() int {
 	return 5 // or the new enterprise capable license version
 }
 
-var _ license.Signable = &ESLicense{}
+var _ license.Signable = (*ESLicense)(nil)
 
 func GenerateTestLicense(signer *license.Signer, typ client.ElasticsearchLicenseType) (client.License, error) {
 	uuid, err := uuid.NewUUID()


### PR DESCRIPTION
Use `(*T)(nil)` for compile-time interface checks
Replace `var _ Interface = &Struct{}` with `var _ Interface = (*Struct)(nil)` for compile-time interface satisfaction assertions. 

This is the more idiomatic Go pattern and avoids unnecessary zero-value allocations at init time.