### PR TITLE
fix: propagate integration test failures in integration-xml target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,10 +182,12 @@ integration: clean
 
 integration-xml: GO_TAGS += integration
 integration-xml: clean
-	@ for pkg in $$(grep 'go:build integration' -rl | grep _test.go | xargs -n1 dirname | uniq); do \
+	@ exit_code=0; \
+	for pkg in $$(grep 'go:build integration' -rl | grep _test.go | xargs -n1 dirname | uniq); do \
 	KUBEBUILDER_ASSETS=/usr/local/bin ECK_TEST_LOG_LEVEL=$(LOG_VERBOSITY) \
-		gotestsum --junitfile integration-tests.xml -- $$(pwd)/$$pkg -tags='$(GO_TAGS)' -cover $(TEST_OPTS) ; \
-	done
+		gotestsum --junitfile integration-tests-$$(basename $$pkg).xml -- $$(pwd)/$$pkg -tags='$(GO_TAGS)' -cover $(TEST_OPTS) || exit_code=$$? ; \
+	done; \
+	exit $$exit_code
 
 lint:
 	GOGC=40 golangci-lint run --verbose


### PR DESCRIPTION
The integration-xml target uses a for loop like this:
```                                                                                                                                                                                                                                                          
   @ for pkg in $$(grep 'go:build integration' -rl | grep _test.go | xargs -n1 dirname | uniq); do \                                                                                                                                                                                                                        
   KUBEBUILDER_ASSETS=/usr/local/bin ECK_TEST_LOG_LEVEL=$(LOG_VERBOSITY) \
       gotestsum --junitfile integration-tests.xml -- $$(pwd)/$$pkg -tags='$(GO_TAGS)' -cover $(TEST_OPTS) ; \
   done            
```                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                            
   The critical issue: The loop runs `gotestsum` multiple times, each with `--junitfile integration-tests.xml`                                                                                                                                                                                                                 
   This means:
   - First iteration: Creates integration-tests.xml with results from first package
   - Second iteration: OVERWRITES integration-tests.xml with results from second package only
   - Final XML file only contains the last package's test results

   This is a PROBLEM because:
   1. Only the last package's test results are preserved
   2. All previous packages' test results are lost
   3. The buildkite pipeline might show the build as successful if the last package's tests pass, even if earlier packages failed

### Steps taken
1. Push commit to force failure (https://github.com/elastic/cloud-on-k8s/pull/9277/commits/30ff81895d2b89ec05f1f7e234dee2cca324ede4)
2. Push commit with pipeline fix
3. Confirm pipeline now returns expected exit code (see [here](https://buildkite.com/elastic/cloud-on-k8s-operator/builds/13886))
4. Drop force-failure commit