### PR TITLE
upgrade to latest ubi-micro to address CVE-2026-0861

### DIFF
--- a/build/Dockerfile-ubi
+++ b/build/Dockerfile-ubi
@@ -27,7 +27,7 @@ RUN --mount=type=cache,mode=0755,target=/go/pkg/mod \
 
 # ---------------------------------------------
 # Copy the operator binary into a lighter image
-FROM registry.access.redhat.com/ubi9/ubi-micro:9.7-1766049073
+FROM registry.access.redhat.com/ubi9/ubi-micro:9.7-1771346390
 
 ARG VERSION
 


### PR DESCRIPTION
Update to latest ubi-micro image to address CVE-2026-0861

* [9.7-1771346390 Details](https://catalog.redhat.com/en/software/containers/ubi9/ubi-micro/615bdf943f6014fa45ae1b58?image=6994a186f87f9e45ac872899)
* [RHSA-2026:2786 - Security Advisory](https://access.redhat.com/errata/RHSA-2026:2786)


