### PR TITLE
Switch OCP deployer to e2-standard-8

### DIFF
--- a/hack/deployer/config/local-disks-ocp/kustomization.yaml
+++ b/hack/deployer/config/local-disks-ocp/kustomization.yaml
@@ -1,0 +1,12 @@
+# OCP: same as local-disks (non-AWS patch) plus smaller PVs for root disk
+# and a ClusterRoleBinding to grant the privileged SCC to the service account.
+resources:
+  - ../local-disks
+  - ocp-scc-patch.yaml
+patches:
+  - target:
+      group: apps
+      version: v1
+      kind: DaemonSet
+      name: local-volume-provisioner
+    path: ocp-pv-size-patch.yaml

--- a/hack/deployer/config/local-disks-ocp/ocp-pv-size-patch.yaml
+++ b/hack/deployer/config/local-disks-ocp/ocp-pv-size-patch.yaml
@@ -1,0 +1,15 @@
+# OCP: fewer PVs (6×10 GiB) to fit on the root disk (no local SSD on e2 instances).
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: local-volume-provisioner
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: disk-mounts
+          env:
+            - name: PV_SIZE_GB
+              value: "10"
+            - name: PV_COUNT
+              value: "6"

--- a/hack/deployer/config/local-disks-ocp/ocp-scc-patch.yaml
+++ b/hack/deployer/config/local-disks-ocp/ocp-scc-patch.yaml
@@ -1,0 +1,15 @@
+# Grant the privileged SCC to the local-storage-admin service account on OCP.
+# Required because the DaemonSet needs privileged containers, hostPath volumes,
+# and Bidirectional mount propagation — all blocked by OCP's default restricted SCC.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-storage-provisioner-scc-privileged
+subjects:
+- kind: ServiceAccount
+  name: local-storage-admin
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+  apiGroup: rbac.authorization.k8s.io

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -105,8 +105,9 @@ plans:
   clusterName: ci
   clientVersion: 4.20.4
   provider: ocp
-  machineType: n1-standard-8
+  machineType: e2-standard-8
   serviceAccount: true
+  diskSetup: kubectl apply -k hack/deployer/config/local-disks-ocp
   ocp:
     region: europe-west6
     nodeCount: 3
@@ -115,8 +116,9 @@ plans:
   clusterName: dev
   clientVersion: 4.20.4
   provider: ocp
-  machineType: n1-standard-8
+  machineType: e2-standard-8
   serviceAccount: true
+  diskSetup: kubectl apply -k hack/deployer/config/local-disks-ocp
   ocp:
     region: europe-west1
     nodeCount: 3


### PR DESCRIPTION
## Summary

Switch OCP deployer from `n1-standard-8` to `e2-standard-8` to fix `ZONE_RESOURCE_POOL_EXHAUSTED` errors during cluster creation in `europe-west6`, especially during EU business hours.

Fixes https://github.com/elastic/cloud-on-k8s/issues/9238

- Change machine type to `e2-standard-8` for both `ocp-ci` and `ocp-dev` plans
- Add OCP-specific local-disks kustomize overlay with loop-backed PVs (6x10GB) on the root disk
- Grant the `privileged` SCC to the provisioner service account, required by OCP's default restricted SCC

## Why E2

- **Availability**: E2 draws from a shared Intel+AMD resource pool, making `ZONE_RESOURCE_POOL_EXHAUSTED` less likely
- **Cost**: ~29% cheaper than N1 at on-demand rates
- **No feature gap**: OCP plans were not using local SSDs or any other N1-specific feature (PVs were backed by GCP Persistent Disks)

## Local disk provisioner

The addition of the local-disks overlay is an optimization to be consistent with what we already do on GKE, AKS, and EKS. OCP was the only CI provider still using GCP Persistent Disks for e2e PVs. This can be reverted independently if there are any concerns or issues — the core fix is the machine type change.

## Test plan

- [x] Created an OCP cluster with `e2-standard-8` on `europe-west6` — completed in ~47 minutes
- [x] Run `buildkite test this -f p=ocp` to validate full e2e pipeline

> ⚠️ ~Still testing — do not merge yet.~

🤖 Generated with [Claude Code](https://claude.com/claude-code)