### PR TITLE
[3.4] fix require.Equal inside retry goroutine in SCP e2e test (#9335)

### DIFF
--- a/test/e2e/es/restart_annotation_test.go
+++ b/test/e2e/es/restart_annotation_test.go
@@ -10,10 +10,11 @@ import (
 	"testing"
 	"time"
 
-	esv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/elasticsearch/v1"
-	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test/elasticsearch"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+
+	esv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test/elasticsearch"
 )
 
 // TestRestartTriggerAnnotationCausesRollingRestart creates an HA cluster, sets the

--- a/test/e2e/es/stackconfigpolicy_test.go
+++ b/test/e2e/es/stackconfigpolicy_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -186,14 +185,18 @@ func TestStackConfigPolicy(t *testing.T) {
 				Name: "Cluster name should be as set in the config",
 				Test: test.Eventually(func() error {
 					esClient, err := elasticsearch.NewElasticsearchClient(es.Elasticsearch, k)
-					assert.NoError(t, err)
+					if err != nil {
+						return err
+					}
 
 					var apiResponse ClusterInfoResponse
 					if _, _, err = request(esClient, http.MethodGet, "/", nil, &apiResponse); err != nil {
 						return err
 					}
 
-					require.Equal(t, clusterNameFromConfig, apiResponse.ClusterName)
+					if apiResponse.ClusterName != clusterNameFromConfig {
+						return fmt.Errorf("expected cluster name %q, got %q", clusterNameFromConfig, apiResponse.ClusterName)
+					}
 					return nil
 				}),
 			},


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.4`:
 - [fix require.Equal inside retry goroutine in SCP e2e test (#9335)](https://github.com/elastic/cloud-on-k8s/pull/9335)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)