### PR TITLE
Implement ECK monitoring support for presenting client certificates to elasticsearch

### DIFF
--- a/pkg/controller/beat/common/stackmon/stackmon.go
+++ b/pkg/controller/beat/common/stackmon/stackmon.go
@@ -86,7 +86,7 @@ func MetricBeat(ctx context.Context, client k8s.Client, beat *v1beta1.Beat, meta
 		return stackmon.BeatSidecar{}, err
 	}
 
-	sidecar, err := stackmon.NewMetricBeatSidecar(ctx, client, beat, v, nil, cfg, meta)
+	sidecar, err := stackmon.NewMetricBeatSidecar(ctx, client, beat, v, nil, nil, cfg, meta)
 	if err != nil {
 		return stackmon.BeatSidecar{}, err
 	}

--- a/pkg/controller/common/stackmon/config.go
+++ b/pkg/controller/common/stackmon/config.go
@@ -55,7 +55,7 @@ func newBeatConfig(
 	assoc := associations[0]
 
 	// build the output section of the beat configuration file
-	outputCfg, caVolume, err := buildOutputConfig(ctx, client, assoc, imageVersion)
+	outputCfg, caVolume, clientCertVolume, err := buildOutputConfig(ctx, client, assoc, imageVersion)
 	if err != nil {
 		return beatConfig{}, err
 	}
@@ -76,9 +76,14 @@ func newBeatConfig(
 	configFilepath := filepath.Join(configDirPath, configFilename)
 	volumes := []volume.VolumeLike{configVolume}
 
-	// add the CA volume
+	// add the CA volume for the target ES
 	if caVolume != nil {
 		volumes = append(volumes, caVolume)
+	}
+
+	// add the client certificate volume for the target ES
+	if clientCertVolume != nil {
+		volumes = append(volumes, clientCertVolume)
 	}
 
 	// merge the base config with the generated part
@@ -115,15 +120,15 @@ func newBeatConfig(
 	}, err
 }
 
-func buildOutputConfig(ctx context.Context, client k8s.Client, assoc commonv1.Association, imageVersion string) (map[string]any, volume.VolumeLike, error) {
+func buildOutputConfig(ctx context.Context, client k8s.Client, assoc commonv1.Association, imageVersion string) (map[string]any, volume.VolumeLike, volume.VolumeLike, error) {
 	credentials, err := association.ElasticsearchAuthSettings(ctx, client, assoc)
 	if err != nil {
-		return nil, volume.SecretVolume{}, err
+		return nil, nil, nil, err
 	}
 
 	assocConf, err := assoc.AssociationConf()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	outputConfig := map[string]any{
 		"username": credentials.Username,
@@ -137,7 +142,7 @@ func buildOutputConfig(ctx context.Context, client k8s.Client, assoc commonv1.As
 
 	v, err := version.Parse(imageVersion)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	// Reloading of certificates is only supported for Beats >= 8.8.0.
 	if v.GE(version.MinFor(8, 8, 0)) {
@@ -163,7 +168,21 @@ func buildOutputConfig(ctx context.Context, client k8s.Client, assoc commonv1.As
 		)
 	}
 
-	return outputConfig, caVolume, nil
+	var clientCertVolume volume.VolumeLike
+	if assocConf.ClientCertIsConfigured() {
+		clientCertDirPath := fmt.Sprintf(
+			"/mnt/elastic-internal/%s-association/%s/%s/client-certs",
+			assoc.AssociationType(), assoc.AssociationRef().GetNamespace(), assoc.AssociationRef().NameOrSecretName(),
+		)
+		outputConfig["ssl.certificate"] = filepath.Join(clientCertDirPath, certificates.CertFileName)
+		outputConfig["ssl.key"] = filepath.Join(clientCertDirPath, certificates.KeyFileName)
+		clientCertVolumeName := fmt.Sprintf("%s-client-cert", caVolumeName(assoc))
+		clientCertVolume = volume.NewSecretVolumeWithMountPath(
+			assocConf.GetClientCertSecretName(), clientCertVolumeName, clientCertDirPath,
+		)
+	}
+
+	return outputConfig, caVolume, clientCertVolume, nil
 }
 
 func mergeConfig(rawConfig string, config map[string]any) ([]byte, error) {
@@ -225,6 +244,18 @@ func TemplateFuncs(
 				return ""
 			}
 			return filepath.Join(caVolume.VolumeMount().MountPath, certificates.CAFileName)
+		},
+		"ClientCertPath": func(clientCertVolume volume.VolumeLike) string {
+			if clientCertVolume == nil {
+				return ""
+			}
+			return filepath.Join(clientCertVolume.VolumeMount().MountPath, certificates.CertFileName)
+		},
+		"ClientKeyPath": func(clientCertVolume volume.VolumeLike) string {
+			if clientCertVolume == nil {
+				return ""
+			}
+			return filepath.Join(clientCertVolume.VolumeMount().MountPath, certificates.KeyFileName)
 		},
 	}
 }

--- a/pkg/controller/common/stackmon/config_test.go
+++ b/pkg/controller/common/stackmon/config_test.go
@@ -18,6 +18,7 @@ import (
 
 	commonv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/metadata"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/stackmon/monitoring"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
@@ -103,6 +104,78 @@ param2: value2
         username: default-monitored-default-monitoring-beat-es-mon-user
 param1: value1
 param2: value2
+`),
+					},
+				},
+			},
+		},
+		{
+			name: "Output config with client certificate",
+			args: args{
+				baseConfig: `
+param1: value1
+`,
+				initObjects: []client.Object{
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "monitored-default-monitoring-beat-es-mon-user",
+							Namespace: "default",
+						},
+						Data: map[string][]byte{
+							"default-monitored-default-monitoring-beat-es-mon-user": []byte("password"),
+						},
+					},
+				},
+				beatName: "metricbeat",
+				image:    "8.8.0",
+				associated: &esv1.Elasticsearch{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "monitored",
+						Namespace: "default",
+						Annotations: map[string]string{
+							commonv1.ElasticsearchConfigAnnotationName(commonv1.ObjectSelector{Name: "monitoring", Namespace: "default"}): `
+{
+	"authSecretName": "monitored-default-monitoring-beat-es-mon-user",
+	"authSecretKey": "default-monitored-default-monitoring-beat-es-mon-user",
+	"isServiceAccount": false,
+	"caCertProvided": true,
+	"caSecretName": "monitored-es-monitoring-default-monitoring-ca",
+	"url": "https://monitoring-es-http.default.svc:9200",
+	"version": "8.4.0",
+	"clientCertSecretName": "monitored-es-monitoring-client-cert"
+}
+`,
+						},
+					},
+					Spec: esv1.ElasticsearchSpec{
+						Monitoring: commonv1.Monitoring{
+							Metrics: commonv1.MetricsMonitoring{ElasticsearchRefs: []commonv1.ObjectSelector{{Name: "monitoring"}}},
+						},
+					},
+				},
+			},
+			want: beatConfig{
+				secret: corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "monitored-es-monitoring-metricbeat-config",
+					},
+					Data: map[string][]byte{
+						"metricbeat.yml": []byte(`output:
+    elasticsearch:
+        hosts:
+            - https://monitoring-es-http.default.svc:9200
+        password: password
+        ssl:
+            certificate: /mnt/elastic-internal/es-monitoring-association/default/monitoring/client-certs/tls.crt
+            certificate_authorities:
+                - /mnt/elastic-internal/es-monitoring-association/default/monitoring/certs/ca.crt
+            key: /mnt/elastic-internal/es-monitoring-association/default/monitoring/client-certs/tls.key
+            restart_on_cert_change:
+                enabled: true
+                period: 1m
+            verification_mode: certificate
+        username: default-monitored-default-monitoring-beat-es-mon-user
+param1: value1
 `),
 					},
 				},
@@ -199,4 +272,62 @@ func TestTemplateFuncsSignature(t *testing.T) {
 	funcs := TemplateFuncs(semver.MustParse("8.0.0"))
 	_, err := template.New("").Funcs(funcs).Parse(`{{ isVersionGTE "8.0.0" }}`)
 	require.NoError(t, err)
+}
+
+func Test_buildOutputConfig_withClientCert(t *testing.T) {
+	authSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "monitored-default-monitoring-beat-es-mon-user",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"default-monitored-default-monitoring-beat-es-mon-user": []byte("password"),
+		},
+	}
+	fakeClient := k8s.NewFakeClient(authSecret)
+
+	associated := &esv1.Elasticsearch{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "monitored",
+			Namespace: "default",
+			Annotations: map[string]string{
+				commonv1.ElasticsearchConfigAnnotationName(commonv1.ObjectSelector{Name: "monitoring", Namespace: "default"}): `
+{
+	"authSecretName": "monitored-default-monitoring-beat-es-mon-user",
+	"authSecretKey": "default-monitored-default-monitoring-beat-es-mon-user",
+	"isServiceAccount": false,
+	"caCertProvided": true,
+	"caSecretName": "monitored-es-monitoring-default-monitoring-ca",
+	"url": "https://monitoring-es-http.default.svc:9200",
+	"version": "8.4.0",
+	"clientCertSecretName": "monitored-es-monitoring-client-cert"
+}
+`,
+			},
+		},
+		Spec: esv1.ElasticsearchSpec{
+			Monitoring: commonv1.Monitoring{
+				Metrics: commonv1.MetricsMonitoring{ElasticsearchRefs: []commonv1.ObjectSelector{{Name: "monitoring"}}},
+			},
+		},
+	}
+
+	assocs := associated.GetAssociations()
+	require.Len(t, assocs, 1)
+
+	outputCfg, _, clientCertVolume, err := buildOutputConfig(context.Background(), fakeClient, assocs[0], "8.8.0")
+	require.NoError(t, err)
+
+	// Verify ssl.certificate and ssl.key are set in the output config
+	certPath, ok := outputCfg["ssl.certificate"]
+	require.True(t, ok, "ssl.certificate should be set in the output config")
+	assert.Contains(t, certPath, certificates.CertFileName)
+
+	keyPath, ok := outputCfg["ssl.key"]
+	require.True(t, ok, "ssl.key should be set in the output config")
+	assert.Contains(t, keyPath, certificates.KeyFileName)
+
+	// Verify the client cert volume is returned
+	require.NotNil(t, clientCertVolume, "client cert volume should be returned when clientCertSecretName is set")
+	assert.Equal(t, "monitored-es-monitoring-client-cert", clientCertVolume.Volume().VolumeSource.Secret.SecretName)
 }

--- a/pkg/controller/common/stackmon/sidecar.go
+++ b/pkg/controller/common/stackmon/sidecar.go
@@ -32,13 +32,14 @@ func NewMetricBeatSidecar(
 	resource monitoring.HasMonitoring,
 	imageVersion semver.Version,
 	caVolume volume.VolumeLike,
+	clientCertVolume volume.VolumeLike,
 	baseConfig string,
 	meta metadata.Metadata,
 ) (BeatSidecar, error) {
 	image := container.ImageRepository(container.MetricbeatImage, imageVersion)
 	// EmptyDir volume so that MetricBeat does not write in the container image, which allows ReadOnlyRootFilesystem: true
 	emptyDir := volume.NewEmptyDirVolume("metricbeat-data", "/usr/share/metricbeat/data")
-	return NewBeatSidecar(ctx, client, "metricbeat", image, imageVersion.String(), resource, monitoring.GetMetricsAssociation(resource), baseConfig, meta, caVolume, emptyDir)
+	return NewBeatSidecar(ctx, client, "metricbeat", image, imageVersion.String(), resource, monitoring.GetMetricsAssociation(resource), baseConfig, meta, caVolume, clientCertVolume, emptyDir)
 }
 
 func NewFileBeatSidecar(
@@ -138,9 +139,10 @@ func CAVolume(
 // TemplateParams are commonly used parameters to render a Beats configuration template.
 // Stack monitoring implementations can choose to implement their own template parameters if needed.
 type TemplateParams struct {
-	URL      string
-	Username string
-	Password string
-	IsSSL    bool
-	CAVolume volume.VolumeLike
+	URL              string
+	Username         string
+	Password         string
+	IsSSL            bool
+	CAVolume         volume.VolumeLike
+	ClientCertVolume volume.VolumeLike
 }

--- a/pkg/controller/elasticsearch/driver/shared/reconcile.go
+++ b/pkg/controller/elasticsearch/driver/shared/reconcile.go
@@ -382,7 +382,7 @@ func ReconcileSharedResources(
 	}
 
 	// Stack monitoring
-	err = stackmon.ReconcileConfigSecrets(ctx, client, es, meta)
+	err = stackmon.ReconcileConfigSecrets(ctx, client, es, meta, clientAuthenticationRequired)
 	if err != nil {
 		esClient.Close()
 		return nil, results.WithError(err)

--- a/pkg/controller/elasticsearch/nodespec/podspec.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec.go
@@ -163,7 +163,7 @@ func BuildPodTemplateSpec(
 		WithTopologySpreadConstraints(spreadConstraints...).
 		WithRequiredNodeAffinityMatchExpressions(requiredMatchExpressions...)
 
-	builder, err = stackmon.WithMonitoring(ctx, client, builder, es, meta)
+	builder, err = stackmon.WithMonitoring(ctx, client, builder, es, meta, clientAuthenticationRequired)
 	if err != nil {
 		return corev1.PodTemplateSpec{}, err
 	}

--- a/pkg/controller/elasticsearch/stackmon/__snapshots__/sidecar_test.snap
+++ b/pkg/controller/elasticsearch/stackmon/__snapshots__/sidecar_test.snap
@@ -1280,3 +1280,45 @@ processors:
 
 # Elasticsearch output configuration is generated and added here
 ---
+
+[TestMetricbeatConfig/with_client_certificate - 1]
+metricbeat.modules:
+  # https://www.elastic.co/guide/en/beats/metricbeat/7.14/metricbeat-module-elasticsearch.html
+  - module: elasticsearch
+    metricsets:
+      - ccr
+      - cluster_stats
+      - enrich
+      - index
+      - index_recovery
+      - index_summary
+      - ingest_pipeline
+      - ml_job
+      - node
+      - node_stats
+      - pending_tasks
+      - shard
+
+    period: 10s
+    xpack.enabled: true
+    hosts: ["https://localhost:9200"]
+    username: elastic
+    password: "secret"
+    ssl.enabled: true
+    # The ssl verification_mode is set to `certificate` in the config template to verify that the certificate is signed by a trusted authority,
+    # but does not perform any hostname verification. This is used when SSL is enabled with or without CA, to support self-signed certificate
+    # with a custom CA or custom certificates with or without a CA that most likely are not issued for `localhost`.
+    ssl.verification_mode: "certificate"
+    ssl.certificate_authorities: ["/mount/ca.crt"]
+    ssl.certificate: "/mnt/elastic-internal/es-monitoring-client-certs/tls.crt"
+    ssl.key: "/mnt/elastic-internal/es-monitoring-client-certs/tls.key"
+
+processors:
+  - add_cloud_metadata: {}
+  - add_host_metadata: {}
+setup.template.settings:
+  index.mapping.total_fields.limit: 12500
+
+# Elasticsearch output configuration is generated
+
+---

--- a/pkg/controller/elasticsearch/stackmon/beat_config.go
+++ b/pkg/controller/elasticsearch/stackmon/beat_config.go
@@ -27,7 +27,7 @@ var (
 )
 
 // ReconcileConfigSecrets reconciles the secrets holding beats configuration
-func ReconcileConfigSecrets(ctx context.Context, client k8s.Client, es esv1.Elasticsearch, meta metadata.Metadata) error {
+func ReconcileConfigSecrets(ctx context.Context, client k8s.Client, es esv1.Elasticsearch, meta metadata.Metadata, clientAuthenticationRequired bool) error {
 	isMonitoringReconcilable, err := monitoring.IsReconcilable(&es)
 	if err != nil {
 		return err
@@ -37,7 +37,7 @@ func ReconcileConfigSecrets(ctx context.Context, client k8s.Client, es esv1.Elas
 	}
 
 	if monitoring.IsMetricsDefined(&es) {
-		b, err := Metricbeat(ctx, client, es, meta)
+		b, err := Metricbeat(ctx, client, es, meta, clientAuthenticationRequired)
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/elasticsearch/stackmon/metricbeat.tpl.yml
+++ b/pkg/controller/elasticsearch/stackmon/metricbeat.tpl.yml
@@ -30,6 +30,10 @@ metricbeat.modules:
     {{- with .CAVolume }}
     ssl.certificate_authorities: ["{{ CAPath . }}"]
     {{- end }}
+    {{- with .ClientCertVolume }}
+    ssl.certificate: "{{ ClientCertPath . }}"
+    ssl.key: "{{ ClientKeyPath . }}"
+    {{- end }}
 
 processors:
   - add_cloud_metadata: {}

--- a/pkg/controller/elasticsearch/stackmon/sidecar.go
+++ b/pkg/controller/elasticsearch/stackmon/sidecar.go
@@ -16,6 +16,7 @@ import (
 	commonv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/elasticsearch/v1"
 	beatstackmon "github.com/elastic/cloud-on-k8s/v3/pkg/controller/beat/common/stackmon"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/defaults"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/stackmon"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/stackmon/monitoring"
@@ -33,7 +34,7 @@ const (
 	cfgHashAnnotation = "elasticsearch.k8s.elastic.co/monitoring-config-hash"
 )
 
-func Metricbeat(ctx context.Context, client k8s.Client, es esv1.Elasticsearch, meta metadata.Metadata) (stackmon.BeatSidecar, error) {
+func Metricbeat(ctx context.Context, client k8s.Client, es esv1.Elasticsearch, meta metadata.Metadata, clientAuthenticationRequired bool) (stackmon.BeatSidecar, error) {
 	username := user.MonitoringUserName
 	password, err := user.GetMonitoringUserPassword(client, k8s.ExtractNamespacedName(&es))
 	if err != nil {
@@ -50,12 +51,24 @@ func Metricbeat(ctx context.Context, client k8s.Client, es esv1.Elasticsearch, m
 		return stackmon.BeatSidecar{}, err
 	}
 
+	// When the source ES has client authentication enabled, mount the internal client certificate
+	// so Metricbeat can authenticate via mTLS when connecting to the local ES.
+	var clientCertVolume volume.VolumeLike
+	if clientAuthenticationRequired {
+		clientCertVolume = volume.NewSecretVolumeWithMountPath(
+			certificates.OperatorClientCertSecretName(esv1.ESNamer, es.Name),
+			"metricbeat-es-client-cert",
+			"/mnt/elastic-internal/es-monitoring-client-certs",
+		)
+	}
+
 	input := stackmon.TemplateParams{
-		URL:      fmt.Sprintf("%s://localhost:%d", es.Spec.HTTP.Protocol(), network.HTTPPort),
-		Username: username,
-		Password: password,
-		IsSSL:    es.Spec.HTTP.TLS.Enabled(),
-		CAVolume: caVolume,
+		URL:              fmt.Sprintf("%s://localhost:%d", es.Spec.HTTP.Protocol(), network.HTTPPort),
+		Username:         username,
+		Password:         password,
+		IsSSL:            es.Spec.HTTP.TLS.Enabled(),
+		CAVolume:         caVolume,
+		ClientCertVolume: clientCertVolume,
 	}
 
 	cfg, err := stackmon.RenderTemplate(v, metricbeatConfigTemplate, input)
@@ -63,7 +76,7 @@ func Metricbeat(ctx context.Context, client k8s.Client, es esv1.Elasticsearch, m
 		return stackmon.BeatSidecar{}, err
 	}
 
-	metricbeat, err := stackmon.NewMetricBeatSidecar(ctx, client, &es, v, caVolume, cfg, meta)
+	metricbeat, err := stackmon.NewMetricBeatSidecar(ctx, client, &es, v, caVolume, clientCertVolume, cfg, meta)
 	if err != nil {
 		return stackmon.BeatSidecar{}, err
 	}
@@ -96,7 +109,7 @@ func Filebeat(ctx context.Context, client k8s.Client, es esv1.Elasticsearch, met
 
 // WithMonitoring updates the Elasticsearch Pod template builder to deploy Metricbeat and Filebeat in sidecar containers
 // in the Elasticsearch pod and injects the volumes for the beat configurations and the ES CA certificates.
-func WithMonitoring(ctx context.Context, client k8s.Client, builder *defaults.PodTemplateBuilder, es esv1.Elasticsearch, meta metadata.Metadata) (*defaults.PodTemplateBuilder, error) {
+func WithMonitoring(ctx context.Context, client k8s.Client, builder *defaults.PodTemplateBuilder, es esv1.Elasticsearch, meta metadata.Metadata, clientAuthenticationRequired bool) (*defaults.PodTemplateBuilder, error) {
 	isMonitoringReconcilable, err := monitoring.IsReconcilable(&es)
 	if err != nil {
 		return nil, err
@@ -109,7 +122,7 @@ func WithMonitoring(ctx context.Context, client k8s.Client, builder *defaults.Po
 	volumes := make([]corev1.Volume, 0)
 
 	if monitoring.IsMetricsDefined(&es) {
-		b, err := Metricbeat(ctx, client, es, meta)
+		b, err := Metricbeat(ctx, client, es, meta, clientAuthenticationRequired)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/elasticsearch/stackmon/sidecar_test.go
+++ b/pkg/controller/elasticsearch/stackmon/sidecar_test.go
@@ -128,7 +128,7 @@ func TestWithMonitoring(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			es := tc.es()
 			builder := defaults.NewPodTemplateBuilder(corev1.PodTemplateSpec{}, esv1.ElasticsearchContainerName)
-			_, err := WithMonitoring(context.Background(), fakeClient, builder, es, metadata.Metadata{})
+			_, err := WithMonitoring(context.Background(), fakeClient, builder, es, metadata.Metadata{}, false)
 			assert.NoError(t, err)
 
 			actual, err := json.MarshalIndent(builder.PodTemplate, " ", "")
@@ -145,12 +145,13 @@ func TestMetricbeatConfig(t *testing.T) {
 		"/mount",
 	)
 	type args struct {
-		URL      string
-		Username string
-		Password string
-		IsSSL    bool
-		CAVolume volume.VolumeLike
-		Version  semver.Version
+		URL              string
+		Username         string
+		Password         string
+		IsSSL            bool
+		CAVolume         volume.VolumeLike
+		ClientCertVolume volume.VolumeLike
+		Version          semver.Version
 	}
 	tests := []struct {
 		name string
@@ -207,6 +208,22 @@ func TestMetricbeatConfig(t *testing.T) {
 				IsSSL:    true,
 				Version:  version.From(8, 17, 0),
 				CAVolume: volumeFixture,
+			},
+		},
+		{
+			name: "with client certificate",
+			args: args{
+				URL:      "https://localhost:9200",
+				Username: "elastic",
+				Password: "secret",
+				IsSSL:    true,
+				Version:  version.From(8, 16, 0),
+				CAVolume: volumeFixture,
+				ClientCertVolume: volume.NewSecretVolumeWithMountPath(
+					"client-cert-secret",
+					"es-client-cert",
+					"/mnt/elastic-internal/es-monitoring-client-certs",
+				),
 			},
 		},
 	}

--- a/pkg/controller/kibana/stackmon/sidecar.go
+++ b/pkg/controller/kibana/stackmon/sidecar.go
@@ -93,7 +93,7 @@ func Metricbeat(ctx context.Context, client k8s.Client, kb kbv1.Kibana, basePath
 		return stackmon.BeatSidecar{}, err
 	}
 
-	metricbeat, err := stackmon.NewMetricBeatSidecar(ctx, client, &kb, v, caVol, cfg, meta)
+	metricbeat, err := stackmon.NewMetricBeatSidecar(ctx, client, &kb, v, caVol, nil, cfg, meta)
 	if err != nil {
 		return stackmon.BeatSidecar{}, err
 	}

--- a/pkg/controller/logstash/stackmon/sidecar.go
+++ b/pkg/controller/logstash/stackmon/sidecar.go
@@ -63,7 +63,7 @@ func Metricbeat(ctx context.Context, client k8s.Client, logstash logstashv1alpha
 		return stackmon.BeatSidecar{}, err
 	}
 
-	metricbeat, err := stackmon.NewMetricBeatSidecar(ctx, client, &logstash, v, caVol, cfg, meta)
+	metricbeat, err := stackmon.NewMetricBeatSidecar(ctx, client, &logstash, v, caVol, nil, cfg, meta)
 	if err != nil {
 		return stackmon.BeatSidecar{}, err
 	}

--- a/test/e2e/es/stack_monitoring_test.go
+++ b/test/e2e/es/stack_monitoring_test.go
@@ -20,6 +20,7 @@ import (
 	commonv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/annotation"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/stackmon/validations"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
@@ -204,4 +205,120 @@ func TestExternalESStackMonitoring(t *testing.T) {
 	}
 
 	test.Sequence(nil, steps, monitoring, monitored).RunSequential(t)
+}
+
+// checkClientAuthAnnotationStep returns a test step that verifies whether the given Elasticsearch resource
+// has (or does not have) the client authentication required annotation.
+func checkClientAuthAnnotationStep(k *test.K8sClient, namespace, esName string, expected bool) test.Step {
+	return test.Step{
+		Name: fmt.Sprintf("Verify ES %s/%s has client authentication annotation = %v", namespace, esName, expected),
+		Test: test.Eventually(func() error {
+			var es esv1.Elasticsearch
+			if err := k.Client.Get(context.Background(), types.NamespacedName{
+				Namespace: namespace,
+				Name:      esName,
+			}, &es); err != nil {
+				return err
+			}
+			if annotation.HasClientAuthenticationRequired(&es) != expected {
+				return fmt.Errorf("expected client authentication required annotation to be %v for ES %s/%s", expected, namespace, esName)
+			}
+			return nil
+		}),
+	}
+}
+
+// TestESStackClientAuthTransitionMonitored tests that when a monitored Elasticsearch cluster transitions
+// from having client authentication enabled to disabled, the monitoring continues to work correctly.
+func TestESStackClientAuthTransitionMonitored(t *testing.T) {
+	if test.Ctx().TestLicense == "" {
+		t.Skip("Skipping client authentication test: no enterprise test license configured")
+	}
+	// only execute this test on supported version
+	err := validations.IsSupportedVersion(test.Ctx().ElasticStackVersion, validations.MinStackVersion)
+	if err != nil {
+		t.SkipNow()
+	}
+
+	// create monitoring cluster without client authentication
+	monitoring := elasticsearch.NewBuilder("test-es-mon-trans").
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources).
+		WithClientAuthenticationRequired()
+
+	// create monitored cluster with client authentication required initially
+	monitored := elasticsearch.NewBuilder("test-es-mon-trans-a").
+		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
+		WithClientAuthenticationRequired().
+		WithMonitoring(monitoring.Ref(), monitoring.Ref())
+
+	monitoringWithLicense := test.LicenseTestBuilder(monitoring)
+	monitoredWithLicense := test.LicenseTestBuilder(monitored)
+	monitoredWithLicense.PostCheckSteps = func(k *test.K8sClient) test.StepList {
+		return test.StepList{
+			checkClientAuthAnnotationStep(k, monitored.Elasticsearch.Namespace, monitored.Elasticsearch.Name, true),
+		}.WithSteps(checks.MonitoredSteps(&monitored, k))
+	}
+
+	// Disable client authentication on monitored cluster
+	monitoredMutated := monitored.DeepCopy().WithMutatedFrom(&monitored)
+	monitoredMutated.Elasticsearch.Spec.HTTP.TLS.Client.Authentication = false
+	monitoredMutatedWrapped := test.WrappedBuilder{
+		BuildingThis: monitoredMutated,
+		PostMutationSteps: func(k *test.K8sClient) test.StepList {
+			return test.StepList{
+				checkClientAuthAnnotationStep(k, monitored.Elasticsearch.Namespace, monitored.Elasticsearch.Name, false),
+			}.WithSteps(checks.MonitoredSteps(monitoredMutated, k))
+		},
+	}
+
+	test.RunMutations(t, []test.Builder{monitoringWithLicense, monitoredWithLicense}, []test.Builder{monitoredMutatedWrapped})
+}
+
+// TestESStackClientAuthTransitionMonitoring tests that when the monitoring Elasticsearch cluster
+// transitions from having client authentication enabled to disabled, the monitoring continues to work correctly.
+func TestESStackClientAuthTransitionMonitoring(t *testing.T) {
+	if test.Ctx().TestLicense == "" {
+		t.Skip("Skipping client authentication test: no enterprise test license configured")
+	}
+	// only execute this test on supported version
+	err := validations.IsSupportedVersion(test.Ctx().ElasticStackVersion, validations.MinStackVersion)
+	if err != nil {
+		t.SkipNow()
+	}
+
+	// create monitoring cluster with client authentication required initially
+	monitoring := elasticsearch.NewBuilder("test-es-mmon-trans").
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources).
+		WithClientAuthenticationRequired()
+
+	// create monitored cluster without client authentication
+	monitored := elasticsearch.NewBuilder("test-es-mmon-trans-a").
+		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
+		WithClientAuthenticationRequired().
+		WithMonitoring(monitoring.Ref(), monitoring.Ref())
+
+	monitoringWithLicense := test.LicenseTestBuilder(monitoring)
+	monitoringWithLicense.PostCheckSteps = func(k *test.K8sClient) test.StepList {
+		return test.StepList{
+			checkClientAuthAnnotationStep(k, monitoring.Elasticsearch.Namespace, monitoring.Elasticsearch.Name, true),
+		}
+	}
+	monitoredWithLicense := test.LicenseTestBuilder(monitored)
+	monitoredWithLicense.PostCheckSteps = func(k *test.K8sClient) test.StepList {
+		return checks.MonitoredSteps(&monitored, k)
+	}
+
+	// Disable client authentication on monitoring cluster
+	monitoringMutated := monitoring.DeepCopy().WithMutatedFrom(&monitoring)
+	monitoringMutated.Elasticsearch.Spec.HTTP.TLS.Client.Authentication = false
+	monitoringMutatedWrapped := test.WrappedBuilder{
+		BuildingThis: monitoringMutated,
+		PostMutationSteps: func(k *test.K8sClient) test.StepList {
+			return test.StepList{
+				checkClientAuthAnnotationStep(k, monitoring.Elasticsearch.Namespace, monitoring.Elasticsearch.Name, false),
+			}.WithSteps(checks.MonitoredSteps(&monitored, k))
+		},
+	}
+
+	test.RunMutations(t, []test.Builder{monitoringWithLicense, monitoredWithLicense}, []test.Builder{monitoringMutatedWrapped})
 }

--- a/test/e2e/es/stack_monitoring_test.go
+++ b/test/e2e/es/stack_monitoring_test.go
@@ -249,7 +249,8 @@ func TestESStackClientAuthTransitionMonitored(t *testing.T) {
 	monitored := elasticsearch.NewBuilder("test-es-mon-trans-a").
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
 		WithClientAuthenticationRequired().
-		WithMonitoring(monitoring.Ref(), monitoring.Ref())
+		WithMonitoring(monitoring.Ref(), monitoring.Ref()).
+		TolerateMutationChecksFailures()
 
 	monitoringWithLicense := test.LicenseTestBuilder(monitoring)
 	monitoredWithLicense := test.LicenseTestBuilder(monitored)
@@ -295,7 +296,8 @@ func TestESStackClientAuthTransitionMonitoring(t *testing.T) {
 	monitored := elasticsearch.NewBuilder("test-es-mmon-trans-a").
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
 		WithClientAuthenticationRequired().
-		WithMonitoring(monitoring.Ref(), monitoring.Ref())
+		WithMonitoring(monitoring.Ref(), monitoring.Ref()).
+		TolerateMutationChecksFailures()
 
 	monitoringWithLicense := test.LicenseTestBuilder(monitoring)
 	monitoringWithLicense.PostCheckSteps = func(k *test.K8sClient) test.StepList {


### PR DESCRIPTION
## Summary

  This PR adds client certificate support to the stack monitoring (Metricbeat/Filebeat sidecar) infrastructure so that monitoring sidecars can authenticate via mTLS when connecting to Elasticsearch clusters that have client authentication enabled. This covers two distinct scenarios: the Metricbeat sidecar connecting to the **source** (monitored) Elasticsearch over its HTTP endpoint, and the monitoring output connecting to the **target** (monitoring) Elasticsearch cluster.

Relates https://github.com/elastic/cloud-on-k8s/issues/9081
  ### Changes

  - **Common stackmon output config**: Extended `buildOutputConfig` to return a third value — a client certificate volume — when the monitoring target ES association has `clientCertSecretName` configured. Adds `ssl.certificate` and `ssl.key` to the Beat output configuration pointing to the mounted client certificate files
  - **Common stackmon sidecar**: Extended `NewMetricBeatSidecar` to accept an optional `clientCertVolume` parameter, which is mounted into the sidecar container alongside the existing CA volume
  - **Elasticsearch Metricbeat sidecar**: When the monitored Elasticsearch cluster has client authentication enabled (`clientAuthenticationRequired`), the operator mounts the internal operator client certificate into the Metricbeat sidecar so it can authenticate to the local ES HTTP endpoint via mTLS. The `clientAuthenticationRequired`
  flag is threaded through `WithMonitoring`, `ReconcileConfigSecrets`, and `Metricbeat`
  - **E2e tests**: Added `TestESStackClientAuthTransitionMonitored` (verifies monitoring continues working when the monitored ES transitions from client auth enabled to disabled) and `TestESStackClientAuthTransitionMonitoring` (verifies monitoring continues working when the monitoring target ES transitions from client auth enabled to
  disabled)