### PR TITLE
[3.3] Add api-reference, 3rd party dependencies and release notes for 3.3.2 release. (#9284)

### DIFF
--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -14,6 +14,18 @@ Breaking changes can impact your Elastic applications, potentially disrupting no
 % **Action**<br> Steps for mitigating deprecation impact.
 % ::::
 
+## 3.3.2 [elastic-cloud-kubernetes-332-breaking-changes]
+
+There are no breaking changes for ECK 3.3.2
+
+## 3.3.1 [elastic-cloud-kubernetes-331-breaking-changes]
+
+There are no breaking changes for ECK 3.3.1
+
+## 3.3.0 [elastic-cloud-kubernetes-330-breaking-changes]
+
+There are no breaking changes for ECK 3.3
+
 ## 3.2.0 [elastic-cloud-kubernetes-320-breaking-changes]
 
 There are no breaking changes for ECK 3.2

--- a/docs/release-notes/deprecations.md
+++ b/docs/release-notes/deprecations.md
@@ -17,6 +17,18 @@ Review the deprecated functionality for Elastic Cloud on Kubernetes. While depre
 % **Action**<br> Steps for mitigating deprecation impact.
 % ::::
 
+## 3.3.2 [elastic-cloud-kubernetes-332-deprecations]
+
+There are no deprecations for ECK 3.3.2
+
+## 3.3.1 [elastic-cloud-kubernetes-331-deprecations]
+
+There are no deprecations for ECK 3.3.1
+
+## 3.3.0 [elastic-cloud-kubernetes-330-deprecations]
+
+7.17.X Elastic stack versions are deprecated as of 15 January 2026 and will be removed in a future release. Please see the [EOL policy](https://www.elastic.co/support/eol) for more details.
+
 ## 3.2.0 [elastic-cloud-kubernetes-320-deprecations]
 
 There are no deprecations for ECK 3.2

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -8,6 +8,116 @@ mapped_pages:
 # Elastic Cloud on Kubernetes release notes [elastic-cloud-kubernetes-release-notes]
 Review the changes, fixes, and more in each release of Elastic Cloud on Kubernetes.
 
+## 3.3.2 [elastic-cloud-kubernetes-332-release-notes]
+
+### Release Highlights
+
+#### Fix ECK FIPS build
+
+ECK 3.3.2 fixes the FIPS build by correctly enabling the BoringCrypto experiment via `GOEXPERIMENT=boringcrypto`. This release also adds preliminary support for native Go FIPS 140-3 mode (introduced in Go 1.24), which will be enabled in a future release once the module is certified.
+
+### Features and enhancements [elastic-cloud-kubernetes-332-features-and-enhancements]
+
+- Fix FIPS build and add native Go FIPS 140-3 support [#9263](https://github.com/elastic/cloud-on-k8s/pull/9263)
+
+:::{dropdown} Updated dependencies
+
+- Go 1.25.7 => 1.25.8
+
+:::
+
+## 3.3.1 [elastic-cloud-kubernetes-331-release-notes]
+
+### Release Highlights
+
+#### Removing Enterprise requirement for Elastic AutoOps
+
+ECK 3.3.1 has removed the enterprise requirement for AutoOpsAgentPolicy. AutoOps can now be used by on premises users without the need for an enterprise license.
+
+### Features and enhancements [elastic-cloud-kubernetes-331-features-and-enhancements]
+
+- Removing enterprise requirement for AutoOpsAgentPolicy [#9125](https://github.com/elastic/cloud-on-k8s/pull/9125)
+- Add Namespace Selector to AutoOpsAgentPolicy [#8991](https://github.com/elastic/cloud-on-k8s/pull/8991)
+- Update minimum AutoOps Agent to 9.2.4 when a Basic license is used [#9157](https://github.com/elastic/cloud-on-k8s/pull/9157)
+
+:::{dropdown} Updated dependencies
+
+- Go 1.25.6 => 1.25.7
+- github.com/elastic/go-ucfg v0.8.9-0.20251017163010-3520930bed4f -> v0.8.9-0.20260108155023-368693374ae9
+- go.elastic.co/apm/v2 v2.7.2 -> v2.7.3
+- golang.org/x/crypto v0.46.0 -> v0.48.0
+- k8s.io/api v0.35.0 -> v0.35.1
+- k8s.io/apimachinery v0.35.0 -> v0.35.1
+- k8s.io/client-go v0.35.0 -> v0.35.1
+
+:::
+
+## 3.3.0 [elastic-cloud-kubernetes-330-release-notes]
+
+### Release Highlights
+
+#### AutoOps Integration (Enterprise feature)
+
+ECK now supports integration with Elastic AutoOps through a new `AutoOpsAgentPolicy` custom resource. This allows you to instrument multiple {{es}} clusters at once for automated health monitoring and performance recommendations. The [AutoOps documentation](https://www.elastic.co/docs/deploy-manage/monitor/autoops.md) provides more details.
+
+#### Elastic Package Registry Integration
+
+ECK now supports deploying and managing Elastic Package Registry (EPR) through a new `PackageRegistry` custom resource. This is particularly useful for air-gapped environments, enabling {{product.kibana}} to reference a self-hosted registry instead of the public one. The [package registry documentation](docs-content://deploy-manage/deploy/cloud-on-k8s/package-registry.md) provides more details.
+
+#### Multiple Stack Configuration Policies composition support (Enterprise feature)
+
+ECK now includes support for multiple Stack Config Policies targeting the same {{es}} cluster or {{product.kibana}} instance, using a weight-based priority system for deterministic policy composition. The [Stack Config Policy documentation](docs-content://deploy-manage/deploy/cloud-on-k8s/elastic-stack-configuration-policies.md) provides more details.
+
+### Features and enhancements [elastic-cloud-kubernetes-330-features-and-enhancements]
+
+- AutoOpsAgentPolicy support [#8941](https://github.com/elastic/cloud-on-k8s/pull/8941) (issue: [#8789](https://github.com/elastic/cloud-on-k8s/issues/8789))
+- ElasticPackageRegistry support [#8800](https://github.com/elastic/cloud-on-k8s/pull/8800) (issue: [#8925](https://github.com/elastic/cloud-on-k8s/issues/8925))
+- Stack Config Policies composition support [#8917](https://github.com/elastic/cloud-on-k8s/pull/8917)
+- Use standard {{product.kibana}} labels and Helm labels on the ECK Operator pod [#8840](https://github.com/elastic/cloud-on-k8s/pull/8840) (issue: [#8584](https://github.com/elastic/cloud-on-k8s/issues/8584))
+- Add service customization support for {{es}} remote cluster server [#8892](https://github.com/elastic/cloud-on-k8s/pull/8892)
+- Removal of {{es}} 6.x support from codebase [#8979](https://github.com/elastic/cloud-on-k8s/pull/8979)
+
+### Fixes [elastic-cloud-kubernetes-330-fixes]
+
+- Upgrade master StatefulSets last when performing a version upgrade of {{es}} [#8871](https://github.com/elastic/cloud-on-k8s/pull/8871) (issue: [#8429](https://github.com/elastic/cloud-on-k8s/issues/8429))
+- Fix race condition for pre-existing Stack Config Policy [#8928](https://github.com/elastic/cloud-on-k8s/pull/8928) (issue: [#8912](https://github.com/elastic/cloud-on-k8s/issues/8912))
+- Do not set {{product.kibana}} server.name [#8930](https://github.com/elastic/cloud-on-k8s/pull/8930) (issue: [#8929](https://github.com/elastic/cloud-on-k8s/issues/8929))
+- Do not write `elasticsearch.k8s.elastic.co/managed-remote-clusters` when not necessary [#8932](https://github.com/elastic/cloud-on-k8s/pull/8932) (issue: [#8781](https://github.com/elastic/cloud-on-k8s/issues/8781))
+- Cleanup orphaned secret mounts when removed from StackConfigPolicy [#8937](https://github.com/elastic/cloud-on-k8s/pull/8937) (issue: [#8921](https://github.com/elastic/cloud-on-k8s/issues/8921))
+- Avoid duplicate error logging for generate GET operations on a GVK [#8957](https://github.com/elastic/cloud-on-k8s/pull/8957)
+- Remove single master at a time upscale restriction [#8940](https://github.com/elastic/cloud-on-k8s/pull/8940) (issue: [#8939](https://github.com/elastic/cloud-on-k8s/issues/8939))
+
+
+### Documentation improvements [elastic-cloud-kubernetes-330-documentation-improvements]
+
+- Update Google Cloud LoadBalancer recipe for new requirements [#8843](https://github.com/elastic/cloud-on-k8s/pull/8843)
+- Fix minUnavailable typo in PDB documentation [#8898](https://github.com/elastic/cloud-on-k8s/pull/8898)
+- Use GKE ComputeClass instead of DaemonSet for GKE AutoPilot [#8982](https://github.com/elastic/cloud-on-k8s/pull/8982)
+- Adjust `vm.max_map_count` to 1048576 in GKE AutoPilot recipes [#8986](https://github.com/elastic/cloud-on-k8s/pull/8986)
+- Remove support for Stack 7.17. [#9038](https://github.com/elastic/cloud-on-k8s/pull/9038)
+
+:::{dropdown} Updated dependencies
+
+- Go 1.25.2 => 1.25.6
+- github.com/KimMachineGun/automemlimit v0.7.4 => v0.7.5
+- github.com/elastic/go-ucfg v0.8.9-0.20250307075119-2a22403faaea => v0.8.9-0.20251017163010-3520930bed4f
+- github.com/gkampitakis/go-snaps v0.5.15 => v0.5.19
+- github.com/google/go-containerregistry v0.20.6 => v0.20.7
+- github.com/googlecloudplatform/compute-class-api => v0.0.0-20251208134148-ae2e7936c1f8
+- github.com/prometheus/common v0.67.1 => v0.67.5
+- github.com/spf13/cobra v1.10.1 => v1.10.2
+- go.elastic.co/apm/v2 v2.7.1 => v2.7.2
+- go.uber.org/zap v1.27.0 => v1.27.1
+- golang.org/x/crypto v0.40.0 => v0.46.0
+- k8s.io/api v0.34.1 => v0.35.0
+- k8s.io/apimachinery v0.34.1 => v0.35.0
+- k8s.io/client-go v0.34.1 => v0.35.0
+- k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 => v0.0.0-20251002143259-bc988d571ff4
+- sigs.k8s.io/controller-runtime v0.22.2 => v0.22.4
+- sigs.k8s.io/controller-tools v0.19.0 => v0.20.0
+
+:::
+
 ## 3.2.0 [elastic-cloud-kubernetes-320-release-notes]
 
 ### Release Highlights

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -17,6 +17,38 @@ Known issues are significant defects or limitations that may impact your impleme
 
 :::
 
+## 3.3.2 [elastic-cloud-kubernetes-332-known-issues]
+
+There are no known issues in ECK 3.3.2
+
+## 3.3.1 [elastic-cloud-kubernetes-331-known-issues]
+
+:::{dropdown} AutoOps - Enterprise license expiring may cause policy phase to be set to `Invalid` prior to 9.2.4
+
+In clusters running AutoOps Agent versions earlier than 9.2.4, an Enterprise license expiring may cause the policy phase to be set to `Invalid`. In this state, the AutoOps Agent stops sending data to AutoOps because the policy no longer passes validation on the controller.
+
+**Workaround**
+
+Renew or restore the Enterprise license so that the AutoOps policy can be validated again. To prevent this issue in the future, upgrade the AutoOps Agent to version 9.2.4 or later.
+
+:::
+
+## 3.3.0 [elastic-cloud-kubernetes-330-known-issues]
+
+:::{dropdown} Stack Config Policies - File settings may not reload correctly on {{es}} versions prior to 8.11.0
+
+{{es}} versions prior to 8.11.0 contain a bug where updates to file-based cluster settings may not be reloaded correctly when the file changes. This is caused by an {{es}} issue where new keys in file-settings are incorrectly deleted during file monitoring and reload operations.
+
+When using Stack Config Policies with affected {{es}} versions, updated settings may not appear correctly when querying the `_cluster/settings` endpoint, even though the Stack Config Policy has been updated. Making an additional manual update to the Stack Config Policy may trigger the settings to reload correctly.
+
+This issue was fixed in {{es}} 8.11.0 via [elasticsearch#99212](https://github.com/elastic/elasticsearch/pull/99212).
+
+**Workaround**
+
+Use {{es}} version 8.11.0 or later when deploying Stack Config Policies.
+
+:::
+
 ## 3.2.0 [elastic-cloud-kubernetes-320-known-issues]
 
 :::{dropdown} Elastic Agent fails with "cipher: message authentication failed" on ECK 3.2.0 re-upgrade


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.3`:
 - [Add api-reference, 3rd party dependencies and release notes for 3.3.2 release. (#9284)](https://github.com/elastic/cloud-on-k8s/pull/9284)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)