### PR TITLE
bump Kibana memory limits in TestUpdateKibanaResources to 2Gi

### DIFF
--- a/test/e2e/kb/resource_test.go
+++ b/test/e2e/kb/resource_test.go
@@ -21,11 +21,11 @@ import (
 func TestUpdateKibanaResources(t *testing.T) {
 	resources := corev1.ResourceRequirements{
 		Requests: map[corev1.ResourceName]resource.Quantity{
-			corev1.ResourceMemory: resource.MustParse("512Mi"),
+			corev1.ResourceMemory: resource.MustParse("1Gi"),
 			corev1.ResourceCPU:    resource.MustParse("100m"),
 		},
 		Limits: map[corev1.ResourceName]resource.Quantity{
-			corev1.ResourceMemory: resource.MustParse("1Gi"),
+			corev1.ResourceMemory: resource.MustParse("2Gi"),
 			corev1.ResourceCPU:    resource.MustParse("500m"),
 		},
 	}


### PR DESCRIPTION
For the same reasons of [this PR](https://github.com/elastic/cloud-on-k8s/pull/9328) we need to bump the resources in the TestUpdateKibanaResources e2e test as well