### PR TITLE
[3.3.1-wip] bump to latest ubi-micro to address CVE-2026-0861 (#9146)

### DIFF
--- a/build/Dockerfile-ubi
+++ b/build/Dockerfile-ubi
@@ -27,7 +27,7 @@ RUN --mount=type=cache,mode=0755,target=/go/pkg/mod \
 
 # ---------------------------------------------
 # Copy the operator binary into a lighter image
-FROM registry.access.redhat.com/ubi9/ubi-micro:9.7-1766049073
+FROM registry.access.redhat.com/ubi9/ubi-micro:9.7-1771346390
 
 ARG VERSION
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.3.1-wip`:
 - [bump to latest ubi-micro to address CVE-2026-0861 (#9146)](https://github.com/elastic/cloud-on-k8s/pull/9146)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)