### PR TITLE
Fix race condition in ClustersExpectation.create

### DIFF
--- a/pkg/controller/common/expectations/per_cluster.go
+++ b/pkg/controller/common/expectations/per_cluster.go
@@ -58,9 +58,13 @@ func (c *ClustersExpectation) get(cluster types.NamespacedName) (*Expectations, 
 }
 
 func (c *ClustersExpectation) create(cluster types.NamespacedName) *Expectations {
-	expectations := NewExpectations(c.client, c.object)
 	c.lock.Lock()
 	defer c.lock.Unlock()
+	// Check again in case another goroutine created it while we were waiting for the lock.
+	if expectations, ok := c.clusters[cluster]; ok {
+		return expectations
+	}
+	expectations := NewExpectations(c.client, c.object)
 	c.clusters[cluster] = expectations
 	return expectations
 }

--- a/pkg/controller/common/expectations/per_cluster_test.go
+++ b/pkg/controller/common/expectations/per_cluster_test.go
@@ -69,3 +69,51 @@ func TestClustersExpectation(t *testing.T) {
 	require.True(t, satisfied)
 	require.Equal(t, "", reason)
 }
+
+func TestClustersExpectation_ConcurrentForCluster(t *testing.T) {
+	client := k8s.NewFakeClient()
+	e := NewClustersExpectations(client, &appsv1.StatefulSet{})
+
+	cluster := types.NamespacedName{Namespace: "ns", Name: "name"}
+
+	// Create a pod to use for deletion expectations
+	pod := corev1.Pod{
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: "ns",
+			Name:      "pod",
+			UID:       uuid.NewUUID(),
+		},
+	}
+	require.NoError(t, client.Create(context.Background(), &pod))
+
+	// Simulate the race condition scenario:
+	// 1. Goroutine 1: calls get(), gets nil (not found)
+	// 2. Goroutine 2: calls get(), gets nil (not found)
+	// 3. Goroutine 1: calls create(), creates and stores expectation A
+	// 4. Goroutine 2: calls create(), should return expectation A (not create B)
+
+	// Both "goroutines" call get() first, both get nil
+	exp1, ok1 := e.get(cluster)
+	exp2, ok2 := e.get(cluster)
+	require.False(t, ok1)
+	require.False(t, ok2)
+	require.Nil(t, exp1)
+	require.Nil(t, exp2)
+
+	// "Goroutine 1" calls create() first
+	exp1 = e.create(cluster)
+	// "Goroutine 2" calls create() second - should return same instance due to double-checked locking
+	exp2 = e.create(cluster)
+
+	// Both should have received the same Expectations instance.
+	// Without the double-checked locking fix, exp2 would be a new instance
+	// that overwrites exp1's instance in the map.
+	require.Same(t, exp1, exp2,
+		"both callers should receive the same Expectations instance")
+
+	// Verify that modifications are visible to both
+	exp1.ExpectDeletion(pod)
+	satisfied, _, err := exp2.Satisfied()
+	require.NoError(t, err)
+	require.False(t, satisfied, "deletion expectation should be visible from both references")
+}


### PR DESCRIPTION
When multiple goroutines call `ForCluster` for the same cluster simultaneously, they could both pass the `get()` check (finding no existing expectations) and then both call `create()`. Without double-checked locking, the second goroutine would overwrite the first one's Expectations instance, potentially losing state.

This fix moves the lock acquisition to the beginning of `create()` and adds a second check after acquiring the lock to return any existing `Expectations` created by another goroutine while waiting for the lock.

This PR also adds a deterministic unit test that verifies the fix by simulating the exact interleaving that would trigger the race condition.

Note that in practice this is not a problem for ECK, but since we aim to share this package with other services I think we should fix it for correctness.