### PR TITLE
Support Elasticsearch role definitions in StackConfigPolicy

### DIFF
--- a/pkg/apis/stackconfigpolicy/v1alpha1/stackconfigpolicy_types.go
+++ b/pkg/apis/stackconfigpolicy/v1alpha1/stackconfigpolicy_types.go
@@ -79,6 +79,9 @@ type ElasticsearchConfigPolicySpec struct {
 	// SecurityRoleMappings holds the Role Mappings settings (/_security/role_mapping)
 	// +kubebuilder:pruning:PreserveUnknownFields
 	SecurityRoleMappings *commonv1.Config `json:"securityRoleMappings,omitempty"`
+	// SecurityRoles holds the Role definitions (/_security/role)
+	// +kubebuilder:pruning:PreserveUnknownFields
+	SecurityRoles *commonv1.Config `json:"securityRoles,omitempty"`
 	// IndexLifecyclePolicies holds the Index Lifecycle policies settings (/_ilm/policy)
 	// +kubebuilder:pruning:PreserveUnknownFields
 	IndexLifecyclePolicies *commonv1.Config `json:"indexLifecyclePolicies,omitempty"`

--- a/pkg/controller/elasticsearch/filesettings/file_settings.go
+++ b/pkg/controller/elasticsearch/filesettings/file_settings.go
@@ -41,6 +41,7 @@ type SettingsState struct {
 	SnapshotRepositories   *commonv1.Config `json:"snapshot_repositories,omitempty"`
 	SLM                    *commonv1.Config `json:"slm,omitempty"`
 	RoleMappings           *commonv1.Config `json:"role_mappings,omitempty"`
+	Roles                  *commonv1.Config `json:"roles,omitempty"`
 	IndexLifecyclePolicies *commonv1.Config `json:"ilm,omitempty"`
 	IngestPipelines        *commonv1.Config `json:"ingest_pipelines,omitempty"`
 	IndexTemplates         *IndexTemplates  `json:"index_templates,omitempty"`
@@ -71,6 +72,7 @@ func newEmptySettingsState() SettingsState {
 		SnapshotRepositories:   &commonv1.Config{Data: map[string]any{}},
 		SLM:                    &commonv1.Config{Data: map[string]any{}},
 		RoleMappings:           &commonv1.Config{Data: map[string]any{}},
+		Roles:                  &commonv1.Config{Data: map[string]any{}},
 		IndexLifecyclePolicies: &commonv1.Config{Data: map[string]any{}},
 		IngestPipelines:        &commonv1.Config{Data: map[string]any{}},
 		IndexTemplates: &IndexTemplates{
@@ -108,6 +110,9 @@ func (s *Settings) updateState(es types.NamespacedName, esConfigPolicy policyv1a
 	}
 	if esConfigPolicy.SecurityRoleMappings != nil {
 		state.RoleMappings = esConfigPolicy.SecurityRoleMappings
+	}
+	if esConfigPolicy.SecurityRoles != nil {
+		state.Roles = esConfigPolicy.SecurityRoles
 	}
 	if esConfigPolicy.IndexLifecyclePolicies != nil {
 		state.IndexLifecyclePolicies = esConfigPolicy.IndexLifecyclePolicies

--- a/pkg/controller/elasticsearch/filesettings/file_settings_test.go
+++ b/pkg/controller/elasticsearch/filesettings/file_settings_test.go
@@ -196,6 +196,7 @@ func Test_updateState(t *testing.T) {
 				}},
 				SLM:                    &commonv1.Config{Data: map[string]any{}},
 				RoleMappings:           &commonv1.Config{Data: map[string]any{}},
+				Roles:                  &commonv1.Config{Data: map[string]any{}},
 				IndexLifecyclePolicies: &commonv1.Config{Data: map[string]any{}},
 				IngestPipelines:        &commonv1.Config{Data: map[string]any{}},
 				IndexTemplates: &IndexTemplates{
@@ -258,6 +259,7 @@ func Test_updateState(t *testing.T) {
 				}},
 				SLM:                    &commonv1.Config{Data: map[string]any{}},
 				RoleMappings:           &commonv1.Config{Data: map[string]any{}},
+				Roles:                  &commonv1.Config{Data: map[string]any{}},
 				IndexLifecyclePolicies: &commonv1.Config{Data: map[string]any{}},
 				IngestPipelines:        &commonv1.Config{Data: map[string]any{}},
 				IndexTemplates: &IndexTemplates{
@@ -302,6 +304,7 @@ func Test_updateState(t *testing.T) {
 				}},
 				SLM:                    &commonv1.Config{Data: map[string]any{}},
 				RoleMappings:           &commonv1.Config{Data: map[string]any{}},
+				Roles:                  &commonv1.Config{Data: map[string]any{}},
 				IndexLifecyclePolicies: &commonv1.Config{Data: map[string]any{}},
 				IngestPipelines:        &commonv1.Config{Data: map[string]any{}},
 				IndexTemplates: &IndexTemplates{
@@ -348,6 +351,7 @@ func Test_updateState(t *testing.T) {
 				}},
 				SLM:                    &commonv1.Config{Data: map[string]any{}},
 				RoleMappings:           &commonv1.Config{Data: map[string]any{}},
+				Roles:                  &commonv1.Config{Data: map[string]any{}},
 				IndexLifecyclePolicies: &commonv1.Config{Data: map[string]any{}},
 				IngestPipelines:        &commonv1.Config{Data: map[string]any{}},
 				IndexTemplates: &IndexTemplates{
@@ -423,11 +427,49 @@ func Test_updateState(t *testing.T) {
 				SnapshotRepositories:   &commonv1.Config{Data: map[string]any{}},
 				SLM:                    snapshotLifecyclePolicies,
 				RoleMappings:           roleMappings,
+				Roles:                  &commonv1.Config{Data: map[string]any{}},
 				IndexLifecyclePolicies: indexLifecyclePolicies,
 				IngestPipelines:        ingestPipelines,
 				IndexTemplates: &IndexTemplates{
 					ComposableIndexTemplates: composableIndexTemplates,
 					ComponentTemplates:       componentTemplates,
+				},
+			},
+		},
+		{
+			name: "security roles: propagated to state",
+			args: args{policy: policyv1alpha1.StackConfigPolicy{Spec: policyv1alpha1.StackConfigPolicySpec{Elasticsearch: policyv1alpha1.ElasticsearchConfigPolicySpec{
+				SecurityRoles: &commonv1.Config{Data: map[string]any{
+					"test-role": map[string]any{
+						"indices": []any{
+							map[string]any{
+								"names":      []any{"logs-*"},
+								"privileges": []any{"read"},
+							},
+						},
+					},
+				}},
+			}}}},
+			want: SettingsState{
+				ClusterSettings:      &commonv1.Config{Data: map[string]any{}},
+				SnapshotRepositories: &commonv1.Config{Data: map[string]any{}},
+				SLM:                  &commonv1.Config{Data: map[string]any{}},
+				RoleMappings:         &commonv1.Config{Data: map[string]any{}},
+				Roles: &commonv1.Config{Data: map[string]any{
+					"test-role": map[string]any{
+						"indices": []any{
+							map[string]any{
+								"names":      []any{"logs-*"},
+								"privileges": []any{"read"},
+							},
+						},
+					},
+				}},
+				IndexLifecyclePolicies: &commonv1.Config{Data: map[string]any{}},
+				IngestPipelines:        &commonv1.Config{Data: map[string]any{}},
+				IndexTemplates: &IndexTemplates{
+					ComponentTemplates:       &commonv1.Config{Data: map[string]any{}},
+					ComposableIndexTemplates: &commonv1.Config{Data: map[string]any{}},
 				},
 			},
 		},

--- a/pkg/controller/stackconfigpolicy/controller_test.go
+++ b/pkg/controller/stackconfigpolicy/controller_test.go
@@ -185,7 +185,7 @@ func TestReconcileStackConfigPolicy_Reconcile(t *testing.T) {
 				commonlabels.StackConfigPolicyOnDeleteLabelName: commonlabels.OrphanSecretResetOnPolicyDelete,
 			},
 		},
-		Data: map[string][]byte{"settings.json": []byte(`{"metadata":{"version":"42","compatibility":"8.4.0"},"state":{"cluster_settings":{"indices.recovery.max_bytes_per_sec":"42mb"},"snapshot_repositories":{},"slm":{},"role_mappings":{},"autoscaling":{},"ilm":{},"ingest_pipelines":{},"index_templates":{"component_templates":{},"composable_index_templates":{}}}}`)},
+		Data: map[string][]byte{"settings.json": []byte(`{"metadata":{"version":"42","compatibility":"8.4.0"},"state":{"cluster_settings":{"indices.recovery.max_bytes_per_sec":"42mb"},"snapshot_repositories":{},"slm":{},"role_mappings":{},"roles":{},"autoscaling":{},"ilm":{},"ingest_pipelines":{},"index_templates":{"component_templates":{},"composable_index_templates":{}}}}`)},
 	}
 	secretHash, err := getSettingsHash(secretFixture)
 	assert.NoError(t, err)
@@ -956,7 +956,7 @@ func TestReconcileStackConfigPolicy_MultipleStackConfigPolicies(t *testing.T) {
 				commonlabels.StackConfigPolicyOnDeleteLabelName: commonlabels.OrphanSecretResetOnPolicyDelete,
 			},
 		},
-		Data: map[string][]byte{"settings.json": []byte(`{"metadata":{"version":"1","compatibility":"8.4.0"},"state":{"cluster_settings":{},"snapshot_repositories":{},"slm":{},"role_mappings":{},"autoscaling":{},"ilm":{},"ingest_pipelines":{},"index_templates":{"component_templates":{},"composable_index_templates":{}}}}`)},
+		Data: map[string][]byte{"settings.json": []byte(`{"metadata":{"version":"1","compatibility":"8.4.0"},"state":{"cluster_settings":{},"snapshot_repositories":{},"slm":{},"role_mappings":{},"roles":{},"autoscaling":{},"ilm":{},"ingest_pipelines":{},"index_templates":{"component_templates":{},"composable_index_templates":{}}}}`)},
 	}
 
 	esPod := getEsPod("ns", map[string]string{})

--- a/pkg/controller/stackconfigpolicy/stackconfigpolicy.go
+++ b/pkg/controller/stackconfigpolicy/stackconfigpolicy.go
@@ -144,6 +144,7 @@ func mergeElasticsearchSpecs(dst, src *policyv1alpha1.ElasticsearchConfigPolicyS
 		{&dst.SnapshotRepositories, src.SnapshotRepositories, mergeConfig},
 		{&dst.SnapshotLifecyclePolicies, src.SnapshotLifecyclePolicies, mergeConfig},
 		{&dst.SecurityRoleMappings, src.SecurityRoleMappings, mergeConfig},
+		{&dst.SecurityRoles, src.SecurityRoles, mergeConfig},
 		{&dst.IndexLifecyclePolicies, src.IndexLifecyclePolicies, mergeConfig},
 		{&dst.IngestPipelines, src.IngestPipelines, mergeConfig},
 		{&dst.IndexTemplates.ComposableIndexTemplates, src.IndexTemplates.ComposableIndexTemplates, mergeConfig},

--- a/pkg/controller/stackconfigpolicy/stackconfigpolicy_test.go
+++ b/pkg/controller/stackconfigpolicy/stackconfigpolicy_test.go
@@ -78,6 +78,11 @@ func Test_getStackPolicyConfigForElasticsearch(t *testing.T) {
 									"enabled": true,
 								},
 							}},
+							SecurityRoles: &commonv1.Config{Data: map[string]any{
+								"policy1-role": map[string]any{
+									"indices": []any{map[string]any{"names": []any{"policy1-*"}, "privileges": []any{"read"}}},
+								},
+							}},
 							IndexLifecyclePolicies: &commonv1.Config{Data: map[string]any{
 								"policy1": map[string]any{
 									"phases": map[string]any{
@@ -158,6 +163,11 @@ func Test_getStackPolicyConfigForElasticsearch(t *testing.T) {
 									"enabled": true,
 								},
 							}},
+							SecurityRoles: &commonv1.Config{Data: map[string]any{
+								"policy2-role": map[string]any{
+									"indices": []any{map[string]any{"names": []any{"policy2-*"}, "privileges": []any{"read"}}},
+								},
+							}},
 							IndexLifecyclePolicies: &commonv1.Config{Data: map[string]any{
 								"policy2": map[string]any{
 									"phases": map[string]any{
@@ -233,6 +243,14 @@ func Test_getStackPolicyConfigForElasticsearch(t *testing.T) {
 							},
 							"policy2": map[string]any{
 								"enabled": true,
+							},
+						}},
+						SecurityRoles: &commonv1.Config{Data: map[string]any{
+							"policy1-role": map[string]any{
+								"indices": []any{map[string]any{"names": []any{"policy1-*"}, "privileges": []any{"read"}}},
+							},
+							"policy2-role": map[string]any{
+								"indices": []any{map[string]any{"names": []any{"policy2-*"}, "privileges": []any{"read"}}},
 							},
 						}},
 						IndexLifecyclePolicies: &commonv1.Config{Data: map[string]any{


### PR DESCRIPTION
Closes #9297

**Problem**

SCP already lets you centrally manage role mappings (who gets which role) via `securityRoleMappings`, but there is no way to define the roles themselves through SCP. Users who want consistent role definitions across multiple clusters have to configure them on each cluster individually via `spec.auth.roles`.

**Solution**

Adds a `securityRoles` field to `StackConfigPolicy.spec.elasticsearch` following the same pattern as `securityRoleMappings`. Roles defined through SCP are reconciled across all targeted clusters, respecting the existing weight-based priority and conflict resolution.

**Changes**

- Added `SecurityRoles` field to `ElasticsearchConfigPolicySpec`
- Added `Roles` to `SettingsState` and wired it through the file-based settings pipeline
- Added `SecurityRoles` to the weight-based merge logic in `mergeElasticsearchSpecs`
- Updated existing tests and added new test cases for propagation and multi-policy merging