### PR TITLE
Add `setup-envtest` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,11 @@ else
 CONTROLLER_GEN=$(shell which controller-gen)
 endif
 
+setup-envtest:
+ifeq ($(shell which setup-envtest 2>/dev/null),)
+	@(cd /tmp; GO111MODULE=on go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
+endif
+
 ## -- Docker image
 
 REGISTRY            ?= docker.elastic.co
@@ -179,17 +184,19 @@ helm-test:
 	@hack/helm/test.sh
 
 integration: GO_TAGS += integration
-integration: clean
-	@ for pkg in $$(grep 'go:build integration' -rl | grep _test.go | xargs -n1 dirname | uniq); do \
-		KUBEBUILDER_ASSETS=/usr/local/bin ECK_TEST_LOG_LEVEL=$(LOG_VERBOSITY) \
+integration: setup-envtest clean
+	@ kubebuilder_assets=$$(setup-envtest use -p path) ; \
+	for pkg in $$(grep 'go:build integration' -rl | grep _test.go | xargs -n1 dirname | uniq); do \
+		KUBEBUILDER_ASSETS=$$kubebuilder_assets ECK_TEST_LOG_LEVEL=$(LOG_VERBOSITY) \
 			go test $$(pwd)/$$pkg -tags='$(GO_TAGS)' -cover $(TEST_OPTS) ; \
 	done
 
 integration-xml: GO_TAGS += integration
-integration-xml: clean
-	@ exit_code=0; \
+integration-xml: setup-envtest clean
+	@ kubebuilder_assets=$$(setup-envtest use -p path) ; \
+	exit_code=0; \
 	for pkg in $$(grep 'go:build integration' -rl | grep _test.go | xargs -n1 dirname | uniq); do \
-	KUBEBUILDER_ASSETS=/usr/local/bin ECK_TEST_LOG_LEVEL=$(LOG_VERBOSITY) \
+	KUBEBUILDER_ASSETS=$$kubebuilder_assets ECK_TEST_LOG_LEVEL=$(LOG_VERBOSITY) \
 		gotestsum --junitfile integration-tests-$$(basename $$pkg).xml -- $$(pwd)/$$pkg -tags='$(GO_TAGS)' -cover $(TEST_OPTS) || exit_code=$$? ; \
 	done; \
 	exit $$exit_code


### PR DESCRIPTION
In order to streamline setting up local machines to be able to run the `integration` or `integration-xml` targets locally, add the `setup-envtest` target such that:

- `setup-envtest` target (line 34-38): installs `setup-envtest` at `latest`, only if not already on `PATH`
    - **NOTE:** `setup-envtest` lives in a subdirectory with its own `go.mod` in the `controller-runtime` repo, so it has its own versioning — you can't install it at the `controller-runtime` module version.
- `integration` and `integration-xml`: now depend on `setup-envtest` and compute `KUBEBUILDER_ASSETS` once via `setup-envtest use -p path` instead of hardcoding `/usr/local/bin`