### PR TITLE
Migrate from gsutil to gcloud storage in ocp deployer

### DIFF
--- a/hack/deployer/runner/ocp.go
+++ b/hack/deployer/runner/ocp.go
@@ -368,7 +368,7 @@ func (d *OCPDriver) uploadClusterState() error {
 	bucketNotFound, err := exec.NewCommand("gcloud storage ls gs://{{.OCPStateBucket}}").
 		AsTemplate(d.bucketParams()).
 		WithoutStreaming().
-		OutputContainsAny("BucketNotFoundException", "Did not find existing container")
+		OutputContainsAny("BucketNotFoundException", "not found: 404")
 	if err != nil {
 		return fmt.Errorf("while checking state bucket existence %w", err)
 	}


### PR DESCRIPTION
Replace the use of gsutil with gcloud storage in ocp deployer

closes: #9149 