### PR TITLE
avoid empty reconcile requests in StackConfigPolicy secret watch

### DIFF
--- a/pkg/controller/stackconfigpolicy/controller.go
+++ b/pkg/controller/stackconfigpolicy/controller.go
@@ -111,25 +111,31 @@ func addWatches(mgr manager.Manager, c controller.Controller, r *ReconcileStackC
 
 func reconcileRequestForSoftOwnerPolicy() handler.TypedEventHandler[*corev1.Secret, reconcile.Request] {
 	return handler.TypedEnqueueRequestsFromMapFunc[*corev1.Secret](func(ctx context.Context, secret *corev1.Secret) []reconcile.Request {
-		softOwners, err := reconciler.SoftOwnerRefs(secret)
-		if err != nil {
-			ulog.Log.Error(err, "Fail to get soft-owner policies of secret", "secret_name", secret.GetName(), "secret_namespace", secret.GetNamespace())
-			return nil
-		}
-
-		if len(softOwners) == 0 {
-			return nil
-		}
-
-		var requests []reconcile.Request
-		for _, nsn := range softOwners {
-			if nsn.Kind != policyv1alpha1.Kind {
-				continue
-			}
-			requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: nsn.Namespace, Name: nsn.Name}})
-		}
-		return requests
+		return toReconcileRequests(secret)
 	})
+}
+
+// toReconcileRequests returns reconcile requests for StackConfigPolicy owners of the given secret.
+// Returns nil if the secret has no soft owners or if none of the owners are StackConfigPolicy resources.
+func toReconcileRequests(secret *corev1.Secret) []reconcile.Request {
+	softOwners, err := reconciler.SoftOwnerRefs(secret)
+	if err != nil {
+		ulog.Log.Error(err, "Fail to get soft-owner policies of secret", "secret_name", secret.GetName(), "secret_namespace", secret.GetNamespace())
+		return nil
+	}
+
+	if len(softOwners) == 0 {
+		return nil
+	}
+
+	var requests []reconcile.Request
+	for _, nsn := range softOwners {
+		if nsn.Kind != policyv1alpha1.Kind {
+			continue
+		}
+		requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: nsn.Namespace, Name: nsn.Name}})
+	}
+	return requests
 }
 
 // requestsAllStackConfigPolicies returns the requests to reconcile all StackConfigPolicy resources.


### PR DESCRIPTION
## Summary
Fixes a bug where the StackConfigPolicy controller logs errors when `managedNamespaces` is configured:
```
  error: unable to get: / because of unknown namespace for the cache
```
The issue was in `reconcileRequestForSoftOwnerPolicy()` which pre-allocated a slice of reconcile requests and used `continue` to skip non-StackConfigPolicy owners, leaving zero-value entries with empty namespace/name in the returned slice.

## Steps to reproduce

1. run ECK operator with `managedNamespaces`:
```
make CGO_ENABLED=0 LICENSE_PUBKEY=$PWD/license.key GO_TAGS='release' MANAGED_NAMESPACES='elastic-system' run
```
Note: you can go with the helm installation if you prefer

2. Deploy an Elasticsearch cluster and a StackConfigPolicy:
```yaml
apiVersion: elasticsearch.k8s.elastic.co/v1
kind: Elasticsearch
metadata:
  name: elasticsearch
  namespace: elastic-system
  labels:
    env: test
  spec:
    version: 9.3.0
    nodeSets:
    - name: default
       count: 1
---
apiVersion: stackconfigpolicy.k8s.elastic.co/v1alpha1
kind: StackConfigPolicy
metadata:
  name: test-policy
  namespace: elastic-system
spec:
  resourceSelector:
    matchLabels:
      env: test
    elasticsearch:
      clusterSettings:
        indices.recovery.max_bytes_per_sec: "100mb"
```

3. Trigger a modification on an Elasticsearch-owned secret:
```console
kubectl annotate secret -n elastic-system elasticsearch-es-elastic-user test=trigger
```

4. Observe the error in operator logs

5. Repeat the above with the code of this PR