### PR TITLE
Optimize makefile performance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ endif
 REGISTRY            ?= docker.elastic.co
 
 export SNAPSHOT     ?= true
-# ?= keeps the variable recursively expanded, so the $(shell) would re-run on every reference.
+# `export` + `?=` + `shell` keeps the variables recursively expanded and thus a huge amount of shell invocations.
 # Splitting into ?= then := ensures the shell command runs at most once and the result is cached.
 VERSION             ?= $(shell cat VERSION)
 export VERSION      := $(VERSION)


### PR DESCRIPTION
> claude sonnet 4.6 was used to write this description

## Summary

Optimize Makefile performance by converting eagerly-exported `shell` variables to simply-expanded (`:=`) variables.

TLDR: This fix saves almost ~7sec on each make execution.

## Problem

The previous Makefile used the pattern:

```makefile
export VERSION ?= $(shell cat VERSION)
export SHA1    ?= $(shell git rev-parse --short=8 --verify HEAD)
export ARCH    ?= $(shell uname -m | sed -e "s|x86_|amd|" -e "s|aarch|arm|")
```

Combining `export` with `?=` (recursively-expanded, lazy assignment) causes these `$(shell ...)` calls to be **re-evaluated every time** the variable is referenced — including once for every sub-make invocation and every recipe line that inherits the environment. In a large Makefile with many targets, this means:

- `cat VERSION` is executed repeatedly instead of once.
- `git rev-parse` is forked repeatedly, adding process overhead and potential latency on every target that reads `SHA1`.
- `uname | sed` is forked repeatedly for `ARCH`.

Each individual call is cheap, but the cumulative effect across a full build (which may invoke dozens of targets and sub-processes) adds unnecessary wall-clock time and I/O.

#### Example
While the `switch-kind` is basically printing a constant string into a file, the target takes around 7.8sec to run.
By inspecting `make --debug=a switch-kind` we can see how many times the variables VERSION (930 logs), SHA1 (1088 logs), ARCH (606 logs) are being expanded.


## Solution

Split each variable into two statements:

```makefile
VERSION        ?= $(shell cat VERSION)
export VERSION := $(VERSION)
```

1. **`?=`** preserves the ability to override from the environment or command line (`make VERSION=1.2.3`).
2. **`:=`** (simply-expanded) evaluates the shell command **exactly once** at parse time and caches the result for the rest of the Makefile execution.
3. **`export`** on the `:=` line ensures the resolved value is still passed to sub-processes.

This applies to `VERSION`, `SHA1`, and `ARCH`.

## Testing

**Time of execution**
Before
```plain
time make switch-kind

real    0m7.830s
user    0m1.840s
sys     0m2.666s
```

After
```plain
time make switch-kind

real    0m0.254s
user    0m0.070s
sys     0m0.076s
```

**Overwriting**

```plain
$ make go-build-elastic-operator
go build \
        -mod readonly \
        -ldflags '-X github.com/elastic/cloud-on-k8s/v3/pkg/about.version=3.4.0-SNAPSHOT -X github.com/elastic/cloud-on-k8s/v3/pkg/about.buildHash=9056cb29 -X github.com/elastic/cloud-on-k8s/v3/pkg/about.buildDate=2026-03-31T10:36:40Z -X github.com/elastic/cloud-on-k8s/v3/pkg/about.buildSnapshot=true ' -tags='release' -a \
        -o elastic-operator github.com/elastic/cloud-on-k8s/v3/cmd
```

```plain
$ make VERSION=fakeVersion SHA1=fakeSHA go-build-elastic-operator
go build \
        -mod readonly \
        -ldflags '-X github.com/elastic/cloud-on-k8s/v3/pkg/about.version=fakeVersion -X github.com/elastic/cloud-on-k8s/v3/pkg/about.buildHash=fakeSHA -X github.com/elastic/cloud-on-k8s/v3/pkg/about.buildDate=2026-03-31T10:37:53Z -X github.com/elastic/cloud-on-k8s/v3/pkg/about.buildSnapshot=true ' -tags='release' -a \
        -o elastic-operator github.com/elastic/cloud-on-k8s/v3/cmd
```

