### PR TITLE
Add per-cluster license type support via spec.licenseType

### DIFF
--- a/config/crds/v1/all-crds.yaml
+++ b/config/crds/v1/all-crds.yaml
@@ -4555,6 +4555,16 @@ spec:
               image:
                 description: Image is the Elasticsearch Docker image to deploy.
                 type: string
+              licenseType:
+                description: |-
+                  LicenseType specifies the desired Elasticsearch license type for this cluster.
+                  When set to "basic", the cluster will run on the free basic license even if the operator
+                  has an enterprise license installed. When empty or set to "enterprise", the cluster will
+                  use the best available license from the operator's license pool.
+                enum:
+                - basic
+                - enterprise
+                type: string
               monitoring:
                 description: |-
                   Monitoring enables you to collect and ship log and monitoring data of this Elasticsearch cluster.

--- a/config/crds/v1/resources/elasticsearch.k8s.elastic.co_elasticsearches.yaml
+++ b/config/crds/v1/resources/elasticsearch.k8s.elastic.co_elasticsearches.yaml
@@ -512,6 +512,16 @@ spec:
               image:
                 description: Image is the Elasticsearch Docker image to deploy.
                 type: string
+              licenseType:
+                description: |-
+                  LicenseType specifies the desired Elasticsearch license type for this cluster.
+                  When set to "basic", the cluster will run on the free basic license even if the operator
+                  has an enterprise license installed. When empty or set to "enterprise", the cluster will
+                  use the best available license from the operator's license pool.
+                enum:
+                - basic
+                - enterprise
+                type: string
               monitoring:
                 description: |-
                   Monitoring enables you to collect and ship log and monitoring data of this Elasticsearch cluster.

--- a/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
+++ b/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
@@ -4604,6 +4604,16 @@ spec:
               image:
                 description: Image is the Elasticsearch Docker image to deploy.
                 type: string
+              licenseType:
+                description: |-
+                  LicenseType specifies the desired Elasticsearch license type for this cluster.
+                  When set to "basic", the cluster will run on the free basic license even if the operator
+                  has an enterprise license installed. When empty or set to "enterprise", the cluster will
+                  use the best available license from the operator's license pool.
+                enum:
+                - basic
+                - enterprise
+                type: string
               monitoring:
                 description: |-
                   Monitoring enables you to collect and ship log and monitoring data of this Elasticsearch cluster.

--- a/pkg/apis/elasticsearch/v1/elasticsearch_types.go
+++ b/pkg/apis/elasticsearch/v1/elasticsearch_types.go
@@ -183,6 +183,19 @@ type ElasticsearchSpec struct {
 
 	// RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying StatefulSets.
 	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty"`
+
+	// LicenseType specifies the desired Elasticsearch license type for this cluster.
+	// When set to "basic", the cluster will run on the free basic license even if the operator
+	// has an enterprise license installed. When empty or set to "enterprise", the cluster will
+	// use the best available license from the operator's license pool.
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum=basic;enterprise
+	LicenseType string `json:"licenseType,omitempty"`
+}
+
+// IsBasicLicense returns true if the cluster is explicitly configured for a basic license.
+func (es ElasticsearchSpec) IsBasicLicense() bool {
+	return strings.ToLower(es.LicenseType) == "basic"
 }
 
 type RemoteClusterServer struct {

--- a/pkg/apis/elasticsearch/v1/elasticsearch_types_test.go
+++ b/pkg/apis/elasticsearch/v1/elasticsearch_types_test.go
@@ -572,3 +572,24 @@ func Test_AssociationConfs(t *testing.T) {
 	}
 	assert.Equal(t, 2, len(esMon.AssocConfs))
 }
+
+func TestElasticsearchSpec_IsBasicLicense(t *testing.T) {
+	tests := []struct {
+		name        string
+		licenseType string
+		want        bool
+	}{
+		{name: "empty (default)", licenseType: "", want: false},
+		{name: "basic", licenseType: "basic", want: true},
+		{name: "Basic (mixed case)", licenseType: "Basic", want: true},
+		{name: "BASIC (upper case)", licenseType: "BASIC", want: true},
+		{name: "enterprise", licenseType: "enterprise", want: false},
+		{name: "Enterprise (mixed case)", licenseType: "Enterprise", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			es := ElasticsearchSpec{LicenseType: tt.licenseType}
+			assert.Equal(t, tt.want, es.IsBasicLicense())
+		})
+	}
+}

--- a/pkg/controller/common/license/check.go
+++ b/pkg/controller/common/license/check.go
@@ -133,6 +133,16 @@ func (lc checker) ValidOperatorLicenseKeyType(ctx context.Context) (OperatorLice
 	return licType, nil
 }
 
+// EnterpriseFeaturesEnabledForCluster checks if enterprise features should be enabled for a
+// specific cluster. Returns false if the cluster's spec explicitly requests a basic license,
+// regardless of the operator-level license. Otherwise delegates to the global checker.
+func EnterpriseFeaturesEnabledForCluster(ctx context.Context, checker Checker, isBasicLicense bool) (bool, error) {
+	if isBasicLicense {
+		return false, nil
+	}
+	return checker.EnterpriseFeaturesEnabled(ctx)
+}
+
 type MockLicenseChecker struct {
 	EnterpriseEnabled bool
 }

--- a/pkg/controller/common/license/check_test.go
+++ b/pkg/controller/common/license/check_test.go
@@ -137,6 +137,47 @@ func TestChecker_EnterpriseFeaturesEnabled(t *testing.T) {
 	}
 }
 
+func TestEnterpriseFeaturesEnabledForCluster(t *testing.T) {
+	tests := []struct {
+		name           string
+		isBasicLicense bool
+		checker        Checker
+		want           bool
+	}{
+		{
+			name:           "basic license annotation, enterprise operator: disabled",
+			isBasicLicense: true,
+			checker:        MockLicenseChecker{EnterpriseEnabled: true},
+			want:           false,
+		},
+		{
+			name:           "basic license annotation, basic operator: disabled",
+			isBasicLicense: true,
+			checker:        MockLicenseChecker{EnterpriseEnabled: false},
+			want:           false,
+		},
+		{
+			name:           "not basic, enterprise operator: enabled",
+			isBasicLicense: false,
+			checker:        MockLicenseChecker{EnterpriseEnabled: true},
+			want:           true,
+		},
+		{
+			name:           "not basic, basic operator: disabled",
+			isBasicLicense: false,
+			checker:        MockLicenseChecker{EnterpriseEnabled: false},
+			want:           false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := EnterpriseFeaturesEnabledForCluster(context.Background(), tt.checker, tt.isBasicLicense)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func Test_CurrentEnterpriseLicense(t *testing.T) {
 	privKey, err := x509.ParsePKCS1PrivateKey(privateKeyFixture)
 	require.NoError(t, err)

--- a/pkg/controller/elasticsearch/driver/shared/reconcile.go
+++ b/pkg/controller/elasticsearch/driver/shared/reconcile.go
@@ -390,7 +390,7 @@ func maybeReconcileEmptyFileSettingsSecret(ctx context.Context, c k8s.Client, li
 	}
 
 	log := ulog.FromContext(ctx)
-	enabled, err := licenseChecker.EnterpriseFeaturesEnabled(ctx)
+	enabled, err := commonlicense.EnterpriseFeaturesEnabledForCluster(ctx, licenseChecker, es.Spec.IsBasicLicense())
 	if err != nil {
 		return false, err
 	}

--- a/pkg/controller/elasticsearch/license/apply_test.go
+++ b/pkg/controller/elasticsearch/license/apply_test.go
@@ -232,6 +232,95 @@ func Test_applyLinkedLicense(t *testing.T) {
 	}
 }
 
+// fakeReconcileClient wraps an esclient.Client and tracks StartBasic calls.
+type fakeReconcileClient struct {
+	esclient.Client
+	startBasicCalled bool
+}
+
+func (f *fakeReconcileClient) StartBasic(_ context.Context) (esclient.StartBasicResponse, error) {
+	f.startBasicCalled = true
+	return esclient.StartBasicResponse{}, nil
+}
+
+func TestReconcile_BasicLicenseCluster(t *testing.T) {
+	tests := []struct {
+		name           string
+		licenseType    string
+		currentLicense esclient.License
+		wantStartBasic bool
+		wantErr        bool
+	}{
+		{
+			name:        "basic cluster with enterprise license: should call startBasic",
+			licenseType: "basic",
+			currentLicense: esclient.License{
+				Type: string(esclient.ElasticsearchLicenseTypeEnterprise),
+			},
+			wantStartBasic: true,
+		},
+		{
+			name:        "basic cluster with platinum license: should call startBasic",
+			licenseType: "basic",
+			currentLicense: esclient.License{
+				Type: string(esclient.ElasticsearchLicenseTypePlatinum),
+			},
+			wantStartBasic: true,
+		},
+		{
+			name:        "basic cluster already basic: no-op",
+			licenseType: "basic",
+			currentLicense: esclient.License{
+				Type: string(esclient.ElasticsearchLicenseTypeBasic),
+			},
+			wantStartBasic: false,
+		},
+		{
+			name:        "basic cluster with trial: tolerate trial",
+			licenseType: "basic",
+			currentLicense: esclient.License{
+				Type: string(esclient.ElasticsearchLicenseTypeTrial),
+			},
+			wantStartBasic: false,
+		},
+		{
+			name:        "non-basic cluster: delegates to applyLinkedLicense (no secret, already basic)",
+			licenseType: "",
+			currentLicense: esclient.License{
+				Type: string(esclient.ElasticsearchLicenseTypeBasic),
+			},
+			wantStartBasic: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			es := esv1.Elasticsearch{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Spec: esv1.ElasticsearchSpec{
+					LicenseType: tt.licenseType,
+				},
+			}
+			mockClient := esclient.NewMockClient(version.MustParse("8.0.0"), func(req *http.Request) *http.Response {
+				// The non-basic test case delegates to applyLinkedLicense which won't make HTTP calls
+				// when no license secret exists and current license is basic.
+				panic("unexpected HTTP call")
+			})
+			updater := &fakeReconcileClient{Client: mockClient}
+			c := k8s.NewFakeClient()
+			err := Reconcile(context.Background(), c, es, updater, tt.currentLicense)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.wantStartBasic, updater.startBasicCalled)
+		})
+	}
+}
+
 func Test_checkEsLicense(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/pkg/controller/elasticsearch/license/reconcile.go
+++ b/pkg/controller/elasticsearch/license/reconcile.go
@@ -22,6 +22,14 @@ func Reconcile(
 	clusterClient esclient.Client,
 	currentLicense esclient.License,
 ) error {
+	// If the cluster is configured for a basic license, ensure it runs on basic.
+	if esCluster.Spec.IsBasicLicense() {
+		if !isBasic(currentLicense) && !isTrial(currentLicense) {
+			return startBasic(ctx, clusterClient)
+		}
+		return nil
+	}
+
 	clusterName := k8s.ExtractNamespacedName(&esCluster)
 	return applyLinkedLicense(ctx, c, clusterName, clusterClient, currentLicense)
 }

--- a/pkg/controller/elasticsearch/pdb/reconcile_default.go
+++ b/pkg/controller/elasticsearch/pdb/reconcile_default.go
@@ -42,7 +42,7 @@ func Reconcile(
 	statefulSets sset.StatefulSetList,
 	meta metadata.Metadata) error {
 	licenseChecker := lic.NewLicenseChecker(k8sClient, operatorNamespace)
-	enterpriseEnabled, err := licenseChecker.EnterpriseFeaturesEnabled(ctx)
+	enterpriseEnabled, err := lic.EnterpriseFeaturesEnabledForCluster(ctx, licenseChecker, es.Spec.IsBasicLicense())
 	if err != nil {
 		return fmt.Errorf("while checking license during pdb reconciliation: %w", err)
 	}

--- a/pkg/controller/elasticsearch/remotecluster/elasticsearch.go
+++ b/pkg/controller/elasticsearch/remotecluster/elasticsearch.go
@@ -48,7 +48,7 @@ func UpdateSettings(
 	span, _ := apm.StartSpan(ctx, "update_remote_clusters", tracing.SpanTypeApp)
 	defer span.End()
 
-	enabled, err := licenseChecker.EnterpriseFeaturesEnabled(ctx)
+	enabled, err := license.EnterpriseFeaturesEnabledForCluster(ctx, licenseChecker, es.Spec.IsBasicLicense())
 	if err != nil {
 		return true, err
 	}

--- a/pkg/controller/license/license_controller.go
+++ b/pkg/controller/license/license_controller.go
@@ -207,6 +207,20 @@ func (r *ReconcileLicenses) reconcileClusterLicense(ctx context.Context, cluster
 	log := ulog.FromContext(ctx)
 
 	var noResult time.Time
+
+	// If the cluster is configured for a basic license, do not create a cluster license secret.
+	// Delete any existing one to ensure the ES license reconciler will revert to basic.
+	if cluster.Spec.IsBasicLicense() {
+		log.V(1).Info("Cluster configured for basic license, removing cluster license secret if present",
+			"namespace", cluster.Namespace, "es_name", cluster.Name)
+		clusterLicenseNSN := types.NamespacedName{
+			Namespace: cluster.Namespace,
+			Name:      esv1.LicenseSecretName(cluster.Name),
+		}
+		err := k8s.DeleteSecretIfExists(ctx, r.Client, clusterLicenseNSN)
+		return noResult, false, err
+	}
+
 	minVersion, err := r.minVersion(cluster)
 	if err != nil {
 		return noResult, true, err

--- a/pkg/controller/license/license_controller_test.go
+++ b/pkg/controller/license/license_controller_test.go
@@ -80,6 +80,17 @@ var cluster = &esv1.Elasticsearch{
 	},
 }
 
+var basicCluster = &esv1.Elasticsearch{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "basic-cluster",
+		Namespace: "namespace",
+	},
+	Spec: esv1.ElasticsearchSpec{
+		Version:     "8.0.0",
+		LicenseType: "basic",
+	},
+}
+
 func enterpriseLicense(t *testing.T, licenseType client.ElasticsearchLicenseType, maxNodes int, expired bool) *corev1.Secret {
 	t.Helper()
 	expiry := time.Now().Add(31 * 24 * time.Hour)
@@ -172,6 +183,42 @@ func TestReconcileLicenses_reconcileInternal(t *testing.T) {
 			k8sResources: []crclient.Object{
 				enterpriseLicense(t, client.ElasticsearchLicenseTypePlatinum, 1, true),
 				cluster,
+			},
+			wantErr:            "",
+			wantClusterLicense: false,
+			wantRequeueAfter:   false,
+		},
+		{
+			name:    "basic license cluster: no cluster license created even with valid enterprise license",
+			cluster: basicCluster,
+			k8sResources: []crclient.Object{
+				enterpriseLicense(t, client.ElasticsearchLicenseTypePlatinum, 1, false),
+				basicCluster,
+			},
+			wantErr:            "",
+			wantClusterLicense: false,
+			wantRequeueAfter:   false,
+		},
+		{
+			name:    "basic license cluster: existing cluster license is deleted",
+			cluster: basicCluster,
+			k8sResources: []crclient.Object{
+				enterpriseLicense(t, client.ElasticsearchLicenseTypePlatinum, 1, false),
+				basicCluster,
+				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+					Name:      esv1.LicenseSecretName("basic-cluster"),
+					Namespace: "namespace",
+				}},
+			},
+			wantErr:            "",
+			wantClusterLicense: false,
+			wantRequeueAfter:   false,
+		},
+		{
+			name:    "basic license cluster without enterprise license: no license created",
+			cluster: basicCluster,
+			k8sResources: []crclient.Object{
+				basicCluster,
 			},
 			wantErr:            "",
 			wantClusterLicense: false,

--- a/pkg/license/aggregator.go
+++ b/pkg/license/aggregator.go
@@ -14,8 +14,10 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
 
 	apmv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/apm/v1"
+	commonv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/elasticsearch/v1"
 	entv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/enterprisesearch/v1"
 	kbv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/kibana/v1"
@@ -35,11 +37,17 @@ type aggregator struct {
 	client k8s.Client
 }
 
-type aggregate func(ctx context.Context) (managedMemory, error)
+type aggregate func(ctx context.Context, basicClusters map[types.NamespacedName]bool) (managedMemory, error)
 
-// aggregateMemory aggregates the total memory of all Elastic managed components
+// aggregateMemory aggregates the total memory of all Elastic managed components.
+// Clusters configured with a basic license and their associated resources are excluded.
 func (a aggregator) aggregateMemory(ctx context.Context) (memoryUsage, error) {
 	usage := newMemoryUsage()
+
+	basicClusters, err := a.basicLicensedClusters(ctx)
+	if err != nil {
+		return memoryUsage{}, err
+	}
 
 	for _, f := range []aggregate{
 		a.aggregateElasticsearchMemory,
@@ -48,7 +56,7 @@ func (a aggregator) aggregateMemory(ctx context.Context) (memoryUsage, error) {
 		a.aggregateEnterpriseSearchMemory,
 		a.aggregateLogstashMemory,
 	} {
-		memory, err := f(ctx)
+		memory, err := f(ctx, basicClusters)
 		if err != nil {
 			return memoryUsage{}, err
 		}
@@ -58,7 +66,48 @@ func (a aggregator) aggregateMemory(ctx context.Context) (memoryUsage, error) {
 	return usage, nil
 }
 
-func (a aggregator) aggregateElasticsearchMemory(ctx context.Context) (managedMemory, error) {
+// basicLicensedClusters returns the set of Elasticsearch clusters configured with a basic license.
+func (a aggregator) basicLicensedClusters(ctx context.Context) (map[types.NamespacedName]bool, error) {
+	var esList esv1.ElasticsearchList
+	if err := a.client.List(ctx, &esList); err != nil {
+		return nil, errors.Wrap(err, "failed to list Elasticsearch clusters for license check")
+	}
+	result := make(map[types.NamespacedName]bool)
+	for _, es := range esList.Items {
+		if es.Spec.IsBasicLicense() {
+			result[types.NamespacedName{Namespace: es.Namespace, Name: es.Name}] = true
+		}
+	}
+	return result, nil
+}
+
+// isReferencingBasicCluster returns true if the given ElasticsearchRef points to a basic-licensed cluster.
+func isReferencingBasicCluster(ref commonv1.ObjectSelector, resourceNamespace string, basicClusters map[types.NamespacedName]bool) bool {
+	if ref.Name == "" {
+		return false
+	}
+	ns := ref.Namespace
+	if ns == "" {
+		ns = resourceNamespace
+	}
+	return basicClusters[types.NamespacedName{Namespace: ns, Name: ref.Name}]
+}
+
+// allRefsBasic returns true if all Elasticsearch references point to basic-licensed clusters.
+// Returns true if there are no references (no enterprise cluster to bill against).
+func allRefsBasic(refs []lsv1alpha1.ElasticsearchCluster, resourceNamespace string, basicClusters map[types.NamespacedName]bool) bool {
+	if len(refs) == 0 {
+		return false
+	}
+	for _, ref := range refs {
+		if !isReferencingBasicCluster(ref.ObjectSelector, resourceNamespace, basicClusters) {
+			return false
+		}
+	}
+	return true
+}
+
+func (a aggregator) aggregateElasticsearchMemory(ctx context.Context, basicClusters map[types.NamespacedName]bool) (managedMemory, error) {
 	var esList esv1.ElasticsearchList
 	err := a.client.List(context.Background(), &esList)
 	if err != nil {
@@ -67,6 +116,9 @@ func (a aggregator) aggregateElasticsearchMemory(ctx context.Context) (managedMe
 
 	var total resource.Quantity
 	for _, es := range esList.Items {
+		if es.Spec.IsBasicLicense() {
+			continue
+		}
 		for _, nodeSet := range es.Spec.NodeSets {
 			mem, err := containerMemLimits(
 				nodeSet.PodTemplate.Spec.Containers,
@@ -87,7 +139,7 @@ func (a aggregator) aggregateElasticsearchMemory(ctx context.Context) (managedMe
 	return managedMemory{total, elasticsearchKey}, nil
 }
 
-func (a aggregator) aggregateEnterpriseSearchMemory(ctx context.Context) (managedMemory, error) {
+func (a aggregator) aggregateEnterpriseSearchMemory(ctx context.Context, basicClusters map[types.NamespacedName]bool) (managedMemory, error) {
 	var entList entv1.EnterpriseSearchList
 	err := a.client.List(context.Background(), &entList)
 	if err != nil {
@@ -96,6 +148,9 @@ func (a aggregator) aggregateEnterpriseSearchMemory(ctx context.Context) (manage
 
 	var total resource.Quantity
 	for _, ent := range entList.Items {
+		if isReferencingBasicCluster(ent.Spec.ElasticsearchRef, ent.Namespace, basicClusters) {
+			continue
+		}
 		mem, err := containerMemLimits(
 			ent.Spec.PodTemplate.Spec.Containers,
 			entv1.EnterpriseSearchContainerName,
@@ -114,7 +169,7 @@ func (a aggregator) aggregateEnterpriseSearchMemory(ctx context.Context) (manage
 	return managedMemory{total, entSearchKey}, nil
 }
 
-func (a aggregator) aggregateKibanaMemory(ctx context.Context) (managedMemory, error) {
+func (a aggregator) aggregateKibanaMemory(ctx context.Context, basicClusters map[types.NamespacedName]bool) (managedMemory, error) {
 	var kbList kbv1.KibanaList
 	err := a.client.List(context.Background(), &kbList)
 	if err != nil {
@@ -123,6 +178,9 @@ func (a aggregator) aggregateKibanaMemory(ctx context.Context) (managedMemory, e
 
 	var total resource.Quantity
 	for _, kb := range kbList.Items {
+		if isReferencingBasicCluster(kb.Spec.ElasticsearchRef, kb.Namespace, basicClusters) {
+			continue
+		}
 		mem, err := containerMemLimits(
 			kb.Spec.PodTemplate.Spec.Containers,
 			kbv1.KibanaContainerName,
@@ -141,7 +199,7 @@ func (a aggregator) aggregateKibanaMemory(ctx context.Context) (managedMemory, e
 	return managedMemory{total, kibanaKey}, nil
 }
 
-func (a aggregator) aggregateLogstashMemory(ctx context.Context) (managedMemory, error) {
+func (a aggregator) aggregateLogstashMemory(ctx context.Context, basicClusters map[types.NamespacedName]bool) (managedMemory, error) {
 	var lsList lsv1alpha1.LogstashList
 	err := a.client.List(context.Background(), &lsList)
 	if err != nil {
@@ -150,6 +208,9 @@ func (a aggregator) aggregateLogstashMemory(ctx context.Context) (managedMemory,
 
 	var total resource.Quantity
 	for _, ls := range lsList.Items {
+		if allRefsBasic(ls.Spec.ElasticsearchRefs, ls.Namespace, basicClusters) {
+			continue
+		}
 		mem, err := containerMemLimits(
 			ls.Spec.PodTemplate.Spec.Containers,
 			lsv1alpha1.LogstashContainerName,
@@ -168,7 +229,7 @@ func (a aggregator) aggregateLogstashMemory(ctx context.Context) (managedMemory,
 	return managedMemory{total, logstashKey}, nil
 }
 
-func (a aggregator) aggregateApmServerMemory(ctx context.Context) (managedMemory, error) {
+func (a aggregator) aggregateApmServerMemory(ctx context.Context, basicClusters map[types.NamespacedName]bool) (managedMemory, error) {
 	var asList apmv1.ApmServerList
 	err := a.client.List(context.Background(), &asList)
 	if err != nil {
@@ -177,6 +238,9 @@ func (a aggregator) aggregateApmServerMemory(ctx context.Context) (managedMemory
 
 	var total resource.Quantity
 	for _, as := range asList.Items {
+		if isReferencingBasicCluster(as.Spec.ElasticsearchRef, as.Namespace, basicClusters) {
+			continue
+		}
 		mem, err := containerMemLimits(
 			as.Spec.PodTemplate.Spec.Containers,
 			apmv1.ApmServerContainerName,

--- a/pkg/license/aggregator_test.go
+++ b/pkg/license/aggregator_test.go
@@ -14,13 +14,16 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apmv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/apm/v1"
+	commonv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/elasticsearch/v1"
 	entv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/enterprisesearch/v1"
 	kbv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/kibana/v1"
@@ -152,6 +155,122 @@ func TestAggregator(t *testing.T) {
 		require.Equal(t, v, val.appUsage[k].inGiB(), k)
 	}
 	require.Equal(t, 329.9073486328125, val.totalMemory.inGiB(), "total")
+}
+
+func TestAggregator_BasicLicenseExcluded(t *testing.T) {
+	// Create an enterprise ES cluster and a basic ES cluster, plus a Kibana referencing each.
+	enterpriseES := &esv1.Elasticsearch{
+		ObjectMeta: metav1.ObjectMeta{Name: "enterprise-es", Namespace: "default"},
+		Spec: esv1.ElasticsearchSpec{
+			Version: "8.0.0",
+			NodeSets: []esv1.NodeSet{{
+				Name:  "data",
+				Count: 1,
+				PodTemplate: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "elasticsearch",
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("4Gi")},
+						},
+					}},
+				}},
+			}},
+		},
+	}
+	basicES := &esv1.Elasticsearch{
+		ObjectMeta: metav1.ObjectMeta{Name: "basic-es", Namespace: "default"},
+		Spec: esv1.ElasticsearchSpec{
+			Version:     "8.0.0",
+			LicenseType: "basic",
+			NodeSets: []esv1.NodeSet{{
+				Name:  "data",
+				Count: 2,
+				PodTemplate: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "elasticsearch",
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("8Gi")},
+						},
+					}},
+				}},
+			}},
+		},
+	}
+	// Kibana referencing enterprise cluster
+	kbEnterprise := &kbv1.Kibana{
+		ObjectMeta: metav1.ObjectMeta{Name: "kb-enterprise", Namespace: "default"},
+		Spec: kbv1.KibanaSpec{
+			ElasticsearchRef: commonv1.ObjectSelector{Name: "enterprise-es", Namespace: "default"},
+			Count:            1,
+			PodTemplate: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: "kibana",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1Gi")},
+					},
+				}},
+			}},
+		},
+	}
+	// Kibana referencing basic cluster
+	kbBasic := &kbv1.Kibana{
+		ObjectMeta: metav1.ObjectMeta{Name: "kb-basic", Namespace: "default"},
+		Spec: kbv1.KibanaSpec{
+			ElasticsearchRef: commonv1.ObjectSelector{Name: "basic-es", Namespace: "default"},
+			Count:            1,
+			PodTemplate: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: "kibana",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("2Gi")},
+					},
+				}},
+			}},
+		},
+	}
+
+	c := k8s.NewFakeClient(enterpriseES, basicES, kbEnterprise, kbBasic)
+	a := aggregator{client: c}
+
+	val, err := a.aggregateMemory(context.Background())
+	require.NoError(t, err)
+
+	// Only enterprise ES cluster (4Gi) should be counted, not basic (2 * 8Gi = 16Gi)
+	require.Equal(t, 4.0, val.appUsage[elasticsearchKey].inGiB(), "elasticsearch")
+	// Only Kibana referencing enterprise cluster (1Gi) should be counted, not basic (2Gi)
+	require.Equal(t, 1.0, val.appUsage[kibanaKey].inGiB(), "kibana")
+	// Total = 4 + 1 = 5
+	require.Equal(t, 5.0, val.totalMemory.inGiB(), "total")
+}
+
+func TestAggregator_AllBasicExcluded(t *testing.T) {
+	// All clusters basic: everything excluded
+	basicES := &esv1.Elasticsearch{
+		ObjectMeta: metav1.ObjectMeta{Name: "basic-es", Namespace: "default"},
+		Spec: esv1.ElasticsearchSpec{
+			Version:     "8.0.0",
+			LicenseType: "basic",
+			NodeSets: []esv1.NodeSet{{
+				Name:  "data",
+				Count: 1,
+				PodTemplate: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "elasticsearch",
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("4Gi")},
+						},
+					}},
+				}},
+			}},
+		},
+	}
+
+	c := k8s.NewFakeClient(basicES)
+	a := aggregator{client: c}
+
+	val, err := a.aggregateMemory(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 0.0, val.totalMemory.inGiB(), "total should be zero when all clusters are basic")
 }
 
 func readObjects(t *testing.T, filePath string) []client.Object {


### PR DESCRIPTION
## Summary

Adds a new `spec.licenseType` field to the Elasticsearch CRD, allowing individual clusters to opt out of enterprise licensing by setting `spec.licenseType: basic`. This addresses the need to run smaller utility clusters on the free basic license without consuming enterprise license capacity.

Closes #8948

### Changes

- **CRD**: New `licenseType` field on `ElasticsearchSpec` with kubebuilder `Enum` validation (`basic`/`enterprise`)
- **License controller**: Skips basic-licensed clusters during license reconciliation and removes any existing cluster license secrets
- **ES license reconciler**: Calls `startBasic` to revert clusters explicitly configured for basic licensing
- **Enterprise feature gates**: PDB reconciliation, remote cluster settings, and file settings all respect the per-cluster license type
- **ERU aggregator**: Excludes basic-licensed ES clusters and their associated Kibana/APM/EntSearch/Logstash resources from Enterprise Resource Unit billing

### Usage

```yaml
apiVersion: elasticsearch.k8s.elastic.co/v1
kind: Elasticsearch
metadata:
  name: my-small-cluster
spec:
  version: 8.17.0
  licenseType: basic       # "basic" or "enterprise" (default: empty = enterprise if available)
  nodeSets:
  - name: default
    count: 1
```

### Edge cases

| Scenario | Behavior |
|----------|----------|
| `licenseType: basic` set on running enterprise cluster | License secret deleted, `startBasic()` called, enterprise features disabled |
| `licenseType` removed/cleared from basic cluster | License controller resumes, enterprise license applied |
| Field empty/unset (default) | Unchanged from current behavior |
| Invalid value | Rejected by webhook via kubebuilder `Enum` validation |

## Test plan

- [x] Unit tests for `IsBasicLicense()` helper (6 cases)
- [x] Unit tests for `EnterpriseFeaturesEnabledForCluster()` (4 cases)
- [x] Unit tests for license controller with basic clusters (3 cases)
- [x] Unit tests for ES license reconciler `Reconcile` with basic clusters (5 cases)
- [x] Unit tests for ERU aggregator excluding basic clusters (2 cases)
- [ ] Manual: Deploy operator with enterprise license, create two ES clusters (one basic, one default), verify licensing and ERU
- [ ] Manual: Toggle `licenseType` on a running cluster and verify transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)