### PR TITLE
[3.4] chore(deps): update go (#9344)

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,6 @@
 # ---------------------------------------------
 # Build the operator binary
-FROM docker.elastic.co/wolfi/go:1.26.1-r1@sha256:257f937e87770e15e9c9cab30d2978c639c38886a278ea2fe91f77dc2d23c7e9 AS builder
+FROM docker.elastic.co/wolfi/go:v1.26.2-r0@sha256:8ae760d4a7bb419d04944fe8c164de74a824e7374b359cd2f926716a6ebf9116 AS builder
 
 ARG VERSION
 ARG SHA1

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/elastic/cloud-on-k8s/v3
 
 go 1.25.7
 
-toolchain go1.26.1
+toolchain go1.26.2
 
 require (
 	cloud.google.com/go/auth v0.20.0

--- a/hack/config-extractor/go.mod
+++ b/hack/config-extractor/go.mod
@@ -2,7 +2,7 @@ module github.com/elastic/cloud-on-k8s/v3/hack/config-extractor
 
 go 1.25.0
 
-toolchain go1.26.1
+toolchain go1.26.2
 
 require (
 	k8s.io/api v0.35.3

--- a/hack/helm/release/go.mod
+++ b/hack/helm/release/go.mod
@@ -2,7 +2,7 @@ module github.com/elastic/cloud-on-k8s/hack/helm/release
 
 go 1.25.7
 
-toolchain go1.26.1
+toolchain go1.26.2
 
 require (
 	cloud.google.com/go/storage v1.62.0

--- a/hack/manifest-gen/Dockerfile
+++ b/hack/manifest-gen/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/go:1.26.1-r1@sha256:257f937e87770e15e9c9cab30d2978c639c38886a278ea2fe91f77dc2d23c7e9 as builder
+FROM docker.elastic.co/wolfi/go:v1.26.2-r0@sha256:8ae760d4a7bb419d04944fe8c164de74a824e7374b359cd2f926716a6ebf9116 as builder
 ADD . /manifest-gen
 WORKDIR /manifest-gen
 ENV GO111MODULE=on CGO_ENABLED=0 GOOS=linux 

--- a/hack/manifest-gen/go.mod
+++ b/hack/manifest-gen/go.mod
@@ -2,7 +2,7 @@ module github.com/elastic/cloud-on-k8s/v3/hack/manifest-gen
 
 go 1.25.0
 
-toolchain go1.26.1
+toolchain go1.26.2
 
 require (
 	github.com/spf13/cobra v1.10.2

--- a/hack/operatorhub/go.mod
+++ b/hack/operatorhub/go.mod
@@ -2,7 +2,7 @@ module github.com/elastic/cloud-on-k8s/v3/hack/operatorhub
 
 go 1.25.7
 
-toolchain go1.26.1
+toolchain go1.26.2
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0

--- a/hack/release-notes/go.mod
+++ b/hack/release-notes/go.mod
@@ -2,7 +2,7 @@ module github.com/elastic/cloud-on-k8s/v3/hack/release-notes
 
 go 1.25.0
 
-toolchain go1.26.1
+toolchain go1.26.2
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/hack/upgrade-test-harness/go.mod
+++ b/hack/upgrade-test-harness/go.mod
@@ -2,7 +2,7 @@ module github.com/elastic/cloud-on-k8s/v3/hack/upgrade-test-harness
 
 go 1.25.0
 
-toolchain go1.26.1
+toolchain go1.26.2
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -1,5 +1,5 @@
 # Docker image for the E2E tests runner
-FROM docker.io/library/golang:1.26.1
+FROM docker.io/library/golang:1.26.2
 
 ARG GO_TAGS
 ARG ARCH


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.4`:
 - [chore(deps): update go (#9344)](https://github.com/elastic/cloud-on-k8s/pull/9344)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)