### PR TITLE
Add Mergify configuration

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,91 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Mergifyio/docs/main/public/mergify-configuration-schema.json
+# https://docs.mergify.com/configuration/file-format/
+
+commands_restrictions:
+  backport:
+    conditions:
+      - or:
+          - sender-permission>=write
+          - sender=elastic-renovate-prod[bot]
+
+defaults:
+  actions:
+    backport:
+      title: "[{{ destination_branch }}] (backport #{{ number }}) {{ title }}"
+      assignees:
+        - "{{ author }}"
+      labels:
+        - "backport"
+
+pull_request_rules:
+  # Automatically assigns the PR author as the assignee when no one is assigned yet.
+  - name: self-assign PRs
+    conditions:
+      - -merged
+      - -closed
+      - "#assignee=0"
+    actions:
+      assign:
+        add_users:
+          - "{{ author }}"
+
+  # Comments on PRs that have merge conflicts, asking the author to resolve them.
+  - name: ask to resolve conflict
+    conditions:
+      - -merged
+      - -closed
+      - conflict
+    actions:
+      comment:
+        message: |
+          This pull request is now in conflicts. Could you fix it? 🙏
+          To fixup this pull request, you can check out it locally. See documentation: https://help.github.com/articles/checking-out-pull-requests-locally/
+          ```
+          git fetch upstream
+          git checkout -b {{head}} upstream/{{head}}
+          git merge upstream/{{base}}
+          git push upstream {{head}}
+          ```
+
+  # Forward-ports merged PRs labeled "forwardport-main" to the main branch via backport. In case we merge something in a release branch first, and then we need it in main branch.
+  - name: forward-port patches to main branch
+    conditions:
+      - merged
+      - label=forwardport-main
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "main"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
+
+  # Backports merged PRs labeled "backport-v3.3" to the 3.3 release branch.
+  - name: backport patches to 3.3 branch
+    conditions:
+      - merged
+      - label=backport-v3.3
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "3.3"
+        labels:
+          - "backport"
+
+  # Backports merged PRs labeled "backport-v3.4" to the 3.4 release branch.
+  - name: backport patches to 3.4 branch
+    conditions:
+      - merged
+      - label=backport-v3.4
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "3.4"
+        labels:
+          - "backport"

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -18,17 +18,6 @@ defaults:
         - "backport"
 
 pull_request_rules:
-  # Automatically assigns the PR author as the assignee when no one is assigned yet.
-  - name: self-assign PRs
-    conditions:
-      - -merged
-      - -closed
-      - "#assignee=0"
-    actions:
-      assign:
-        add_users:
-          - "{{ author }}"
-
 
   # Forward-ports merged PRs labeled "forwardport-main" to the main branch via backport. In case we merge something in a release branch first, and then we need it in main branch.
   - name: forward-port patches to main branch
@@ -37,6 +26,7 @@ pull_request_rules:
       - label=forwardport-main
     actions:
       backport:
+        title: "[{{ destination_branch }}] (forward-port #{{ number }}) {{ title }}"
         branches: ["main"]
 
   # Backports merged PRs labeled "backport-v3.3" to the 3.3 release branch.

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -29,23 +29,6 @@ pull_request_rules:
         add_users:
           - "{{ author }}"
 
-  # Comments on PRs that have merge conflicts, asking the author to resolve them.
-  - name: ask to resolve conflict
-    conditions:
-      - -merged
-      - -closed
-      - conflict
-    actions:
-      comment:
-        message: |
-          This pull request is now in conflicts. Could you fix it? 🙏
-          To fixup this pull request, you can check out it locally. See documentation: https://help.github.com/articles/checking-out-pull-requests-locally/
-          ```
-          git fetch upstream
-          git checkout -b {{head}} upstream/{{head}}
-          git merge upstream/{{base}}
-          git push upstream {{head}}
-          ```
 
   # Forward-ports merged PRs labeled "forwardport-main" to the main branch via backport. In case we merge something in a release branch first, and then we need it in main branch.
   - name: forward-port patches to main branch
@@ -54,13 +37,7 @@ pull_request_rules:
       - label=forwardport-main
     actions:
       backport:
-        assignees:
-          - "{{ author }}"
-        branches:
-          - "main"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
+        branches: ["main"]
 
   # Backports merged PRs labeled "backport-v3.3" to the 3.3 release branch.
   - name: backport patches to 3.3 branch
@@ -69,12 +46,7 @@ pull_request_rules:
       - label=backport-v3.3
     actions:
       backport:
-        assignees:
-          - "{{ author }}"
-        branches:
-          - "3.3"
-        labels:
-          - "backport"
+        branches: ["3.3"]
 
   # Backports merged PRs labeled "backport-v3.4" to the 3.4 release branch.
   - name: backport patches to 3.4 branch
@@ -83,9 +55,4 @@ pull_request_rules:
       - label=backport-v3.4
     actions:
       backport:
-        assignees:
-          - "{{ author }}"
-        branches:
-          - "3.4"
-        labels:
-          - "backport"
+        branches: ["3.4"]


### PR DESCRIPTION
https://docs.mergify.com/configuration/file-format/

Summary
  - Introduce .github/mergify.yml to automate common PR workflows via Mergify

What it does
  - Auto-assign PRs to their author when no assignee is set (irrelevant to backport but useful 😅).
  - Conflict notification: comments on PRs with merge conflicts asking the author to resolve them
  - Backport automation: label-driven backports to 3.3 and 3.4 release branches
    - Adding label `backport-v3.3` will open a backport pr to `3.3` branch (after merge).
    - Adding label `backport-v3.4` will open a backport pr to `3.4` branch (after merge).
  - Forward-port to main: PRs merged in release branches can be forwarded to main via the forwardport-main label
  - Restricts the backport command to users with write permission and Renovate bot
