### PR TITLE
[3.4] Update supported versions and stack versions for 3.4 release

### DIFF
--- a/.buildkite/e2e/nightly-main-matrix.yaml
+++ b/.buildkite/e2e/nightly-main-matrix.yaml
@@ -3,10 +3,10 @@
   fixed:
     E2E_PROVIDER: gke
   mixed:
-    - E2E_STACK_VERSION: "8.19.11"
-    - E2E_STACK_VERSION: "9.2.5"
-    # current stack version 9.3.0 is tested in all other tests no need to test it again
-    - E2E_STACK_VERSION: "8.19.12-SNAPSHOT"
+    - E2E_STACK_VERSION: "8.19.13"
+    - E2E_STACK_VERSION: "9.2.7"
+    # current stack version 9.3.2 is tested in all other tests no need to test it again
+    - E2E_STACK_VERSION: "8.19.14-SNAPSHOT"
     - E2E_STACK_VERSION: "9.4.0-SNAPSHOT"
 
 - label: ocp
@@ -14,7 +14,7 @@
     E2E_PROVIDER: ocp
   mixed:
     ## Test the current stack version.
-    - E2E_STACK_VERSION: "9.3.0"
+    - E2E_STACK_VERSION: "9.3.2"
     ## Also test the next stack version to detect any change in the images that might not be compatible with the CRI-O runtime.
     - E2E_STACK_VERSION: "9.4.0-SNAPSHOT"
 
@@ -22,10 +22,10 @@
   fixed:
     E2E_PROVIDER: kind
   mixed:
-    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.31.12@sha256:0f5cc49c5e73c0c2bb6e2df56e7df189240d83cf94edfa30946482eb08ec57d2
-    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.32.8@sha256:abd489f042d2b644e2d033f5c2d900bc707798d075e8186cb65e3f1367a9d5a1
-    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.33.4@sha256:25a6018e48dfcaee478f4a59af81157a437f15e6e140bf103f85a2e7cd0cbbf2
-    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a
+    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.31.14@sha256:6f86cf509dbb42767b6e79debc3f2c32e4ee01386f0489b3b2be24b0a55aac2b
+    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.32.11@sha256:5fc52d52a7b9574015299724bd68f183702956aa4a2116ae75a63cb574b35af8
+    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.33.7@sha256:d26ef333bdb2cbe9862a0f7c3803ecc7b4303d8cea8e814b481b09949d353040
+    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.34.3@sha256:08497ee19eace7b4b5348db5c6a1591d7752b164530a36f855cb0f2bdcbadd48
     # The latest version of kind/k8s needs to be listed twice at the end of this list
     # as it's tested in both ipv4 and ipv6 mode.
     - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f

--- a/.buildkite/e2e/release-branch-matrix.yaml
+++ b/.buildkite/e2e/release-branch-matrix.yaml
@@ -21,22 +21,22 @@
     - E2E_STACK_VERSION: "8.16.6"
     - E2E_STACK_VERSION: "8.17.10"
     - E2E_STACK_VERSION: "8.18.8"
-    - E2E_STACK_VERSION: "8.19.11"
+    - E2E_STACK_VERSION: "8.19.13"
     - E2E_STACK_VERSION: "9.0.8"
     - E2E_STACK_VERSION: "9.1.10"
-    - E2E_STACK_VERSION: "9.2.5"
-    # current stack version 9.3.0 is tested in all other tests no need to test it again
-    - E2E_STACK_VERSION: "8.19.12-SNAPSHOT"
+    - E2E_STACK_VERSION: "9.2.7"
+    # current stack version 9.3.2 is tested in all other tests no need to test it again
+    - E2E_STACK_VERSION: "8.19.14-SNAPSHOT"
     - E2E_STACK_VERSION: "9.4.0-SNAPSHOT"
 
 - label: kind
   fixed:
     E2E_PROVIDER: kind
   mixed:
-    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.31.12@sha256:0f5cc49c5e73c0c2bb6e2df56e7df189240d83cf94edfa30946482eb08ec57d2
-    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.32.8@sha256:abd489f042d2b644e2d033f5c2d900bc707798d075e8186cb65e3f1367a9d5a1
-    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.33.4@sha256:25a6018e48dfcaee478f4a59af81157a437f15e6e140bf103f85a2e7cd0cbbf2
-    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a
+    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.31.14@sha256:6f86cf509dbb42767b6e79debc3f2c32e4ee01386f0489b3b2be24b0a55aac2b
+    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.32.11@sha256:5fc52d52a7b9574015299724bd68f183702956aa4a2116ae75a63cb574b35af8
+    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.33.7@sha256:d26ef333bdb2cbe9862a0f7c3803ecc7b4303d8cea8e814b481b09949d353040
+    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.34.3@sha256:08497ee19eace7b4b5348db5c6a1591d7752b164530a36f855cb0f2bdcbadd48
     # The latest version of kind/k8s needs to be listed twice at the end of this list
     # as it's tested in both ipv4 and ipv6 mode.
     - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f
@@ -65,10 +65,10 @@
   fixed:
     E2E_PROVIDER: ocp
   mixed:
-    - DEPLOYER_CLIENT_VERSION: "4.21.6"
-      E2E_STACK_VERSION: "9.2.4"
-    - DEPLOYER_CLIENT_VERSION: "4.21.6"
-      E2E_STACK_VERSION: "9.3.0-SNAPSHOT"
+    - DEPLOYER_CLIENT_VERSION: "4.21.7"
+      E2E_STACK_VERSION: "9.2.7"
+    - DEPLOYER_CLIENT_VERSION: "4.21.7"
+      E2E_STACK_VERSION: "9.3.2"
 
 - label: eks-arm
   fixed:

--- a/Makefile
+++ b/Makefile
@@ -463,7 +463,7 @@ drivah-build-e2e:
 
 # -- run
 
-E2E_STACK_VERSION          ?= 9.3.0
+E2E_STACK_VERSION          ?= 9.3.2
 # regexp to filter tests to run
 export TESTS_MATCH         ?= "^Test"
 export E2E_JSON            ?= false

--- a/config/e2e/monitoring.yaml
+++ b/config/e2e/monitoring.yaml
@@ -5,7 +5,7 @@ metadata:
   name: e2e-agent
   namespace: {{ .E2ENamespace }}
 spec:
-  version: 9.3.0
+  version: 9.3.2
   elasticsearchRefs:
     - secretName: eck-{{ .TestRun }}
   daemonSet:

--- a/config/recipes/apm-server-jaeger/apm-server-jaeger.yaml
+++ b/config/recipes/apm-server-jaeger/apm-server-jaeger.yaml
@@ -4,7 +4,7 @@ metadata:
   name: apm-server-quickstart
   namespace: default
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   config:
     name: elastic-apm

--- a/config/recipes/associations-rbac/apm_es_kibana_rbac.yaml
+++ b/config/recipes/associations-rbac/apm_es_kibana_rbac.yaml
@@ -84,7 +84,7 @@ metadata:
   name: elasticsearch-sample
   namespace: elasticsearch-ns
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
     - name: default
       count: 1
@@ -97,7 +97,7 @@ metadata:
   name: kibana-sample
   namespace: kibana-ns
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   config:
     xpack.fleet.packages:
@@ -115,7 +115,7 @@ metadata:
   name: apm-apm-sample
   namespace: apmserver-ns
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: "elasticsearch-sample"

--- a/config/recipes/autopilot/elasticsearch.yaml
+++ b/config/recipes/autopilot/elasticsearch.yaml
@@ -21,7 +21,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
   - name: default
     count: 1

--- a/config/recipes/autopilot/fleet-kubernetes-integration.yaml
+++ b/config/recipes/autopilot/fleet-kubernetes-integration.yaml
@@ -20,7 +20,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
   - name: default
     count: 1
@@ -43,7 +43,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -107,7 +107,7 @@ kind: Agent
 metadata:
   name: fleet-server
 spec:
-  version: 9.3.0
+  version: 9.3.2
   kibanaRef:
     name: kibana
   elasticsearchRefs:
@@ -148,7 +148,7 @@ kind: Agent
 metadata: 
   name: elastic-agent
 spec:
-  version: 9.3.0
+  version: 9.3.2
   kibanaRef:
     name: kibana
   fleetServerRef: 

--- a/config/recipes/autopilot/kubernetes-integration.yaml
+++ b/config/recipes/autopilot/kubernetes-integration.yaml
@@ -4,7 +4,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -27,7 +27,7 @@ kind: Agent
 metadata:
   name: elastic-agent
 spec:
-  version: 9.3.0
+  version: 9.3.2
   elasticsearchRefs:
   - name: elasticsearch
   daemonSet:

--- a/config/recipes/autopilot/metricbeat_hosts.yaml
+++ b/config/recipes/autopilot/metricbeat_hosts.yaml
@@ -4,7 +4,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -28,7 +28,7 @@ metadata:
   name: metricbeat
 spec:
   type: metricbeat
-  version: 9.3.0
+  version: 9.3.2
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:

--- a/config/recipes/autoscaling/elasticsearch.yaml
+++ b/config/recipes/autoscaling/elasticsearch.yaml
@@ -51,7 +51,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
     - name: master
       count: 3

--- a/config/recipes/beats/auditbeat_hosts.yaml
+++ b/config/recipes/beats/auditbeat_hosts.yaml
@@ -4,7 +4,7 @@ metadata:
   name: auditbeat
 spec:
   type: auditbeat
-  version: 9.3.0
+  version: 9.3.2
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -118,7 +118,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
   - name: default
     count: 3
@@ -130,7 +130,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/filebeat_autodiscover.yaml
+++ b/config/recipes/beats/filebeat_autodiscover.yaml
@@ -4,7 +4,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 9.3.0
+  version: 9.3.2
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -122,7 +122,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
   - name: default
     count: 3
@@ -134,7 +134,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/filebeat_autodiscover_by_metadata.yaml
+++ b/config/recipes/beats/filebeat_autodiscover_by_metadata.yaml
@@ -4,7 +4,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 9.3.0
+  version: 9.3.2
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -118,7 +118,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
   - name: default
     count: 3
@@ -130,7 +130,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/filebeat_no_autodiscover.yaml
+++ b/config/recipes/beats/filebeat_no_autodiscover.yaml
@@ -4,7 +4,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 9.3.0
+  version: 9.3.2
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -60,7 +60,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
   - name: default
     count: 3
@@ -72,7 +72,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/heartbeat_es_kb_health.yaml
+++ b/config/recipes/beats/heartbeat_es_kb_health.yaml
@@ -4,7 +4,7 @@ metadata:
   name: heartbeat
 spec:
   type: heartbeat
-  version: 9.3.0
+  version: 9.3.2
   elasticsearchRef:
     name: elasticsearch
   config:
@@ -27,7 +27,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
   - name: default
     count: 3
@@ -39,7 +39,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/metricbeat_hosts.yaml
+++ b/config/recipes/beats/metricbeat_hosts.yaml
@@ -4,7 +4,7 @@ metadata:
   name: metricbeat
 spec:
   type: metricbeat
-  version: 9.3.0
+  version: 9.3.2
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -182,7 +182,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
   - name: default
     count: 3
@@ -194,7 +194,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/openshift_monitoring.yaml
+++ b/config/recipes/beats/openshift_monitoring.yaml
@@ -4,7 +4,7 @@ metadata:
   name: metricbeat
 spec:
   type: metricbeat
-  version: 9.3.0
+  version: 9.3.2
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -229,7 +229,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 9.3.0
+  version: 9.3.2
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -332,7 +332,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
   - name: default
     count: 3
@@ -344,7 +344,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/packetbeat_dns_http.yaml
+++ b/config/recipes/beats/packetbeat_dns_http.yaml
@@ -4,7 +4,7 @@ metadata:
   name: packetbeat
 spec:
   type: packetbeat
-  version: 9.3.0
+  version: 9.3.2
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -44,7 +44,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
   - name: default
     count: 3
@@ -56,7 +56,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/stack_monitoring.yaml
+++ b/config/recipes/beats/stack_monitoring.yaml
@@ -6,7 +6,7 @@ metadata:
   name: metricbeat
 spec:
   type: metricbeat
-  version: 9.3.0
+  version: 9.3.2
   elasticsearchRef:
     name: elasticsearch-monitoring
   config:
@@ -140,7 +140,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 9.3.0
+  version: 9.3.2
   elasticsearchRef:
     name: elasticsearch-monitoring
   kibanaRef:
@@ -260,7 +260,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
   - name: default
     count: 3
@@ -276,7 +276,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -293,7 +293,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-monitoring
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
   - name: default
     count: 3
@@ -305,7 +305,7 @@ kind: Kibana
 metadata:
   name: kibana-monitoring
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: elasticsearch-monitoring

--- a/config/recipes/elastic-agent/fleet-apm-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-apm-integration.yaml
@@ -3,7 +3,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -61,7 +61,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
   - name: default
     count: 3
@@ -73,7 +73,7 @@ kind: Agent
 metadata:
   name: fleet-server
 spec:
-  version: 9.3.0
+  version: 9.3.2
   kibanaRef:
     name: kibana
   elasticsearchRefs:
@@ -95,7 +95,7 @@ kind: Agent
 metadata: 
   name: elastic-agent
 spec:
-  version: 9.3.0
+  version: 9.3.2
   kibanaRef:
     name: kibana
   fleetServerRef: 

--- a/config/recipes/elastic-agent/fleet-custom-logs-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-custom-logs-integration.yaml
@@ -3,7 +3,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -70,7 +70,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
   - name: default
     count: 3
@@ -82,7 +82,7 @@ kind: Agent
 metadata:
   name: fleet-server
 spec:
-  version: 9.3.0
+  version: 9.3.2
   kibanaRef:
     name: kibana
   elasticsearchRefs:
@@ -104,7 +104,7 @@ kind: Agent
 metadata: 
   name: elastic-agent
 spec:
-  version: 9.3.0
+  version: 9.3.2
   kibanaRef:
     name: kibana
   fleetServerRef: 

--- a/config/recipes/elastic-agent/fleet-ingress-setup.yaml
+++ b/config/recipes/elastic-agent/fleet-ingress-setup.yaml
@@ -3,7 +3,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -57,7 +57,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
   - name: default-3
     count: 3
@@ -134,7 +134,7 @@ kind: Agent
 metadata:
   name: fleet-server
 spec:
-  version: 9.3.0
+  version: 9.3.2
   http:
     # Configuring the same certificates used for the ingress here has the effect that 
     # the CA certificate that is expected in ca.crt inside this secret is propagated to the agents
@@ -177,7 +177,7 @@ spec:
     providers.kubernetes:
       add_resource_metadata:
         deployment: true
-  version: 9.3.0
+  version: 9.3.2
   kibanaRef:
     name: kibana
   fleetServerRef:

--- a/config/recipes/elastic-agent/fleet-kubernetes-integration-nonroot.yaml
+++ b/config/recipes/elastic-agent/fleet-kubernetes-integration-nonroot.yaml
@@ -71,7 +71,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -129,7 +129,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
   - name: default
     count: 3
@@ -141,7 +141,7 @@ kind: Agent
 metadata:
   name: fleet-server
 spec:
-  version: 9.3.0
+  version: 9.3.2
   kibanaRef:
     name: kibana
   elasticsearchRefs:
@@ -161,7 +161,7 @@ kind: Agent
 metadata: 
   name: elastic-agent
 spec:
-  version: 9.3.0
+  version: 9.3.2
   kibanaRef:
     name: kibana
   fleetServerRef: 

--- a/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
@@ -3,7 +3,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -54,7 +54,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
   - name: default
     count: 3
@@ -66,7 +66,7 @@ kind: Agent
 metadata:
   name: fleet-server
 spec:
-  version: 9.3.0
+  version: 9.3.2
   kibanaRef:
     name: kibana
   elasticsearchRefs:
@@ -88,7 +88,7 @@ kind: Agent
 metadata: 
   name: elastic-agent
 spec:
-  version: 9.3.0
+  version: 9.3.2
   kibanaRef:
     name: kibana
   fleetServerRef: 

--- a/config/recipes/elastic-agent/ksm-sharding.yaml
+++ b/config/recipes/elastic-agent/ksm-sharding.yaml
@@ -3,7 +3,7 @@ kind: Agent
 metadata:
   name: elastic-agent
 spec:
-  version: 9.3.0
+  version: 9.3.2
   elasticsearchRefs:
   - name: elasticsearch
   statefulSet:
@@ -457,7 +457,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
   - name: default
     count: 3
@@ -469,7 +469,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/elastic-agent/kubernetes-integration.yaml
+++ b/config/recipes/elastic-agent/kubernetes-integration.yaml
@@ -3,7 +3,7 @@ kind: Agent
 metadata:
   name: elastic-agent
 spec:
-  version: 9.3.0
+  version: 9.3.2
   elasticsearchRefs:
   - name: elasticsearch
   daemonSet:
@@ -222,7 +222,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
   - name: default
     count: 3
@@ -234,7 +234,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/elastic-agent/multi-output.yaml
+++ b/config/recipes/elastic-agent/multi-output.yaml
@@ -3,7 +3,7 @@ kind: Agent
 metadata:
   name: elastic-agent
 spec:
-  version: 9.3.0
+  version: 9.3.2
   elasticsearchRefs:
   - outputName: default
     name: elasticsearch
@@ -196,7 +196,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
   - name: default
     count: 3
@@ -208,7 +208,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -218,7 +218,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-mon
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
   - name: default
     count: 3
@@ -230,7 +230,7 @@ kind: Kibana
 metadata:
   name: kibana-mon
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: elasticsearch-mon

--- a/config/recipes/elastic-agent/system-integration.yaml
+++ b/config/recipes/elastic-agent/system-integration.yaml
@@ -3,7 +3,7 @@ kind: Agent
 metadata:
   name: elastic-agent
 spec:
-  version: 9.3.0
+  version: 9.3.2
   elasticsearchRefs:
   - name: elasticsearch
   daemonSet:
@@ -31,7 +31,7 @@ spec:
       meta:
         package:
           name: system
-          version: 9.3.0
+          version: 9.3.2
       data_stream:
         namespace: default
       streams:
@@ -136,7 +136,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
   - name: default
     count: 3
@@ -148,7 +148,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/gclb/01-elastic-stack.yaml
+++ b/config/recipes/gclb/01-elastic-stack.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 9.3.0
+  version: 9.3.2
   http:
     service:
       metadata:
@@ -45,7 +45,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   http:
     service:

--- a/config/recipes/gclb/99-kibana-path.yaml
+++ b/config/recipes/gclb/99-kibana-path.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: thor
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   config:
     # Make Kibana aware of the fact that it is behind a proxy

--- a/config/recipes/istio-gateway/03-elasticsearch-kibana.yaml
+++ b/config/recipes/istio-gateway/03-elasticsearch-kibana.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: ekmnt
 spec:
-  version: 9.3.0
+  version: 9.3.2
   http:
     tls:
       selfSignedCertificate:
@@ -82,7 +82,7 @@ metadata:
   labels:
     app: ekmnt
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   http:
     tls:

--- a/config/recipes/logstash/logstash-eck.yaml
+++ b/config/recipes/logstash/logstash-eck.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
     - name: default
       count: 3
@@ -17,7 +17,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -28,7 +28,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 9.3.0
+  version: 9.3.2
   config:
     filebeat.inputs:
       - type: filestream
@@ -68,7 +68,7 @@ metadata:
   name: logstash
 spec:
   count: 1
-  version: 9.3.0
+  version: 9.3.2
   elasticsearchRefs:
     - clusterName: eck
       name: elasticsearch

--- a/config/recipes/logstash/logstash-es-role.yaml
+++ b/config/recipes/logstash/logstash-es-role.yaml
@@ -15,7 +15,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.3.0
+  version: 9.3.2
   auth:
     roles:
       - secretName: my-roles-secret
@@ -31,7 +31,7 @@ metadata:
   name: logstash
 spec:
   count: 1
-  version: 9.3.0
+  version: 9.3.2
   elasticsearchRefs:
     - name: elasticsearch
       clusterName: eck

--- a/config/recipes/logstash/logstash-monitored.yaml
+++ b/config/recipes/logstash/logstash-monitored.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
     - name: default
       count: 3
@@ -17,7 +17,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -28,7 +28,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 9.3.0
+  version: 9.3.2
   config:
     filebeat.inputs:
       - type: filestream
@@ -68,7 +68,7 @@ metadata:
   name: logstash
 spec:
   count: 1
-  version: 9.3.0
+  version: 9.3.2
   elasticsearchRefs:
     - clusterName: eck
       name: elasticsearch
@@ -117,7 +117,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-monitoring
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
     - name: default
       count: 3
@@ -129,7 +129,7 @@ kind: Kibana
 metadata:
   name: kibana-monitoring
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: elasticsearch-monitoring

--- a/config/recipes/logstash/logstash-multi.yaml
+++ b/config/recipes/logstash/logstash-multi.yaml
@@ -12,7 +12,7 @@ metadata:
   name: qa
   namespace: qa
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
     - name: default
       count: 3
@@ -25,7 +25,7 @@ kind: Elasticsearch
 metadata:
   name: production
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
     - name: default
       count: 3
@@ -39,7 +39,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 9.3.0
+  version: 9.3.2
   config:
     filebeat.inputs:
       - type: filestream
@@ -79,7 +79,7 @@ metadata:
   name: logstash
 spec:
   count: 1
-  version: 9.3.0
+  version: 9.3.2
   elasticsearchRefs:
   - clusterName: prod-es
     name: production

--- a/config/recipes/logstash/logstash-pipeline-as-secret.yaml
+++ b/config/recipes/logstash/logstash-pipeline-as-secret.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
     - name: default
       count: 3
@@ -17,7 +17,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -28,7 +28,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 9.3.0
+  version: 9.3.2
   config:
     filebeat.inputs:
       - type: filestream
@@ -68,7 +68,7 @@ metadata:
   name: logstash
 spec:
   count: 1
-  version: 9.3.0
+  version: 9.3.2
   elasticsearchRefs:
     - clusterName: eck
       name: elasticsearch

--- a/config/recipes/logstash/logstash-pipeline-as-volume.yaml
+++ b/config/recipes/logstash/logstash-pipeline-as-volume.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
     - name: default
       count: 3
@@ -17,7 +17,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -28,7 +28,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 9.3.0
+  version: 9.3.2
   config:
     filebeat.inputs:
       - type: filestream
@@ -68,7 +68,7 @@ metadata:
   name: logstash
 spec:
   count: 1
-  version: 9.3.0
+  version: 9.3.2
   elasticsearchRefs:
     - clusterName: eck
       name: elasticsearch

--- a/config/recipes/logstash/logstash-volumes.yaml
+++ b/config/recipes/logstash/logstash-volumes.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
     - name: default
       count: 3
@@ -18,7 +18,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 9.3.0
+  version: 9.3.2
   config:
     filebeat.inputs:
       - type: filestream
@@ -58,7 +58,7 @@ metadata:
   name: logstash
 spec:
   count: 1
-  version: 9.3.0
+  version: 9.3.2
   elasticsearchRefs:
     - clusterName: eck
       name: elasticsearch

--- a/config/recipes/maps/01-ems.yaml
+++ b/config/recipes/maps/01-ems.yaml
@@ -3,5 +3,5 @@ kind: ElasticMapsServer
 metadata:
   name: ems-sample
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1

--- a/config/recipes/maps/02-es-kb.yaml
+++ b/config/recipes/maps/02-es-kb.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
     - name: default
       count: 3
@@ -27,7 +27,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   config:
     # Configure this to a domain you control

--- a/config/recipes/mtls/manual/beats.yaml
+++ b/config/recipes/mtls/manual/beats.yaml
@@ -122,7 +122,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.3.0
+  version: 9.3.2
   http:
     tls:
       certificate:
@@ -142,7 +142,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -165,7 +165,7 @@ metadata:
   name: metricbeat
 spec:
   type: metricbeat
-  version: 9.3.0
+  version: 9.3.2
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:

--- a/config/recipes/mtls/manual/fleet.yaml
+++ b/config/recipes/mtls/manual/fleet.yaml
@@ -149,7 +149,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.3.0
+  version: 9.3.2
   http:
     tls:
       certificate:
@@ -169,7 +169,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -242,7 +242,7 @@ kind: Agent
 metadata:
   name: fleet-server
 spec:
-  version: 9.3.0
+  version: 9.3.2
   kibanaRef:
     name: kibana
   elasticsearchRefs:
@@ -302,7 +302,7 @@ kind: Agent
 metadata:
   name: elastic-agent
 spec:
-  version: 9.3.0
+  version: 9.3.2
   kibanaRef:
     name: kibana
   fleetServerRef:

--- a/config/recipes/mtls/manual/standalone-agent.yaml
+++ b/config/recipes/mtls/manual/standalone-agent.yaml
@@ -122,7 +122,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.3.0
+  version: 9.3.2
   http:
     tls:
       certificate:
@@ -142,7 +142,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -164,7 +164,7 @@ kind: Agent
 metadata:
   name: elastic-agent
 spec:
-  version: 9.3.0
+  version: 9.3.2
   elasticsearchRefs:
   - name: elasticsearch
   config:
@@ -192,7 +192,7 @@ spec:
       meta:
         package:
           name: system
-          version: 9.3.0
+          version: 9.3.2
       data_stream:
         namespace: default
       streams:

--- a/config/recipes/packageregistry/epr-eck.yaml
+++ b/config/recipes/packageregistry/epr-eck.yaml
@@ -4,7 +4,7 @@ kind: PackageRegistry
 metadata:
   name: registry
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
 ---
 apiVersion: kibana.k8s.elastic.co/v1
@@ -12,7 +12,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -48,7 +48,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
   - name: default
     count: 1
@@ -60,7 +60,7 @@ kind: Agent
 metadata:
   name: fleet-server
 spec:
-  version: 9.3.0
+  version: 9.3.2
   kibanaRef:
     name: kibana
   elasticsearchRefs:

--- a/config/recipes/packageregistry/epr-extra-ca.yaml
+++ b/config/recipes/packageregistry/epr-extra-ca.yaml
@@ -4,7 +4,7 @@ kind: PackageRegistry
 metadata:
   name: registry
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
 ---
 apiVersion: kibana.k8s.elastic.co/v1
@@ -12,7 +12,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -72,7 +72,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
   - name: default
     count: 1
@@ -84,7 +84,7 @@ kind: Agent
 metadata:
   name: fleet-server
 spec:
-  version: 9.3.0
+  version: 9.3.2
   kibanaRef:
     name: kibana
   elasticsearchRefs:

--- a/config/recipes/packageregistry/epr-volumes.yaml
+++ b/config/recipes/packageregistry/epr-volumes.yaml
@@ -4,7 +4,7 @@ kind: PackageRegistry
 metadata:
   name: registry
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   config:
     package_paths:
@@ -26,7 +26,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -62,7 +62,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
   - name: default
     count: 1
@@ -74,7 +74,7 @@ kind: Agent
 metadata:
   name: fleet-server
 spec:
-  version: 9.3.0
+  version: 9.3.2
   kibanaRef:
     name: kibana
   elasticsearchRefs:

--- a/config/recipes/remoteclusters/elasticsearch.yaml
+++ b/config/recipes/remoteclusters/elasticsearch.yaml
@@ -9,7 +9,7 @@ metadata:
   name: cluster1
   namespace: ns1
 spec:
-  version: 9.3.0
+  version: 9.3.2
   remoteClusters:
     - name: to-ns2-cluster2
       elasticsearchRef:
@@ -38,7 +38,7 @@ spec:
 #      spec:
 #        # expose this cluster Service with a LoadBalancer
 #        type: LoadBalancer
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: "cluster1"
@@ -54,7 +54,7 @@ metadata:
   name: cluster2
   namespace: ns2
 spec:
-  version: 9.3.0
+  version: 9.3.2
   ## Required for this cluster to be accessed using remote cluster API keys.
   remoteClusterServer:
     enabled: true
@@ -75,7 +75,7 @@ spec:
 #      spec:
 #        # expose this cluster Service with a LoadBalancer
 #        type: LoadBalancer
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: "cluster2"

--- a/config/recipes/traefik/02-elastic-stack.yaml
+++ b/config/recipes/traefik/02-elastic-stack.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
   - name: master
     count: 1
@@ -41,7 +41,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   config:
     xpack.fleet.packages:
@@ -57,7 +57,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: hulk

--- a/config/samples/apm/apm_es_kibana.yaml
+++ b/config/samples/apm/apm_es_kibana.yaml
@@ -5,7 +5,7 @@ kind: Elasticsearch
 metadata:
   name: es-apm-sample
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
   - name: default
     count: 3
@@ -19,7 +19,7 @@ kind: Kibana
 metadata:
   name: kb-apm-sample
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: "es-apm-sample"
@@ -33,7 +33,7 @@ kind: ApmServer
 metadata:
   name: apm-apm-sample
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: "es-apm-sample"

--- a/config/samples/elasticsearch/elasticsearch.yaml
+++ b/config/samples/elasticsearch/elasticsearch.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
   - name: default
     # Uncomment zoneAwareness to spread this NodeSet across zones.

--- a/config/samples/kibana/kibana_es.yaml
+++ b/config/samples/kibana/kibana_es.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
   - name: default
     count: 1
@@ -18,7 +18,7 @@ kind: Kibana
 metadata:
   name: kibana-sample
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 1
   elasticsearchRef:
     name: "elasticsearch-sample"

--- a/config/samples/logstash/logstash.yaml
+++ b/config/samples/logstash/logstash.yaml
@@ -3,7 +3,7 @@ kind: Logstash
 metadata:
   name: logstash-sample
 spec:
-  version: 9.3.0
+  version: 9.3.2
   count: 3
   config:
     log.level: info

--- a/config/samples/logstash/logstash_es.yaml
+++ b/config/samples/logstash/logstash_es.yaml
@@ -3,7 +3,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
     - name: default
       count: 2
@@ -16,7 +16,7 @@ metadata:
   name: logstash-sample
 spec:
   count: 1
-  version: 9.3.0
+  version: 9.3.2
   elasticsearchRefs:
     - clusterName: production
       name: elasticsearch-sample

--- a/config/samples/logstash/logstash_pv.yaml
+++ b/config/samples/logstash/logstash_pv.yaml
@@ -4,7 +4,7 @@ metadata:
   name: d
 spec:
   count: 1
-  version: 9.3.0
+  version: 9.3.2
   config:
     queue.type: persisted
   pipelines:

--- a/config/samples/logstash/logstash_stackmonitor.yaml
+++ b/config/samples/logstash/logstash_stackmonitor.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: monitoring
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
     - name: default
       count: 3
@@ -17,7 +17,7 @@ metadata:
   name: logstash-sample
 spec:
   count: 1
-  version: 9.3.0
+  version: 9.3.2
   config:
     log.level: info
     api.http.host: "0.0.0.0"
@@ -55,7 +55,7 @@ kind: Kibana
 metadata:
   name: kibana-sample
 spec:
-  version: 9.3.0
+  version: 9.3.2
   elasticsearchRef:
     name: monitoring
   count: 1

--- a/config/samples/logstash/logstash_svc.yaml
+++ b/config/samples/logstash/logstash_svc.yaml
@@ -3,7 +3,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: 9.3.0
+  version: 9.3.2
   nodeSets:
     - name: default
       count: 3
@@ -16,7 +16,7 @@ metadata:
   name: logstash-sample
 spec:
   count: 2
-  version: 9.3.0
+  version: 9.3.2
   config:
     log.level: info
     api.http.host: "0.0.0.0"

--- a/deploy/eck-stack/charts/eck-autoops-agent-policy/values.yaml
+++ b/deploy/eck-stack/charts/eck-autoops-agent-policy/values.yaml
@@ -51,7 +51,7 @@ autoOpsRef: {}
 # config: {}
 
 # Image is the AutoOps Agent Docker image to deploy.
-# image: "docker.elastic.co/elastic-agent/elastic-otel-collector-wolfi:9.3.0-SNAPSHOT"
+# image: "docker.elastic.co/elastic-agent/elastic-otel-collector-wolfi:9.4.0-SNAPSHOT"
 
 # RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying Deployment.
 # revisionHistoryLimit: 2

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -103,7 +103,7 @@ plans:
 - id: ocp-ci
   operation: create
   clusterName: ci
-  clientVersion: 4.21.6
+  clientVersion: 4.21.7
   provider: ocp
   machineType: e2-standard-8
   serviceAccount: true
@@ -114,7 +114,7 @@ plans:
 - id: ocp-dev
   operation: create
   clusterName: dev
-  clientVersion: 4.21.6
+  clientVersion: 4.21.7
   provider: ocp
   machineType: e2-standard-8
   serviceAccount: true
@@ -164,7 +164,7 @@ plans:
 - id: kind-dev
   operation: create
   clusterName: eck
-  clientVersion: 0.30.0
+  clientVersion: 0.31.0
   provider: kind
   kubernetesVersion: 1.35.0
   enforceSecurityPolicies: true
@@ -176,7 +176,7 @@ plans:
 - id: kind-ci
   operation: create
   clusterName: kind-ci
-  clientVersion: 0.30.0
+  clientVersion: 0.31.0
   provider: kind
   kubernetesVersion: 1.35.0
   enforceSecurityPolicies: true
@@ -189,15 +189,15 @@ plans:
   operation: create
   clusterName: eck
   provider: k3d
-  kubernetesVersion: 1.35.0
+  kubernetesVersion: 1.35.3
   k3d:
     clientImage: ghcr.io/k3d-io/k3d:5.8.3
-    nodeImage: rancher/k3s:v1.35.0-k3s1
+    nodeImage: rancher/k3s:v1.35.3-k3s1
 - id: k3d-ci
   operation: create
   clusterName: k3d-ci
   provider: k3d
-  kubernetesVersion: 1.35.0
+  kubernetesVersion: 1.35.3
   k3d:
     clientImage: ghcr.io/k3d-io/k3d:5.8.3
-    nodeImage: rancher/k3s:v1.35.0-k3s1
+    nodeImage: rancher/k3s:v1.35.3-k3s1


### PR DESCRIPTION
## Summary

  - Bump OpenShift client version from 4.21.6 to 4.21.7 in deployer plans and release branch e2e matrix
  - Bump kind node images to latest patch versions (kind v0.31.0):
    - 1.31.12 → 1.31.14
    - 1.32.8 → 1.32.11
    - 1.33.4 → 1.33.7
    - 1.34.0 → 1.34.3
  - Bump kind client version from 0.30.0 to 0.31.0
  - Bump k3s from v1.35.0-k3s1 to v1.35.3-k3s1
  - Update stack versions to latest released versions:
    - 8.19.11 → 8.19.13
    - 9.2.5 → 9.2.7
    - 9.3.0 → 9.3.2