### PR TITLE
[3.3.1] Add namespaceSelector to 3.3.1 api reference docs

### DIFF
--- a/docs/reference/api-reference/3_3_1.md
+++ b/docs/reference/api-reference/3_3_1.md
@@ -294,6 +294,7 @@ AutoOpsAgentPolicy represents an Elastic AutoOps Policy resource in a Kubernetes
 | --- | --- |
 | *`version`* __string__ | Version of the AutoOpsAgentPolicy. |
 | *`resourceSelector`* __[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#labelselector-v1-meta)__ | ResourceSelector is a label selector for the resources to be configured.<br>Any Elasticsearch instances that match the selector will be configured to send data to AutoOps. |
+| *`namespaceSelector`* __[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#labelselector-v1-meta)__ | NamespaceSelector is a namespace selector for the resources to be configured.<br>Any Elasticsearch instances that belong to the selected namespaces will be configured to send data to AutoOps. |
 | *`autoOpsRef`* __[AutoOpsRef](#autoopsref)__ | AutoOpsRef defines a reference to a secret containing connection details for AutoOps via Cloud Connect. |
 | *`image`* __string__ | Image is the AutoOps Agent Docker image to deploy. |
 | *`podTemplate`* __[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podtemplatespec-v1-core)__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Agent pods |


### PR DESCRIPTION
*Note this is merging to the `3.3.1-wip` branch for the 3.3.1 release.

During the merge of https://github.com/elastic/cloud-on-k8s/pull/9132 only the 3.3.0 api reference docs were updated. This fixes that issue.