### PR TITLE
[3.3] Increment eck-stack helm charts for 3.3.2 release.

### DIFF
--- a/deploy/eck-stack/Chart.yaml
+++ b/deploy/eck-stack/Chart.yaml
@@ -3,36 +3,36 @@ name: eck-stack
 description: Elastic Stack managed by the ECK Operator
 kubeVersion: ">= 1.21.0-0"
 type: application
-version: 0.18.1
+version: 0.18.2
 
 dependencies:
   - name: eck-elasticsearch
     condition: eck-elasticsearch.enabled
-    version: "0.18.1"
+    version: "0.18.2"
   - name: eck-kibana
     condition: eck-kibana.enabled
-    version: "0.18.1"
+    version: "0.18.2"
   - name: eck-agent
     condition: eck-agent.enabled
-    version: "0.18.1"
+    version: "0.18.2"
   - name: eck-fleet-server
     condition: eck-fleet-server.enabled
-    version: "0.18.1"
+    version: "0.18.2"
   - name: eck-beats
     condition: eck-beats.enabled
-    version: "0.18.1"
+    version: "0.18.2"
   - name: eck-logstash
     condition: eck-logstash.enabled
-    version: "0.18.1"
+    version: "0.18.2"
   - name: eck-apm-server
     condition: eck-apm-server.enabled
-    version: "0.18.1"
+    version: "0.18.2"
   - name: eck-enterprise-search
     condition: eck-enterprise-search.enabled
-    version: "0.18.1"
+    version: "0.18.2"
   - name: eck-autoops-agent-policy
     condition: eck-autoops-agent-policy.enabled
-    version: "0.18.1"
+    version: "0.18.2"
   - name: eck-package-registry
     condition: eck-package-registry.enabled
-    version: "0.18.1"
+    version: "0.18.2"

--- a/deploy/eck-stack/charts/eck-agent/Chart.yaml
+++ b/deploy/eck-stack/charts/eck-agent/Chart.yaml
@@ -3,7 +3,7 @@ name: eck-agent
 description: Elastic Agent managed by the ECK operator
 kubeVersion: ">= 1.21.0-0"
 type: application
-version: 0.18.1
+version: 0.18.2
 sources:
   - https://github.com/elastic/cloud-on-k8s
   - https://github.com/elastic/elastic-agent

--- a/deploy/eck-stack/charts/eck-agent/templates/tests/elastic-agent-cluster-role-binding_test.yaml
+++ b/deploy/eck-stack/charts/eck-agent/templates/tests/elastic-agent-cluster-role-binding_test.yaml
@@ -79,7 +79,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-agent
             clusterRoleBinding: label
-            helm.sh/chart: eck-agent-0.18.1
+            helm.sh/chart: eck-agent-0.18.2
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-stack/charts/eck-agent/templates/tests/elastic-agent-cluster-role_test.yaml
+++ b/deploy/eck-stack/charts/eck-agent/templates/tests/elastic-agent-cluster-role_test.yaml
@@ -138,7 +138,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-agent
             clusterRole: label
-            helm.sh/chart: eck-agent-0.18.1
+            helm.sh/chart: eck-agent-0.18.2
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-stack/charts/eck-agent/templates/tests/elastic-agent-service-account_test.yaml
+++ b/deploy/eck-stack/charts/eck-agent/templates/tests/elastic-agent-service-account_test.yaml
@@ -49,7 +49,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-agent
             serviceAccount: label
-            helm.sh/chart: eck-agent-0.18.1
+            helm.sh/chart: eck-agent-0.18.2
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-stack/charts/eck-agent/templates/tests/elastic-agent_test.yaml
+++ b/deploy/eck-stack/charts/eck-agent/templates/tests/elastic-agent_test.yaml
@@ -50,7 +50,7 @@ tests:
             app.kubernetes.io/instance: quickstart
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-agent
-            helm.sh/chart: eck-agent-0.18.1
+            helm.sh/chart: eck-agent-0.18.2
             test: label
       - equal:
           path: metadata.annotations
@@ -97,7 +97,7 @@ tests:
             app.kubernetes.io/instance: quickstart
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-agent
-            helm.sh/chart: eck-agent-0.18.1
+            helm.sh/chart: eck-agent-0.18.2
       - equal:
           path: spec
           value:
@@ -166,7 +166,7 @@ tests:
             app.kubernetes.io/instance: quickstart
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-agent
-            helm.sh/chart: eck-agent-0.18.1
+            helm.sh/chart: eck-agent-0.18.2
       - equal:
           path: spec
           value:

--- a/deploy/eck-stack/charts/eck-apm-server/Chart.yaml
+++ b/deploy/eck-stack/charts/eck-apm-server/Chart.yaml
@@ -3,7 +3,7 @@ name: eck-apm-server
 description: Elastic APM Server managed by the ECK operator
 kubeVersion: ">= 1.21.0-0"
 type: application
-version: 0.18.1
+version: 0.18.2
 sources:
   - https://github.com/elastic/cloud-on-k8s
   - https://github.com/elastic/apm-server

--- a/deploy/eck-stack/charts/eck-apm-server/templates/tests/apmserver_test.yaml
+++ b/deploy/eck-stack/charts/eck-apm-server/templates/tests/apmserver_test.yaml
@@ -62,7 +62,7 @@ tests:
             app.kubernetes.io/instance: quickstart
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-apm-server
-            helm.sh/chart: eck-apm-server-0.18.1
+            helm.sh/chart: eck-apm-server-0.18.2
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-stack/charts/eck-autoops-agent-policy/Chart.yaml
+++ b/deploy/eck-stack/charts/eck-autoops-agent-policy/Chart.yaml
@@ -3,7 +3,7 @@ name: eck-autoops-agent-policy
 description: AutoOps Agent Policy managed by the ECK operator
 kubeVersion: ">= 1.21.0-0"
 type: application
-version: 0.18.1
+version: 0.18.2
 sources:
   - https://github.com/elastic/cloud-on-k8s
 

--- a/deploy/eck-stack/charts/eck-beats/Chart.yaml
+++ b/deploy/eck-stack/charts/eck-beats/Chart.yaml
@@ -4,7 +4,7 @@ description: Elastic Beats managed by the ECK operator
 # Requirement comes from minimum version supported for eck-operator (https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s_supported_versions.html)
 kubeVersion: ">= 1.20.0-0"
 type: application
-version: 0.18.1
+version: 0.18.2
 sources:
   - https://github.com/elastic/cloud-on-k8s
   - https://github.com/elastic/beats

--- a/deploy/eck-stack/charts/eck-beats/templates/tests/beats-metricbeat-example_test.yaml
+++ b/deploy/eck-stack/charts/eck-beats/templates/tests/beats-metricbeat-example_test.yaml
@@ -122,7 +122,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-beats
             clusterRole: label
-            helm.sh/chart:  eck-beats-0.18.1
+            helm.sh/chart:  eck-beats-0.18.2
             test: label
       - equal:
           path: metadata.annotations
@@ -185,7 +185,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-beats
             clusterRoleBinding: label
-            helm.sh/chart:  eck-beats-0.18.1
+            helm.sh/chart:  eck-beats-0.18.2
             test: label
       - equal:
           path: metadata.annotations
@@ -233,7 +233,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-beats
             serviceAccount: label
-            helm.sh/chart:  eck-beats-0.18.1
+            helm.sh/chart:  eck-beats-0.18.2
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-stack/charts/eck-beats/templates/tests/beats_test.yaml
+++ b/deploy/eck-stack/charts/eck-beats/templates/tests/beats_test.yaml
@@ -63,7 +63,7 @@ tests:
             app.kubernetes.io/instance: quickstart
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-beats
-            helm.sh/chart: eck-beats-0.18.1
+            helm.sh/chart: eck-beats-0.18.2
       - equal:
           path: spec
           value:
@@ -136,7 +136,7 @@ tests:
             app.kubernetes.io/instance: quickstart
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-beats
-            helm.sh/chart: eck-beats-0.18.1
+            helm.sh/chart: eck-beats-0.18.2
       - equal:
           path: spec
           value:

--- a/deploy/eck-stack/charts/eck-elasticsearch/Chart.yaml
+++ b/deploy/eck-stack/charts/eck-elasticsearch/Chart.yaml
@@ -3,7 +3,7 @@ name: eck-elasticsearch
 description: Elasticsearch managed by the ECK operator
 kubeVersion: ">= 1.21.0-0"
 type: application
-version: 0.18.1
+version: 0.18.2
 sources:
   - https://github.com/elastic/cloud-on-k8s
   - https://github.com/elastic/elasticsearch/

--- a/deploy/eck-stack/charts/eck-elasticsearch/templates/tests/elasticsearch_test.yaml
+++ b/deploy/eck-stack/charts/eck-elasticsearch/templates/tests/elasticsearch_test.yaml
@@ -110,7 +110,7 @@ tests:
             app.kubernetes.io/instance: quickstart
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-elasticsearch
-            helm.sh/chart: eck-elasticsearch-0.18.1
+            helm.sh/chart: eck-elasticsearch-0.18.2
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-stack/charts/eck-elasticsearch/templates/tests/ingress_test.yaml
+++ b/deploy/eck-stack/charts/eck-elasticsearch/templates/tests/ingress_test.yaml
@@ -56,7 +56,7 @@ tests:
             app.kubernetes.io/instance: quickstart
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-elasticsearch
-            helm.sh/chart: eck-elasticsearch-0.18.1
+            helm.sh/chart: eck-elasticsearch-0.18.2
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-stack/charts/eck-enterprise-search/Chart.yaml
+++ b/deploy/eck-stack/charts/eck-enterprise-search/Chart.yaml
@@ -3,7 +3,7 @@ name: eck-enterprise-search
 description: Elastic Enterprise Search managed by the ECK operator
 kubeVersion: ">= 1.21.0-0"
 type: application
-version: 0.18.1
+version: 0.18.2
 sources:
   - https://github.com/elastic/cloud-on-k8s
 icon: https://github.com/elastic/ent-search/blob/main/public/app-search-favicon-196x196.png

--- a/deploy/eck-stack/charts/eck-enterprise-search/templates/tests/entsearch_test.yaml
+++ b/deploy/eck-stack/charts/eck-enterprise-search/templates/tests/entsearch_test.yaml
@@ -62,7 +62,7 @@ tests:
             app.kubernetes.io/instance: quickstart
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-enterprise-search
-            helm.sh/chart: eck-enterprise-search-0.18.1
+            helm.sh/chart: eck-enterprise-search-0.18.2
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-stack/charts/eck-fleet-server/Chart.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/Chart.yaml
@@ -3,7 +3,7 @@ name: eck-fleet-server
 description: Elastic Fleet Server as an Agent managed by the ECK operator
 kubeVersion: ">= 1.21.0-0"
 type: application
-version: 0.18.1
+version: 0.18.2
 sources:
   - https://github.com/elastic/cloud-on-k8s
   - https://github.com/elastic/elastic-agent

--- a/deploy/eck-stack/charts/eck-fleet-server/templates/tests/fleet-server-cluster-role-binding_test.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/templates/tests/fleet-server-cluster-role-binding_test.yaml
@@ -49,7 +49,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-fleet-server
             clusterRoleBinding: label
-            helm.sh/chart: eck-fleet-server-0.18.1
+            helm.sh/chart: eck-fleet-server-0.18.2
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-stack/charts/eck-fleet-server/templates/tests/fleet-server-cluster-role_test.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/templates/tests/fleet-server-cluster-role_test.yaml
@@ -88,7 +88,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-fleet-server
             clusterRole: label
-            helm.sh/chart: eck-fleet-server-0.18.1
+            helm.sh/chart: eck-fleet-server-0.18.2
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-stack/charts/eck-fleet-server/templates/tests/fleet-server-service-account_test.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/templates/tests/fleet-server-service-account_test.yaml
@@ -34,7 +34,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-fleet-server
             serviceAccount: label
-            helm.sh/chart: eck-fleet-server-0.18.1
+            helm.sh/chart: eck-fleet-server-0.18.2
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-stack/charts/eck-fleet-server/templates/tests/fleet-server_test.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/templates/tests/fleet-server_test.yaml
@@ -52,7 +52,7 @@ tests:
             app.kubernetes.io/instance: quickstart
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-fleet-server
-            helm.sh/chart: eck-fleet-server-0.18.1
+            helm.sh/chart: eck-fleet-server-0.18.2
             test: label
       - equal:
           path: metadata.annotations
@@ -87,7 +87,7 @@ tests:
             app.kubernetes.io/instance: quickstart
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-fleet-server
-            helm.sh/chart: eck-fleet-server-0.18.1
+            helm.sh/chart: eck-fleet-server-0.18.2
       - equal:
           path: spec
           value:
@@ -135,7 +135,7 @@ tests:
             app.kubernetes.io/instance: quickstart
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-fleet-server
-            helm.sh/chart: eck-fleet-server-0.18.1
+            helm.sh/chart: eck-fleet-server-0.18.2
       - equal:
           path: spec
           value:

--- a/deploy/eck-stack/charts/eck-kibana/Chart.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/Chart.yaml
@@ -3,7 +3,7 @@ name: eck-kibana
 description: Kibana managed by the ECK operator
 kubeVersion: ">= 1.21.0-0"
 type: application
-version: 0.18.1
+version: 0.18.2
 sources:
   - https://github.com/elastic/cloud-on-k8s
   - https://github.com/elastic/kibana

--- a/deploy/eck-stack/charts/eck-kibana/templates/tests/ingress_test.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/templates/tests/ingress_test.yaml
@@ -56,7 +56,7 @@ tests:
             app.kubernetes.io/instance: quickstart
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-kibana
-            helm.sh/chart: eck-kibana-0.18.1
+            helm.sh/chart: eck-kibana-0.18.2
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-stack/charts/eck-kibana/templates/tests/kibana_test.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/templates/tests/kibana_test.yaml
@@ -61,7 +61,7 @@ tests:
             app.kubernetes.io/instance: quickstart
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-kibana
-            helm.sh/chart: eck-kibana-0.18.1
+            helm.sh/chart: eck-kibana-0.18.2
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-stack/charts/eck-logstash/Chart.yaml
+++ b/deploy/eck-stack/charts/eck-logstash/Chart.yaml
@@ -3,7 +3,7 @@ name: eck-logstash
 description: Logstash managed by the ECK operator
 kubeVersion: ">= 1.21.0-0"
 type: application
-version: 0.18.1
+version: 0.18.2
 sources:
   - https://github.com/elastic/cloud-on-k8s
   - https://github.com/elastic/logstash

--- a/deploy/eck-stack/charts/eck-logstash/templates/tests/logstash_test.yaml
+++ b/deploy/eck-stack/charts/eck-logstash/templates/tests/logstash_test.yaml
@@ -101,7 +101,7 @@ tests:
             app.kubernetes.io/instance: quickstart
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-logstash
-            helm.sh/chart: eck-logstash-0.18.1
+            helm.sh/chart: eck-logstash-0.18.2
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-stack/charts/eck-package-registry/Chart.yaml
+++ b/deploy/eck-stack/charts/eck-package-registry/Chart.yaml
@@ -3,7 +3,7 @@ name: eck-package-registry
 description: Elastic Package Registry managed by the ECK operator
 kubeVersion: ">= 1.21.0-0"
 type: application
-version: 0.18.1
+version: 0.18.2
 sources:
   - https://github.com/elastic/cloud-on-k8s
   - https://github.com/elastic/package-registry


### PR DESCRIPTION
I again forgot to increment the eck-stack helm charts for the patch release.

*note this is merging into the `3.3` branch*