### PR TITLE
Add ECK cert mismatch causing stack connection failure

### DIFF
--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -27,7 +27,7 @@ For more information, check [PR #9197](https://github.com/elastic/cloud-on-k8s/p
 
 **Workaround**
 
-Delete the transport certificate secret (`<cluster>-es-<nodeset>-es-transport-certs`) and the HTTP certificate secret (`<cluster>-es-http-certs-internal`) to force ECK to regenerate all certificates. For more details, refer to the [KB article](https://support.elastic.co/knowledge/5198af8e). Alternatively, upgrade to ECK 3.4.0 or later once available.
+Delete the transport certificate secret (`<cluster>-es-<nodeset>-es-transport-certs`) and the HTTP certificate secret (`<cluster>-es-http-certs-internal`) to force ECK to regenerate all certificates. For more details, refer to the [KB article](https://ela.st/eck-operator-upgrade-cert-issue). Alternatively, upgrade to ECK 3.4.0 or later once available.
 
 :::
 
@@ -41,7 +41,7 @@ For more information, check [PR #9197](https://github.com/elastic/cloud-on-k8s/p
 
 **Workaround**
 
-Delete the transport certificate secret (`<cluster>-es-<nodeset>-es-transport-certs`) and the HTTP certificate secret (`<cluster>-es-http-certs-internal`) to force ECK to regenerate all certificates. For more details, refer to the [KB article](https://support.elastic.co/knowledge/5198af8e). Alternatively, upgrade to ECK 3.4.0 or later once available.
+Delete the transport certificate secret (`<cluster>-es-<nodeset>-es-transport-certs`) and the HTTP certificate secret (`<cluster>-es-http-certs-internal`) to force ECK to regenerate all certificates. For more details, refer to the [KB article](https://ela.st/eck-operator-upgrade-cert-issue). Alternatively, upgrade to ECK 3.4.0 or later once available.
 
 :::
 
@@ -76,7 +76,7 @@ For more information, check [PR #9197](https://github.com/elastic/cloud-on-k8s/p
 
 **Workaround**
 
-Delete the transport certificate secret (`<cluster>-es-<nodeset>-es-transport-certs`) and the HTTP certificate secret (`<cluster>-es-http-certs-internal`) to force ECK to regenerate all certificates. For more details, refer to the [KB article](https://support.elastic.co/knowledge/5198af8e). Alternatively, upgrade to ECK 3.4.0 or later once available.
+Delete the transport certificate secret (`<cluster>-es-<nodeset>-es-transport-certs`) and the HTTP certificate secret (`<cluster>-es-http-certs-internal`) to force ECK to regenerate all certificates. For more details, refer to the [KB article](https://ela.st/eck-operator-upgrade-cert-issue). Alternatively, upgrade to ECK 3.4.0 or later once available.
 
 :::
 

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -19,7 +19,17 @@ Known issues are significant defects or limitations that may impact your impleme
 
 ## 3.3.2 [elastic-cloud-kubernetes-332-known-issues]
 
-There are no known issues in ECK 3.3.2
+:::{dropdown} Certificate mismatch causing {{es}} and {{kb}} connection failure during ECK operator upgrade
+
+During or after the upgrade of the ECK operator to 3.3.0-3.3.2, HTTP or transport certificate issues can arise due to mismatched Authority Key Identifier (AKI) and Subject Key Identifier (SKI) values. This results in SSL handshake failures and prevents ES nodes from joining the cluster or Kibana/Fleet/other HTTP clients from connecting to it.
+
+For more information, check [PR #9263](https://github.com/elastic/cloud-on-k8s/pull/9263).
+
+**Workaround**
+
+Upgrade to ECK 3.4.0 or later. Alternatively, follow the [KB article](https://support.elastic.co/knowledge/5198af8e) to regenerate relevant certificates without upgrade. 
+
+:::
 
 ## 3.3.1 [elastic-cloud-kubernetes-331-known-issues]
 

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -19,7 +19,7 @@ Known issues are significant defects or limitations that may impact your impleme
 
 ## 3.3.2 [elastic-cloud-kubernetes-332-known-issues]
 
-:::{dropdown} Certificate mismatch causing {{es}} and {{kb}} connection failure during ECK operator upgrade
+:::{dropdown} Certificate mismatch causing {{es}} and {{product.kibana}} connection failure during ECK operator upgrade
 
 During or after upgrading the ECK operator to 3.3.0–3.3.2, HTTP and transport certificate issues can arise due to mismatched Authority Key Identifier (AKI) and Subject Key Identifier (SKI) values. This results in SSL handshake failures, preventing ES nodes from joining the cluster and Kibana, Fleet, and other HTTP clients from connecting to it.
 
@@ -33,7 +33,7 @@ Delete the transport certificate secret (`<cluster>-es-<nodeset>-es-transport-ce
 
 ## 3.3.1 [elastic-cloud-kubernetes-331-known-issues]
 
-:::{dropdown} Certificate mismatch causing {{es}} and {{kb}} connection failure during ECK operator upgrade
+:::{dropdown} Certificate mismatch causing {{es}} and {{product.kibana}} connection failure during ECK operator upgrade
 
 During or after upgrading the ECK operator to 3.3.0–3.3.2, HTTP and transport certificate issues can arise due to mismatched Authority Key Identifier (AKI) and Subject Key Identifier (SKI) values. This results in SSL handshake failures, preventing ES nodes from joining the cluster and Kibana, Fleet, and other HTTP clients from connecting to it.
 
@@ -68,7 +68,7 @@ Renew or restore the Enterprise license so that the AutoOps policy can be valida
 
 ## 3.3.0 [elastic-cloud-kubernetes-330-known-issues]
 
-:::{dropdown} Certificate mismatch causing {{es}} and {{kb}} connection failure during ECK operator upgrade
+:::{dropdown} Certificate mismatch causing {{es}} and {{product.kibana}} connection failure during ECK operator upgrade
 
 During or after upgrading the ECK operator to 3.3.0–3.3.2, HTTP and transport certificate issues can arise due to mismatched Authority Key Identifier (AKI) and Subject Key Identifier (SKI) values. This results in SSL handshake failures, preventing ES nodes from joining the cluster and Kibana, Fleet, and other HTTP clients from connecting to it.
 

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -21,13 +21,13 @@ Known issues are significant defects or limitations that may impact your impleme
 
 :::{dropdown} Certificate mismatch causing {{es}} and {{kb}} connection failure during ECK operator upgrade
 
-During or after the upgrade of the ECK operator to 3.3.0-3.3.2, HTTP or transport certificate issues can arise due to mismatched Authority Key Identifier (AKI) and Subject Key Identifier (SKI) values. This results in SSL handshake failures and prevents ES nodes from joining the cluster or Kibana/Fleet/other HTTP clients from connecting to it.
+During or after upgrading the ECK operator to 3.3.0–3.3.2, HTTP and transport certificate issues can arise due to mismatched Authority Key Identifier (AKI) and Subject Key Identifier (SKI) values. This results in SSL handshake failures, preventing ES nodes from joining the cluster and Kibana, Fleet, and other HTTP clients from connecting to it.
 
 For more information, check [PR #9197](https://github.com/elastic/cloud-on-k8s/pull/9197).
 
 **Workaround**
 
-Upgrade to ECK 3.4.0 or later. Alternatively, follow the [KB article](https://support.elastic.co/knowledge/5198af8e) to regenerate relevant certificates without upgrade. 
+Upgrade to ECK 3.4.0 or later. Alternatively, follow the [KB article](https://support.elastic.co/knowledge/5198af8e) to regenerate relevant certificates without upgrading. 
 
 :::
 

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -27,11 +27,23 @@ For more information, check [PR #9197](https://github.com/elastic/cloud-on-k8s/p
 
 **Workaround**
 
-Upgrade to ECK 3.4.0 or later. Alternatively, follow the [KB article](https://support.elastic.co/knowledge/5198af8e) to regenerate relevant certificates without upgrading. 
+Delete the transport certificate secret (`<cluster>-es-<nodeset>-es-transport-certs`) and the HTTP certificate secret (`<cluster>-es-http-certs-internal`) to force ECK to regenerate all certificates. For more details, refer to the [KB article](https://support.elastic.co/knowledge/5198af8e). Alternatively, upgrade to ECK 3.4.0 or later once available.
 
 :::
 
 ## 3.3.1 [elastic-cloud-kubernetes-331-known-issues]
+
+:::{dropdown} Certificate mismatch causing {{es}} and {{kb}} connection failure during ECK operator upgrade
+
+During or after upgrading the ECK operator to 3.3.0–3.3.2, HTTP and transport certificate issues can arise due to mismatched Authority Key Identifier (AKI) and Subject Key Identifier (SKI) values. This results in SSL handshake failures, preventing ES nodes from joining the cluster and Kibana, Fleet, and other HTTP clients from connecting to it.
+
+For more information, check [PR #9197](https://github.com/elastic/cloud-on-k8s/pull/9197).
+
+**Workaround**
+
+Delete the transport certificate secret (`<cluster>-es-<nodeset>-es-transport-certs`) and the HTTP certificate secret (`<cluster>-es-http-certs-internal`) to force ECK to regenerate all certificates. For more details, refer to the [KB article](https://support.elastic.co/knowledge/5198af8e). Alternatively, upgrade to ECK 3.4.0 or later once available.
+
+:::
 
 :::{dropdown} FIPS operator images use standard Go cryptography instead of BoringCrypto
 Due to a build configuration issue, ECK operator FIPS images published between versions 2.9.0 and 3.3.1 use the standard Go cryptography library instead of BoringCrypto. Standard Go does not use FIPS 140-2/3 validated cryptographic libraries. Upgrade to version 3.3.2 or later to get images built using FIPS 140-2/3 validated cryptographic libraries.
@@ -55,6 +67,18 @@ Renew or restore the Enterprise license so that the AutoOps policy can be valida
 :::
 
 ## 3.3.0 [elastic-cloud-kubernetes-330-known-issues]
+
+:::{dropdown} Certificate mismatch causing {{es}} and {{kb}} connection failure during ECK operator upgrade
+
+During or after upgrading the ECK operator to 3.3.0–3.3.2, HTTP and transport certificate issues can arise due to mismatched Authority Key Identifier (AKI) and Subject Key Identifier (SKI) values. This results in SSL handshake failures, preventing ES nodes from joining the cluster and Kibana, Fleet, and other HTTP clients from connecting to it.
+
+For more information, check [PR #9197](https://github.com/elastic/cloud-on-k8s/pull/9197).
+
+**Workaround**
+
+Delete the transport certificate secret (`<cluster>-es-<nodeset>-es-transport-certs`) and the HTTP certificate secret (`<cluster>-es-http-certs-internal`) to force ECK to regenerate all certificates. For more details, refer to the [KB article](https://support.elastic.co/knowledge/5198af8e). Alternatively, upgrade to ECK 3.4.0 or later once available.
+
+:::
 
 :::{dropdown} FIPS operator images use standard Go cryptography instead of BoringCrypto
 Due to a build configuration issue, ECK operator FIPS images published between versions 2.9.0 and 3.3.1 use the standard Go cryptography library instead of BoringCrypto. Standard Go does not use FIPS 140-2/3 validated cryptographic libraries. Upgrade to version 3.3.2 or later to get images built using FIPS 140-2/3 validated cryptographic libraries.

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -23,7 +23,7 @@ Known issues are significant defects or limitations that may impact your impleme
 
 During or after the upgrade of the ECK operator to 3.3.0-3.3.2, HTTP or transport certificate issues can arise due to mismatched Authority Key Identifier (AKI) and Subject Key Identifier (SKI) values. This results in SSL handshake failures and prevents ES nodes from joining the cluster or Kibana/Fleet/other HTTP clients from connecting to it.
 
-For more information, check [PR #9263](https://github.com/elastic/cloud-on-k8s/pull/9263).
+For more information, check [PR #9197](https://github.com/elastic/cloud-on-k8s/pull/9197).
 
 **Workaround**
 


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to Elastic Cloud on Kubernetes!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? yes
- Have you followed the [contributor guidelines](https://github.com/elastic/cloud-on-k8s/tree/main/CONTRIBUTING.md)? yes
- If you submit code, is your pull request against main? We recommend pull requests against main. We will backport them as needed. not code

## Description

During troubleshooting, we (support) found that, 
* During or after the upgrade of the Elastic Cloud on Kubernetes (ECK) operator to 3.3.x, HTTP or transport certificate issues can arise due to mismatched Authority Key Identifier (AKI) and Subject Key Identifier (SKI) values. This results in SSL handshake failures and prevents ES nodes from joining the cluster or Kibana/Fleet/other HTTP clients from connecting to it.
* KB article: https://support.elastic.co/knowledge/5198af8e (internal view: https://support.elastic.dev/knowledge/view/5198af8e)

We would like to raise a doc PR to record this as ECK known issue for version 3.3.0-3.3.2.

The fix is tentatively scheduled for release in ECK 3.4.0 per https://github.com/elastic/cloud-on-k8s/pull/9197. 

## View / preview

After merge:
https://www.elastic.co/docs/release-notes/cloud-on-k8s/known-issues

Before merge:
[docs/release-notes/known-issues.md](https://docs-v3-preview.elastic.dev/elastic/cloud-on-k8s/pull/9342/release-notes/known-issues)

---

cc @jeanfabrice 

