### PR TITLE
Fix EKS cluster creation

### DIFF
--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -130,7 +130,7 @@ plans:
   kubernetesVersion: 1.34
   diskSetup: kubectl apply -f hack/deployer/config/local-disks/ssd-provisioner.yaml
   eks:
-    region: ap-northeast-3
+    region: ap-northeast-1
     nodeCount: 3
     nodeAMI: auto
 - id: eks-arm-ci

--- a/hack/deployer/runner/eks.go
+++ b/hack/deployer/runner/eks.go
@@ -137,7 +137,7 @@ func (e *EKSDriver) Execute() error {
 			if err := os.WriteFile(createCfgFile, createCfg.Bytes(), 0o600); err != nil {
 				return fmt.Errorf("while writing create cfg %w", err)
 			}
-			if err := e.newCmd(`eksctl create cluster -v 1 -f {{.CreateCfgFile}}`).Run(); err != nil {
+			if err := e.newCmd(`eksctl create cluster -v 4 -f {{.CreateCfgFile}}`).Run(); err != nil {
 				return err
 			}
 		} else {

--- a/hack/deployer/runner/eks.go
+++ b/hack/deployer/runner/eks.go
@@ -137,7 +137,7 @@ func (e *EKSDriver) Execute() error {
 			if err := os.WriteFile(createCfgFile, createCfg.Bytes(), 0o600); err != nil {
 				return fmt.Errorf("while writing create cfg %w", err)
 			}
-			if err := e.newCmd(`eksctl create cluster -v 4 -f {{.CreateCfgFile}}`).Run(); err != nil {
+			if err := e.newCmd(`eksctl create cluster -v 1 -f {{.CreateCfgFile}}`).Run(); err != nil {
 				return err
 			}
 		} else {


### PR DESCRIPTION
Switch EKS CI region from ap-northeast-3 (Osaka) to ap-northeast-1 (Tokyo) to work around a CloudFormation tag policy conflict.

The error occurs during nodegroup CloudFormation stack creation.

* No recent `eksctl` change.
* No code changes to our deployer or tag configuration
* EKS ARM in `eu-west-1` works fine (region-specific issue)

This seems to point to an AWS Organizations tag policy or CloudFormation behavior change in ap-northeast-3 that auto-injects tags conflicting with our CI tags (division, org, team, project).

Should fix https://github.com/elastic/cloud-on-k8s/issues/9232