### PR TITLE
Sort version folders descending and exclude main.md

### DIFF
--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -3,8 +3,6 @@ products:
   - id: cloud-kubernetes
 exclude:
   - design/**/*.md
-  - reference/api-reference/main.md
-  - reference/third-party-dependencies/main.md
 cross_links:
   - apm-agent-go
   - docs-content

--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -3,6 +3,8 @@ products:
   - id: cloud-kubernetes
 exclude:
   - design/**/*.md
+  - reference/api-reference/main.md
+  - reference/third-party-dependencies/main.md
 cross_links:
   - apm-agent-go
   - docs-content

--- a/docs/reference/toc.yml
+++ b/docs/reference/toc.yml
@@ -2,6 +2,12 @@ toc:
   - file: index.md
   - file: api-docs.md
   - folder: api-reference
+    sort: desc
+    exclude:
+      - main.md
   - folder: third-party-dependencies
+    sort: desc
+    exclude:
+      - main.md
   - file: eck-configuration-flags.md
   - file: upgrade-predicates.md


### PR DESCRIPTION
Sort `api-reference` and `third-party-dependencies` folders in descending order and exclude `main.md` from auto-discovery.

Uses the new `sort` and `exclude` options introduced in [docs-builder#2870](https://github.com/elastic/docs-builder/pull/2870).

Should resolve https://github.com/elastic/cloud-on-k8s/issues/9118