### PR TITLE
[cache]: set TransformStripManagedFields

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -595,7 +595,10 @@ func startOperator(ctx context.Context) error {
 	}
 
 	// implicitly allows watching cluster-scoped resources (e.g. storage classes)
-	opts.Cache = cache.Options{DefaultNamespaces: map[string]cache.Config{}}
+	opts.Cache = cache.Options{
+		DefaultNamespaces: map[string]cache.Config{},
+		DefaultTransform:  cache.TransformStripManagedFields(),
+	}
 	for _, ns := range managedNamespaces {
 		opts.Cache.DefaultNamespaces[ns] = cache.Config{}
 	}


### PR DESCRIPTION
Mentioned as first item of this: https://github.com/elastic/cloud-on-k8s/issues/8799#issuecomment-4199785035


Small but noticeable improvement to the memory footprint. 

Worth adding to 3.4.0 since it's safe. 