### PR TITLE
Add loop-backed local volumes for Kind clusters

### DIFF
--- a/hack/deployer/config/local-disks-kind/kind-pv-size-patch.yaml
+++ b/hack/deployer/config/local-disks-kind/kind-pv-size-patch.yaml
@@ -1,0 +1,20 @@
+# Kind: 4x5 GiB loop-backed PVs so each ES Pod sees individual volume capacity via df,
+# preventing multiple pods from all trying to allocate 90% of the shared host disk for cache.
+# PV_SIZE_GB=5: backing files are sparse but grow as ES writes (cache, indices). All PVs
+# share the Docker Desktop VM disk, so keep them small to avoid saturation (12 × 5 GiB max).
+# Keep PV_COUNT low: Kind nodes are containers on a single kernel, sharing one loop device
+# pool (see losetup_attach in ssd-provisioner.yaml). 4 PVs × 3 nodes = 12 loop devices.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: local-volume-provisioner
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: disk-mounts
+          env:
+            - name: PV_SIZE_GB
+              value: "5"
+            - name: PV_COUNT
+              value: "4"

--- a/hack/deployer/config/local-disks-kind/kustomization.yaml
+++ b/hack/deployer/config/local-disks-kind/kustomization.yaml
@@ -1,0 +1,10 @@
+# Kind: same as local-disks (non-AWS patch) plus smaller PVs for Kind/Docker Desktop.
+resources:
+  - ../local-disks
+patches:
+  - target:
+      group: apps
+      version: v1
+      kind: DaemonSet
+      name: local-volume-provisioner
+    path: kind-pv-size-patch.yaml

--- a/hack/deployer/config/local-disks/ssd-provisioner.yaml
+++ b/hack/deployer/config/local-disks/ssd-provisioner.yaml
@@ -88,6 +88,35 @@ data:
     # does not see a stale attachment. We set loop= before each losetup; the trap runs when a
     # command fails (shell ERR) and runs losetup -d on that device if it is still a block device.
     trap 'if [ -n "$loop" ] && [ -b "$loop" ]; then losetup -d "$loop" 2>/dev/null || true; fi' ERR
+    # losetup wrapper: creates missing /dev/loop* device nodes on demand.
+    # On VMs, /dev is devtmpfs and the kernel auto-creates nodes — this is a no-op.
+    # In Kind, nodes are Docker containers where /dev is a plain tmpfs populated with a
+    # static snapshot at container start. When losetup -f asks /dev/loop-control for a new
+    # device number, the kernel creates the node on the host's devtmpfs but not in the
+    # container's tmpfs. See https://github.com/kubernetes-sigs/kind/issues/1248
+    # Retries handle races when Kind nodes (containers on one kernel) compete for the same
+    # loop device pool: another pod can grab a device between probe and attach.
+    losetup_attach() {
+      local out dev minor attempt=0
+      while [ $attempt -lt 5 ]; do
+        out=$(losetup -f 2>&1) || true
+        dev=$(printf '%s' "$out" | grep -o '/dev/loop[0-9]*' | head -1) || true
+        if [ -n "$dev" ] && [ ! -e "$dev" ]; then
+          minor="${dev#/dev/loop}"
+          echo "Device node $dev missing in container (tmpfs /dev), creating it" >&2
+          mknod "$dev" b 7 "$minor" 2>/dev/null || true
+        fi
+        # The attach may get a different device than the one we probed (TOCTOU: another
+        # pod on the same kernel can grab it in between). If that happens the attach fails
+        # and the retry loop re-probes, creating the new device node on the next iteration.
+        if losetup -f --show "$1" 2>/dev/null; then
+          return 0
+        fi
+        attempt=$((attempt + 1))
+        echo "losetup_attach: attempt $attempt failed, retrying..." >&2
+      done
+      losetup -f --show "$1"
+    }
     # When format.sh is skipped (GKE/AKS kustomize overlay), ssd0 does not exist; pvs is created by the loop.
     mkdir -p /mnt/disks/ssd0
     for i in $(seq 1 $PV_COUNT); do
@@ -102,14 +131,14 @@ data:
       if [ ! -f "${img}" ]; then
         echo "Creating sparse file ${img} size ${PV_SIZE_GB}G"
         truncate -s "${PV_SIZE_GB}G" "${img}"
-        loop=$(losetup -f --show "${img}")
+        loop=$(losetup_attach "${img}")
         echo "Formatting ${loop} as ext4"
         mkfs.ext4 -m 0 -F "${loop}"
         # Flush ext4 superblock to the backing file before detach so the kernel sees it on reattach.
         sync
         losetup -d "${loop}"
       fi
-      loop=$(losetup -f --show "${img}")
+      loop=$(losetup_attach "${img}")
       mount -t ext4 -o defaults,noatime,nobarrier "${loop}" "${mount_point}"
       echo "Mounted ${loop} at ${mount_point}"
     done

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -168,6 +168,7 @@ plans:
   provider: kind
   kubernetesVersion: 1.35.0
   enforceSecurityPolicies: true
+  diskSetup: kubectl apply -k hack/deployer/config/local-disks-kind
   kind:
     nodeCount: 3
     nodeImage: kindest/node:v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f
@@ -179,6 +180,7 @@ plans:
   provider: kind
   kubernetesVersion: 1.35.0
   enforceSecurityPolicies: true
+  diskSetup: kubectl apply -k hack/deployer/config/local-disks-kind
   kind:
     nodeCount: 3
     nodeImage: kindest/node:v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f

--- a/hack/deployer/runner/kind.go
+++ b/hack/deployer/runner/kind.go
@@ -7,7 +7,6 @@ package runner
 import (
 	"errors"
 	"fmt"
-	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
@@ -139,32 +138,43 @@ func (k *KindDriver) create() error {
 		return err
 	}
 
-	// Get kubeconfig from kind
+	// Kind runs inside a Docker container, so the kubeconfig is not automatically added to
+	// ~/.kube/config (unlike GKE/EKS/AKS which update the default kubeconfig during creation).
+	// Merge it so that subsequent plain kubectl calls (setupDisks, kyverno.Install, etc.) work.
 	kubeCfg, err := k.getKubeConfig()
 	if err != nil {
 		return err
 	}
 	defer os.Remove(kubeCfg.Name())
 
-	// Delete standard storage class but ignore error if not found
-	if err := kubectl("--kubeconfig", kubeCfg.Name(), "delete", "storageclass", "standard"); err != nil {
+	if err := mergeKubeconfig(kubeCfg.Name()); err != nil {
 		return err
 	}
 
-	tmpStorageClass, err := k.createTmpStorageClass()
-	if err != nil {
+	// mergeKubeconfig preserves the current-context from the existing host kubeconfig.
+	// Explicitly switch to the Kind cluster to avoid targeting a previously selected cluster.
+	if err := kubectl("config", "use-context", fmt.Sprintf("kind-%s", k.plan.ClusterName)); err != nil {
 		return err
 	}
 
-	defer os.Remove(tmpStorageClass)
-
-	if k.plan.EnforceSecurityPolicies {
-		if err := kyverno.Install("--kubeconfig", kubeCfg.Name()); err != nil {
+	// Delete standard storage class (replaced by e2e-default from the local-disks overlay).
+	if k.plan.DiskSetup != "" {
+		if err := kubectl("delete", "storageclass", "standard"); err != nil {
 			return err
 		}
 	}
 
-	return kubectl("--kubeconfig", kubeCfg.Name(), "apply", "-f", tmpStorageClass)
+	if err := setupDisks(k.plan); err != nil {
+		return err
+	}
+
+	if k.plan.EnforceSecurityPolicies {
+		if err := kyverno.Install(); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (k *KindDriver) inContainerName(file *os.File) string {
@@ -283,12 +293,6 @@ func (k *KindDriver) GetCredentials() error {
 	}
 	defer os.Remove(config.Name())
 	return mergeKubeconfig(config.Name())
-}
-
-func (k *KindDriver) createTmpStorageClass() (string, error) {
-	tmpFile := filepath.Join(os.TempDir(), storageClassFileName)
-	err := os.WriteFile(tmpFile, []byte(storageClass), fs.ModePerm)
-	return tmpFile, err
 }
 
 func (k *KindDriver) ensureClientImage() error {


### PR DESCRIPTION
Fixes https://github.com/elastic/cloud-on-k8s/issues/9223

## Summary

- Kind nodes are Docker containers sharing a single host kernel, so host-directory PVs expose the full host disk capacity to every Pod. When multiple ES Pods each try to allocate 90% of remaining space for cache, they all see the same disk and over-allocate.
- Add a `local-disks-kind` kustomize overlay (4x5 GiB loop-backed PVs per node) that gives each PV its own ext4 filesystem, so `df` reports individual volume capacity.

### Changes

- New `hack/deployer/config/local-disks-kind/` overlay with `PV_COUNT=4` (Kind nodes share one loop device pool across all nodes)
- Wire `diskSetup` into `kind-dev` and `kind-ci` plans
- Update Kind driver to merge kubeconfig before `setupDisks`, and skip the simple `local-path` StorageClass when `diskSetup` is configured
- Fix `losetup_attach` in the base `entrypoint.sh`: Kind nodes may lack `/dev/loop*` device nodes, so probe via `losetup -f`, parse the output to extract the device path, and `mknod` on demand before attaching

## Test plan

- [x] Verify kustomize renders correctly for all overlays (`local-disks`, `local-disks-aks`, `local-disks-ocp`, `local-disks-kind`)
- [x] Create a Kind cluster with the deployer and verify loop-backed PVs are created
- [x] Run E2E tests on Kind to confirm ES Pods see individual PV capacity
- [x] Verify no regression on cloud providers (EKS, GKE, AKS) manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)