### PR TITLE
Fix NetworkPolicy namespace selector label for soft multi-tenancy

### DIFF
--- a/deploy/eck-operator/templates/managed-ns-network-policy.yaml
+++ b/deploy/eck-operator/templates/managed-ns-network-policy.yaml
@@ -40,7 +40,7 @@ spec:
         # Operator
         - namespaceSelector:
             matchLabels:
-              name: "{{ $.Release.Namespace }}"
+              kubernetes.io/metadata.name: "{{ $.Release.Namespace }}"
           podSelector:
             matchLabels:
               {{- include "eck-operator.selectorLabels" $ | nindent 14 }}


### PR DESCRIPTION
## Summary

- Fix the `namespaceSelector` in the managed namespace NetworkPolicy template to use the `kubernetes.io/metadata.name` label instead of the non-existent `name` label.
- Without this fix, when `softMultiTenancy` is enabled, the generated NetworkPolicy blocks the ECK operator from accessing Elasticsearch nodes on port 9200, causing the operator to continuously re-queue with `"Elasticsearch cannot be reached yet"` log messages.
- The `kubernetes.io/metadata.name` label is automatically set by Kubernetes on every namespace (since 1.21+), making it the correct label to use for namespace selection.

Fixes #9150

Made with [Cursor](https://cursor.com)