### PR TITLE
[3.3.2] Update ECK version used in e2e tests

### DIFF
--- a/config/e2e/helm-monitoring-operator.yaml
+++ b/config/e2e/helm-monitoring-operator.yaml
@@ -6,7 +6,7 @@ managedNamespaces: [{{ .E2ENamespace }}]
 
 image:
   repository: docker.elastic.co/eck/eck-operator
-  tag: 3.3.1
+  tag: 3.3.2
 
 podAnnotations:
   co.elastic.metrics/metricsets: collector


### PR DESCRIPTION
Update ECK version used in e2e tests to 3.3.2