### PR TITLE
fix(e2e): wait for ES HTTP endpoint before creating AutoOpsAgentPolicy

### DIFF
--- a/test/e2e/test/autoops/steps.go
+++ b/test/e2e/test/autoops/steps.go
@@ -22,6 +22,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/cmd/run"
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test"
+	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test/elasticsearch"
 )
 
 func (b Builder) InitTestSteps(k *test.K8sClient) test.StepList {
@@ -89,6 +90,19 @@ func (b Builder) InitTestSteps(k *test.K8sClient) test.StepList {
 
 func (b Builder) CreationTestSteps(k *test.K8sClient) test.StepList {
 	return test.StepList{}.
+		WithStep(test.Step{
+			// Wait for all ES clusters matching the policy selector to be reachable before creating the
+			// AutoOpsAgentPolicy. The autoops-agent (elastic-otel-collector) initialises its metricbeat
+			// receiver immediately on startup and does not retry on a failed initial connection. If ES is
+			// not yet accepting connections at that point the receiver stays in a failed state, the
+			// OTel health-check endpoint returns HTTP 500, and the pod readiness probe never passes.
+			// This step guards against that race between ECK marking ES Ready and the ES HTTP endpoint
+			// being truly accessible.
+			Name: "ES clusters matching selector should be reachable before creating AutoOpsAgentPolicy",
+			Test: test.Eventually(func() error {
+				return b.checkMatchingESClustersReachable(k)
+			}),
+		}).
 		WithStep(test.Step{
 			Name: "Creating configuration secret should succeed",
 			Test: func(t *testing.T) {
@@ -318,4 +332,45 @@ func (b Builder) DeletionTestSteps(k *test.K8sClient) test.StepList {
 
 func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
 	return test.StepList{}
+}
+
+// checkMatchingESClustersReachable verifies that every ES cluster that this policy will monitor has
+// a reachable and healthy HTTP endpoint. It mirrors the filtering logic used by the operator so that
+// only clusters which will actually receive an autoops-agent deployment are checked.
+func (b Builder) checkMatchingESClustersReachable(k *test.K8sClient) error {
+	selector, err := metav1.LabelSelectorAsSelector(&b.AutoOpsAgentPolicy.Spec.ResourceSelector)
+	if err != nil {
+		return fmt.Errorf("parsing resource selector: %w", err)
+	}
+
+	var esList esv1.ElasticsearchList
+	if err := k.Client.List(context.Background(), &esList, &k8sclient.ListOptions{LabelSelector: selector}); err != nil {
+		return fmt.Errorf("listing ES clusters: %w", err)
+	}
+
+	isNamespaceAllowed, err := k8s.NamespaceFilterFunc(context.Background(), k.Client, b.AutoOpsAgentPolicy.Spec.NamespaceSelector)
+	if err != nil {
+		return fmt.Errorf("building namespace filter: %w", err)
+	}
+
+	for _, es := range esList.Items {
+		if !isNamespaceAllowed(es.Namespace) {
+			continue
+		}
+		if es.Status.Phase != esv1.ElasticsearchReadyPhase {
+			return fmt.Errorf("ES cluster %s/%s is not ready yet (phase: %s)", es.Namespace, es.Name, es.Status.Phase)
+		}
+		esClient, err := elasticsearch.NewElasticsearchClient(es, k)
+		if err != nil {
+			return fmt.Errorf("creating ES client for %s/%s: %w", es.Namespace, es.Name, err)
+		}
+		health, err := esClient.GetClusterHealth(context.Background())
+		if err != nil {
+			return fmt.Errorf("ES cluster %s/%s not reachable: %w", es.Namespace, es.Name, err)
+		}
+		if health.Status == esv1.ElasticsearchRedHealth {
+			return fmt.Errorf("ES cluster %s/%s health is red", es.Namespace, es.Name)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

- Fixes a flake in `TestAutoOpsAgentPolicyEnterprise` (observed in [build #1202](https://buildkite.com/elastic/cloud-on-k8s-operator-nightly/builds/1202)) where the test timed out with `policy not ready, phase: AutoOpsAgentsNotReady`.
- Adds a new creation step that waits for every ES cluster matched by the policy's selectors to have a reachable, non-red HTTP endpoint **before** the `AutoOpsAgentPolicy` is created.
- Reuses the operator's own namespace-filter logic (`k8s.NamespaceFilterFunc`) so only clusters that will actually receive an agent deployment are checked.

## Root cause

The `elastic-otel-collector-wolfi` container's **metricbeat receiver initialises once at startup and does not retry** if the initial ES connection is refused. The race looks like this:

1. ECK marks ES as `ElasticsearchReadyPhase`.
2. The operator immediately reconciles the `AutoOpsAgentPolicy` and schedules the autoops-agent `Deployment`.
3. The agent pod starts and the metricbeat receiver tries to connect to the ES ClusterIP — which is still briefly refusing connections even though the ECK phase is `Ready`.
4. The receiver fails permanently; the OTel health-check endpoint returns HTTP 500; the readiness probe never passes.
5. The `Deployment` never reaches `Available`; the policy stays at `AutoOpsAgentsNotReady` for the full 15-minute timeout.

## Fix

Insert a `test.Eventually` step at the start of `CreationTestSteps` that:
- Lists all ES clusters matching `ResourceSelector` + `NamespaceSelector`
- Asserts each is in `ElasticsearchReadyPhase`
- Makes an authenticated HTTP request to verify the cluster health endpoint responds (not red)

Only once all matched clusters pass does the policy get created, ensuring the agent pod starts into a window where ES is truly accessible.

## Test plan

- [ ] Verify existing `TestAutoOpsAgentPolicy` and `TestAutoOpsAgentPolicyEnterprise` tests still pass on a nightly run.

Made with [Cursor](https://cursor.com)