### PR TITLE
[3.3] Fix boringcrypto golang version check in FIPS binary validation

### DIFF
--- a/.buildkite/scripts/build/verify-fips-binary.sh
+++ b/.buildkite/scripts/build/verify-fips-binary.sh
@@ -43,7 +43,7 @@ fi
 
 if [[ "${fips_type}" == "boringcrypto" ]]; then
   go_ver_output=$(go version -m "${binary}" 2>&1)
-  if [[ "${go_ver_output}" != *'-X:boringcrypto'* ]]; then
+  if [[ "${go_ver_output}" != *'X:boringcrypto'* ]]; then
     echo "FAIL: binary does not have boringcrypto in golang version string" >&2
     rc=1
   fi


### PR DESCRIPTION
Fix boringcrypto golang version check in FIPS binary validation.

The Golang version of a binary is different between 1.25 and 1.26 when boringcrypto is linked. I adjusted the validation binary script accordingly. 


Fix to this backport: https://github.com/elastic/cloud-on-k8s/pull/9266