### PR TITLE
[3.3.1-wip] Add feature/enhancement note for 3.3.1 release (9.2.4 change) (#9163)

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -20,6 +20,7 @@ ECK 3.3.1 has removed the enterprise requirement for AutoOpsAgentPolicy. AutoOps
 
 - Removing enterprise requirement for AutoOpsAgentPolicy [#9125](https://github.com/elastic/cloud-on-k8s/pull/9125)
 - Add Namespace Selector to AutoOpsAgentPolicy [#8991](https://github.com/elastic/cloud-on-k8s/pull/8991)
+- Update minimum AutoOps Agent to 9.2.4 when a Basic license is used [#9157](https://github.com/elastic/cloud-on-k8s/pull/9157)
 
 :::{dropdown} Updated dependencies
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.3.1-wip`:
 - [Add feature/enhancement note for 3.3.1 release (9.2.4 change) (#9163)](https://github.com/elastic/cloud-on-k8s/pull/9163)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)