### PR TITLE
[3.3] Bump go to 1.25.8

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,6 @@
 # ---------------------------------------------
 # Build the operator binary
-FROM docker.elastic.co/wolfi/go:1.25.7-r0@sha256:9227cbd3114dc22685223176d02a11e3e31c4368cf28d00c01f651fa7c38e342 AS builder
+FROM docker.elastic.co/wolfi/go:1.25.8-r1@sha256:18f228e409111fd89115c7461209fd8ad59d94b8f72a1a8a38d88c166971d898 AS builder
 
 ARG VERSION
 ARG SHA1

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/elastic/cloud-on-k8s/v3
 
 go 1.25.0
 
-toolchain go1.25.7
+toolchain go1.25.8
 
 require (
 	dario.cat/mergo v1.0.2

--- a/hack/config-extractor/go.mod
+++ b/hack/config-extractor/go.mod
@@ -2,7 +2,7 @@ module github.com/elastic/cloud-on-k8s/v3/hack/config-extractor
 
 go 1.25.0
 
-toolchain go1.25.7
+toolchain go1.25.8
 
 require (
 	k8s.io/api v0.35.0

--- a/hack/helm/release/go.mod
+++ b/hack/helm/release/go.mod
@@ -2,7 +2,7 @@ module github.com/elastic/cloud-on-k8s/hack/helm/release
 
 go 1.25.0
 
-toolchain go1.25.7
+toolchain go1.25.8
 
 require (
 	cloud.google.com/go/storage v1.58.0

--- a/hack/manifest-gen/Dockerfile
+++ b/hack/manifest-gen/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/go:1.25.7-r0@sha256:9227cbd3114dc22685223176d02a11e3e31c4368cf28d00c01f651fa7c38e342 as builder
+FROM docker.elastic.co/wolfi/go:1.25.8-r1@sha256:18f228e409111fd89115c7461209fd8ad59d94b8f72a1a8a38d88c166971d898 as builder
 ADD . /manifest-gen
 WORKDIR /manifest-gen
 ENV GO111MODULE=on CGO_ENABLED=0 GOOS=linux

--- a/hack/manifest-gen/go.mod
+++ b/hack/manifest-gen/go.mod
@@ -2,7 +2,7 @@ module github.com/elastic/cloud-on-k8s/v3/hack/manifest-gen
 
 go 1.24.0
 
-toolchain go1.25.7
+toolchain go1.25.8
 
 require (
 	github.com/spf13/cobra v1.10.2

--- a/hack/operatorhub/go.mod
+++ b/hack/operatorhub/go.mod
@@ -2,7 +2,7 @@ module github.com/elastic/cloud-on-k8s/v3/hack/operatorhub
 
 go 1.25.0
 
-toolchain go1.25.7
+toolchain go1.25.8
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0

--- a/hack/release-notes/go.mod
+++ b/hack/release-notes/go.mod
@@ -2,7 +2,7 @@ module github.com/elastic/cloud-on-k8s/v3/hack/release-notes
 
 go 1.24.0
 
-toolchain go1.25.7
+toolchain go1.25.8
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/hack/upgrade-test-harness/go.mod
+++ b/hack/upgrade-test-harness/go.mod
@@ -2,7 +2,7 @@ module github.com/elastic/cloud-on-k8s/v3/hack/upgrade-test-harness
 
 go 1.25.0
 
-toolchain go1.25.7
+toolchain go1.25.8
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -1,5 +1,5 @@
 # Docker image for the E2E tests runner
-FROM docker.io/library/golang:1.25.5
+FROM docker.io/library/golang:1.25.8
 
 ARG GO_TAGS
 ARG ARCH


### PR DESCRIPTION
Bump go `1.25.8` for the upcoming 3.3.2 release.