### PR TITLE
stop ignoring test/ in Renovate so test/e2e/Dockerfile is tracked

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,15 @@
   "labels": [
     ">renovate"
   ],
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/bower_components/**",
+    "**/vendor/**",
+    "**/examples/**",
+    "**/__tests__/**",
+    "**/tests/**",
+    "**/__fixtures__/**"
+  ],
   "schedule": [
     "after 1am on monday"
   ],


### PR DESCRIPTION
## Summary
[PR #9154](https://github.com/elastic/cloud-on-k8s/pull/9154) is failing because Renovate bumped `go.mod`'s `go` directive to `1.25.6` (as a transitive requirement of `go-containerregistry` v0.21.0), but `test/e2e/Dockerfile` still uses `golang:1.25.5`. The build fails at `go mod download` with:

```
go: go.mod requires go >= 1.25.6 (running go 1.25.5; GOTOOLCHAIN=local)
```

The root cause is that `test/e2e/Dockerfile` is not tracked by Renovate at all. The [`config:recommended`](https://docs.renovatebot.com/presets-config/#configrecommended) preset includes [`:ignoreModulesAndTests`](https://docs.renovatebot.com/presets-default/#ignoremodulesandtests), which sets `ignorePaths` to include `**/test/**`, causing Renovate to completely skip any files under `test/`. This can be confirmed by checking the [Dependency Dashboard](https://github.com/elastic/cloud-on-k8s/issues/8003) where `test/e2e/Dockerfile` is absent from the detected dependencies. This PR overrides `ignorePaths` to reproduce the same list from `:ignoreModulesAndTests` but without `**/test/**`, so that `test/e2e/Dockerfile` is detected and its `docker.io/library/golang` image is kept up to date via the existing `go` package group.