### PR TITLE
Add logs-elastic* index privileges to stack monitoring role

### DIFF
--- a/pkg/controller/elasticsearch/user/roles.go
+++ b/pkg/controller/elasticsearch/user/roles.go
@@ -227,6 +227,11 @@ var (
 					Privileges: []string{"manage", "read", "create_doc", "view_index_metadata", "create_index"},
 				},
 				{
+					// logs-elastic* covers data streams for ES-managed log datasets (e.g. logs-elasticsearch.querylog-*)
+					// that are shipped by the Filebeat sidecar starting with ES 9.4. Uses a broad pattern to
+					// accommodate additional datasets that will follow the same naming convention.
+					// auto_configure is required because data streams need it to create backing indices from
+					// the managed index template on first write.
 					Names:      []string{"logs-elastic*"},
 					Privileges: []string{"manage", "read", "create_doc", "view_index_metadata", "create_index", "auto_configure"},
 				},

--- a/pkg/controller/elasticsearch/user/roles.go
+++ b/pkg/controller/elasticsearch/user/roles.go
@@ -226,6 +226,10 @@ var (
 					Names:      []string{"filebeat-*"},
 					Privileges: []string{"manage", "read", "create_doc", "view_index_metadata", "create_index"},
 				},
+				{
+					Names:      []string{"logs-elastic*"},
+					Privileges: []string{"manage", "read", "create_doc", "view_index_metadata", "create_index", "auto_configure"},
+				},
 			},
 		},
 		FleetAdminUserRole: esclient.Role{

--- a/test/e2e/es/stack_monitoring_test.go
+++ b/test/e2e/es/stack_monitoring_test.go
@@ -53,7 +53,7 @@ func TestESStackMonitoring(t *testing.T) {
 
 	// checks that the sidecar beats have sent data in the monitoring clusters
 	steps := func(k *test.K8sClient) test.StepList {
-		return checks.MonitoredSteps(&monitored, k)
+		return append(checks.MonitoredSteps(&monitored, k), checks.QuerylogSteps(&monitored, &logs, k)...)
 	}
 
 	test.Sequence(nil, steps, metrics, logs, monitored).RunSequential(t)
@@ -199,8 +199,9 @@ func TestExternalESStackMonitoring(t *testing.T) {
 			},
 		}
 
-		c := checks.MonitoredSteps(&monitored, k)
-		return append(s, c...)
+		// QuerylogSteps not added here: the external monitoring user uses built-in roles
+		// (remote_monitoring_agent, etc.) that don't include logs-elastic* privileges.
+		return append(s, checks.MonitoredSteps(&monitored, k)...)
 	}
 
 	test.Sequence(nil, steps, monitoring, monitored).RunSequential(t)

--- a/test/e2e/test/checks/monitoring.go
+++ b/test/e2e/test/checks/monitoring.go
@@ -160,17 +160,17 @@ type querylogChecks struct {
 	k8sClient *test.K8sClient
 }
 
-func (qc querylogChecks) esClient(es esv1.Elasticsearch) (esClient.Client, error) {
+func (qc querylogChecks) clientFor(b *elasticsearch.Builder) (esClient.Client, error) {
+	es := esv1.Elasticsearch{}
+	ref := types.NamespacedName{Name: b.Elasticsearch.Name, Namespace: b.Elasticsearch.Namespace}
+	if err := qc.k8sClient.Client.Get(context.Background(), ref, &es); err != nil {
+		return nil, err
+	}
 	return elasticsearch.NewElasticsearchClient(es, qc.k8sClient)
 }
 
 func (qc querylogChecks) setQueryLog(enabled bool) error {
-	monitoredES := esv1.Elasticsearch{}
-	ref := types.NamespacedName{Name: qc.monitored.Elasticsearch.Name, Namespace: qc.monitored.Elasticsearch.Namespace}
-	if err := qc.k8sClient.Client.Get(context.Background(), ref, &monitoredES); err != nil {
-		return err
-	}
-	client, err := qc.esClient(monitoredES)
+	client, err := qc.clientFor(qc.monitored)
 	if err != nil {
 		return err
 	}
@@ -189,12 +189,7 @@ func (qc querylogChecks) setQueryLog(enabled bool) error {
 }
 
 func (qc querylogChecks) generateQueries() error {
-	monitoredES := esv1.Elasticsearch{}
-	ref := types.NamespacedName{Name: qc.monitored.Elasticsearch.Name, Namespace: qc.monitored.Elasticsearch.Namespace}
-	if err := qc.k8sClient.Client.Get(context.Background(), ref, &monitoredES); err != nil {
-		return err
-	}
-	client, err := qc.esClient(monitoredES)
+	client, err := qc.clientFor(qc.monitored)
 	if err != nil {
 		return err
 	}
@@ -246,12 +241,7 @@ func (qc querylogChecks) checkQuerylogIndex() test.Step {
 			if err := qc.generateQueries(); err != nil {
 				return err
 			}
-			esLogs := esv1.Elasticsearch{}
-			ref := types.NamespacedName{Name: qc.logs.Elasticsearch.Name, Namespace: qc.logs.Elasticsearch.Namespace}
-			if err := qc.k8sClient.Client.Get(context.Background(), ref, &esLogs); err != nil {
-				return err
-			}
-			client, err := qc.esClient(esLogs)
+			client, err := qc.clientFor(qc.logs)
 			if err != nil {
 				return err
 			}

--- a/test/e2e/test/checks/monitoring.go
+++ b/test/e2e/test/checks/monitoring.go
@@ -13,12 +13,11 @@ import (
 	"strconv"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 
 	esv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/elasticsearch/v1"
-	esClient "github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/client"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/version"
+	esClient "github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/client"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test"
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test/elasticsearch"
@@ -54,17 +53,11 @@ type stackMonitoringChecks struct {
 }
 
 func (c stackMonitoringChecks) Steps() test.StepList {
-	steps := test.StepList{
+	return test.StepList{
 		c.CheckBeatSidecarsInElasticsearch(),
 		c.CheckMonitoringMetricsIndex(),
 		c.CheckFilebeatIndex(),
 	}
-	// On 9.4+ verify that querylog events can be shipped to the monitoring cluster
-	v := version.MustParse(test.Ctx().ElasticStackVersion)
-	if v.GTE(version.MinFor(9, 4, 0)) {
-		steps = append(steps, c.EnableQueryLogAndGenerateQueries(), c.CheckQuerylogIndex(), c.DisableQueryLog())
-	}
-	return steps
 }
 
 func (c stackMonitoringChecks) CheckBeatSidecarsInElasticsearch() test.Step {
@@ -111,7 +104,7 @@ func (c stackMonitoringChecks) CheckMonitoringMetricsIndex() test.Step {
 				return err
 			}
 			// Check that there is at least one document
-			err = ContainsDocuments(client, indexPattern)
+			err = containsDocuments(client, indexPattern)
 			if err != nil {
 				return err
 			}
@@ -137,7 +130,7 @@ func (c stackMonitoringChecks) CheckFilebeatIndex() test.Step {
 			if err != nil {
 				return err
 			}
-			err = ContainsDocuments(client, "filebeat-*")
+			err = containsDocuments(client, "filebeat-*")
 			if err != nil {
 				return err
 			}
@@ -145,93 +138,133 @@ func (c stackMonitoringChecks) CheckFilebeatIndex() test.Step {
 		})}
 }
 
-// monitoredESClient returns an ES client for the monitored resource if it is an Elasticsearch cluster.
-// Returns nil, nil if the monitored resource is not an Elasticsearch cluster.
-func (c stackMonitoringChecks) monitoredESClient() (esClient.Client, error) {
-	monitoredES := esv1.Elasticsearch{}
-	ref := types.NamespacedName{Name: c.monitored.Name(), Namespace: c.monitored.Namespace()}
-	if err := c.k8sClient.Client.Get(context.Background(), ref, &monitoredES); err != nil {
-		if errors.IsNotFound(err) {
-			return nil, nil
-		}
-		return nil, err
+// QuerylogSteps returns steps that enable query logging on the monitored ES cluster, generate
+// queries, verify that querylog events are indexed in the logs monitoring cluster, and then
+// disable query logging again. Returns nil on versions before 9.4 where querylog is not available.
+func QuerylogSteps(monitored, logs *elasticsearch.Builder, k *test.K8sClient) test.StepList {
+	v := version.MustParse(test.Ctx().ElasticStackVersion)
+	if !v.GTE(version.MinFor(9, 4, 0)) {
+		return nil
 	}
-	return elasticsearch.NewElasticsearchClient(monitoredES, c.k8sClient)
+	qc := querylogChecks{monitored: monitored, logs: logs, k8sClient: k}
+	return test.StepList{
+		qc.enableAndGenerateQueries(),
+		qc.checkQuerylogIndex(),
+		qc.disableQueryLog(),
+	}
 }
 
-func (c stackMonitoringChecks) setQueryLog(enabled bool) error {
-	client, err := c.monitoredESClient()
+type querylogChecks struct {
+	monitored *elasticsearch.Builder
+	logs      *elasticsearch.Builder
+	k8sClient *test.K8sClient
+}
+
+func (qc querylogChecks) esClient(es esv1.Elasticsearch) (esClient.Client, error) {
+	return elasticsearch.NewElasticsearchClient(es, qc.k8sClient)
+}
+
+func (qc querylogChecks) setQueryLog(enabled bool) error {
+	monitoredES := esv1.Elasticsearch{}
+	ref := types.NamespacedName{Name: qc.monitored.Elasticsearch.Name, Namespace: qc.monitored.Elasticsearch.Namespace}
+	if err := qc.k8sClient.Client.Get(context.Background(), ref, &monitoredES); err != nil {
+		return err
+	}
+	client, err := qc.esClient(monitoredES)
 	if err != nil {
 		return err
 	}
-	if client == nil {
-		return nil
-	}
 	body := strings.NewReader(fmt.Sprintf(`{"persistent":{"elasticsearch.querylog.enabled":%v}}`, enabled))
-	req, err := http.NewRequest(http.MethodPut, "/_cluster/settings", body)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPut, "/_cluster/settings", body)
 	if err != nil {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	_, err = client.Request(context.Background(), req)
-	return err
+	resp, err := client.Request(context.Background(), req)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
 }
 
-func (c stackMonitoringChecks) EnableQueryLogAndGenerateQueries() test.Step {
+func (qc querylogChecks) generateQueries() error {
+	monitoredES := esv1.Elasticsearch{}
+	ref := types.NamespacedName{Name: qc.monitored.Elasticsearch.Name, Namespace: qc.monitored.Elasticsearch.Namespace}
+	if err := qc.k8sClient.Client.Get(context.Background(), ref, &monitoredES); err != nil {
+		return err
+	}
+	client, err := qc.esClient(monitoredES)
+	if err != nil {
+		return err
+	}
+	// Index a document to ensure there is data to query — searches against an empty cluster
+	// (0 shards) do not generate querylog entries.
+	indexReq, err := http.NewRequestWithContext(context.Background(), http.MethodPut, "/querylog-test/_doc/1?refresh=true", strings.NewReader(`{"msg":"querylog-test"}`))
+	if err != nil {
+		return err
+	}
+	indexReq.Header.Set("Content-Type", "application/json")
+	indexResp, err := client.Request(context.Background(), indexReq)
+	if err != nil {
+		return err
+	}
+	indexResp.Body.Close()
+	// Run searches to generate querylog entries
+	for range 5 {
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/querylog-test/_search", strings.NewReader(`{"query":{"match_all":{}}}`))
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := client.Request(context.Background(), req)
+		if err != nil {
+			return err
+		}
+		resp.Body.Close()
+	}
+	return nil
+}
+
+func (qc querylogChecks) enableAndGenerateQueries() test.Step {
 	return test.Step{
 		Name: "Enable query logging and generate queries",
 		Test: test.Eventually(func() error {
-			if err := c.setQueryLog(true); err != nil {
+			if err := qc.setQueryLog(true); err != nil {
 				return err
 			}
-			client, err := c.monitoredESClient()
-			if err != nil {
-				return err
-			}
-			if client == nil {
-				return nil
-			}
-			for range 5 {
-				req, err := http.NewRequest(http.MethodGet, "/_search", strings.NewReader(`{"query":{"match_all":{}}}`))
-				if err != nil {
-					return err
-				}
-				req.Header.Set("Content-Type", "application/json")
-				if _, err = client.Request(context.Background(), req); err != nil {
-					return err
-				}
-			}
-			return nil
+			return qc.generateQueries()
 		}),
 	}
 }
 
-func (c stackMonitoringChecks) CheckQuerylogIndex() test.Step {
+func (qc querylogChecks) checkQuerylogIndex() test.Step {
 	return test.Step{
-		Name: "Check that querylog documents are indexed in logs-elasticsearch.querylog-*",
+		Name: "Check that querylog documents are indexed in logs-elasticsearch.querylog-default",
 		Test: test.Eventually(func() error {
-			if c.monitored.GetLogsCluster() == nil {
-				return nil
-			}
-			esLogsRef := *c.monitored.GetLogsCluster()
-			esLogs := esv1.Elasticsearch{}
-			if err := c.k8sClient.Client.Get(context.Background(), esLogsRef, &esLogs); err != nil {
+			// Keep generating queries on each retry to ensure Filebeat has data to ship
+			if err := qc.generateQueries(); err != nil {
 				return err
 			}
-			client, err := elasticsearch.NewElasticsearchClient(esLogs, c.k8sClient)
+			esLogs := esv1.Elasticsearch{}
+			ref := types.NamespacedName{Name: qc.logs.Elasticsearch.Name, Namespace: qc.logs.Elasticsearch.Namespace}
+			if err := qc.k8sClient.Client.Get(context.Background(), ref, &esLogs); err != nil {
+				return err
+			}
+			client, err := qc.esClient(esLogs)
 			if err != nil {
 				return err
 			}
-			return ContainsDocuments(client, "logs-elasticsearch.querylog-*")
+			return hasDocumentsInDataStream(client, "logs-elasticsearch.querylog-default")
 		}),
 	}
 }
 
-func (c stackMonitoringChecks) DisableQueryLog() test.Step {
+func (qc querylogChecks) disableQueryLog() test.Step {
 	return test.Step{
 		Name: "Disable query logging",
 		Test: test.Eventually(func() error {
-			return c.setQueryLog(false)
+			return qc.setQueryLog(false)
 		}),
 	}
 }
@@ -242,7 +275,58 @@ type Index struct {
 	DocsCount string `json:"docs.count"`
 }
 
-func ContainsDocuments(esClient esClient.Client, indexPattern string) error {
+// hasDocumentsInDataStream checks that a data stream exists and contains at least one document.
+// Uses the _data_stream API to verify existence and _search to check for documents, following
+// the same pattern as the agent e2e checks (see test/e2e/test/agent/checks.go).
+func hasDocumentsInDataStream(client esClient.Client, dataStream string) error {
+	// Check that the data stream exists
+	dsReq, err := http.NewRequestWithContext(context.Background(), http.MethodGet, fmt.Sprintf("/_data_stream/%s", dataStream), nil)
+	if err != nil {
+		return err
+	}
+	dsResp, err := client.Request(context.Background(), dsReq)
+	if err != nil {
+		return err
+	}
+	defer dsResp.Body.Close()
+	var dsResult struct {
+		DataStreams []struct {
+			Name string `json:"name"`
+		} `json:"data_streams"`
+	}
+	if err := json.NewDecoder(dsResp.Body).Decode(&dsResult); err != nil {
+		return err
+	}
+	if len(dsResult.DataStreams) == 0 {
+		return fmt.Errorf("data stream [%s] does not exist", dataStream)
+	}
+	// Check that there is at least one document
+	searchReq, err := http.NewRequestWithContext(context.Background(), http.MethodGet, fmt.Sprintf("/%s/_search?size=0", dataStream), nil)
+	if err != nil {
+		return err
+	}
+	searchResp, err := client.Request(context.Background(), searchReq)
+	if err != nil {
+		return err
+	}
+	defer searchResp.Body.Close()
+	var searchResult struct {
+		Hits struct {
+			Total struct {
+				Value int `json:"value"`
+			} `json:"total"`
+		} `json:"hits"`
+	}
+	if err := json.NewDecoder(searchResp.Body).Decode(&searchResult); err != nil {
+		return err
+	}
+	if searchResult.Hits.Total.Value == 0 {
+		return fmt.Errorf("data stream [%s] has no documents", dataStream)
+	}
+	return nil
+}
+
+func containsDocuments(esClient esClient.Client, indexPattern string) error {
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/_cat/indices/%s?format=json", indexPattern), nil) //nolint:noctx
 	if err != nil {
 		return err

--- a/test/e2e/test/checks/monitoring.go
+++ b/test/e2e/test/checks/monitoring.go
@@ -11,11 +11,14 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 
 	esv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/elasticsearch/v1"
 	esClient "github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/client"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test"
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test/elasticsearch"
@@ -51,11 +54,17 @@ type stackMonitoringChecks struct {
 }
 
 func (c stackMonitoringChecks) Steps() test.StepList {
-	return test.StepList{
+	steps := test.StepList{
 		c.CheckBeatSidecarsInElasticsearch(),
 		c.CheckMonitoringMetricsIndex(),
 		c.CheckFilebeatIndex(),
 	}
+	// On 9.4+ verify that querylog events can be shipped to the monitoring cluster
+	v := version.MustParse(test.Ctx().ElasticStackVersion)
+	if v.GTE(version.MinFor(9, 4, 0)) {
+		steps = append(steps, c.EnableQueryLogAndGenerateQueries(), c.CheckQuerylogIndex(), c.DisableQueryLog())
+	}
+	return steps
 }
 
 func (c stackMonitoringChecks) CheckBeatSidecarsInElasticsearch() test.Step {
@@ -102,7 +111,7 @@ func (c stackMonitoringChecks) CheckMonitoringMetricsIndex() test.Step {
 				return err
 			}
 			// Check that there is at least one document
-			err = containsDocuments(client, indexPattern)
+			err = ContainsDocuments(client, indexPattern)
 			if err != nil {
 				return err
 			}
@@ -128,12 +137,103 @@ func (c stackMonitoringChecks) CheckFilebeatIndex() test.Step {
 			if err != nil {
 				return err
 			}
-			err = containsDocuments(client, "filebeat-*")
+			err = ContainsDocuments(client, "filebeat-*")
 			if err != nil {
 				return err
 			}
 			return nil
 		})}
+}
+
+// monitoredESClient returns an ES client for the monitored resource if it is an Elasticsearch cluster.
+// Returns nil, nil if the monitored resource is not an Elasticsearch cluster.
+func (c stackMonitoringChecks) monitoredESClient() (esClient.Client, error) {
+	monitoredES := esv1.Elasticsearch{}
+	ref := types.NamespacedName{Name: c.monitored.Name(), Namespace: c.monitored.Namespace()}
+	if err := c.k8sClient.Client.Get(context.Background(), ref, &monitoredES); err != nil {
+		if errors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return elasticsearch.NewElasticsearchClient(monitoredES, c.k8sClient)
+}
+
+func (c stackMonitoringChecks) setQueryLog(enabled bool) error {
+	client, err := c.monitoredESClient()
+	if err != nil {
+		return err
+	}
+	if client == nil {
+		return nil
+	}
+	body := strings.NewReader(fmt.Sprintf(`{"persistent":{"elasticsearch.querylog.enabled":%v}}`, enabled))
+	req, err := http.NewRequest(http.MethodPut, "/_cluster/settings", body)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	_, err = client.Request(context.Background(), req)
+	return err
+}
+
+func (c stackMonitoringChecks) EnableQueryLogAndGenerateQueries() test.Step {
+	return test.Step{
+		Name: "Enable query logging and generate queries",
+		Test: test.Eventually(func() error {
+			if err := c.setQueryLog(true); err != nil {
+				return err
+			}
+			client, err := c.monitoredESClient()
+			if err != nil {
+				return err
+			}
+			if client == nil {
+				return nil
+			}
+			for range 5 {
+				req, err := http.NewRequest(http.MethodGet, "/_search", strings.NewReader(`{"query":{"match_all":{}}}`))
+				if err != nil {
+					return err
+				}
+				req.Header.Set("Content-Type", "application/json")
+				if _, err = client.Request(context.Background(), req); err != nil {
+					return err
+				}
+			}
+			return nil
+		}),
+	}
+}
+
+func (c stackMonitoringChecks) CheckQuerylogIndex() test.Step {
+	return test.Step{
+		Name: "Check that querylog documents are indexed in logs-elasticsearch.querylog-*",
+		Test: test.Eventually(func() error {
+			if c.monitored.GetLogsCluster() == nil {
+				return nil
+			}
+			esLogsRef := *c.monitored.GetLogsCluster()
+			esLogs := esv1.Elasticsearch{}
+			if err := c.k8sClient.Client.Get(context.Background(), esLogsRef, &esLogs); err != nil {
+				return err
+			}
+			client, err := elasticsearch.NewElasticsearchClient(esLogs, c.k8sClient)
+			if err != nil {
+				return err
+			}
+			return ContainsDocuments(client, "logs-elasticsearch.querylog-*")
+		}),
+	}
+}
+
+func (c stackMonitoringChecks) DisableQueryLog() test.Step {
+	return test.Step{
+		Name: "Disable query logging",
+		Test: test.Eventually(func() error {
+			return c.setQueryLog(false)
+		}),
+	}
 }
 
 // Index partially models Elasticsearch cluster index returned by /_cat/indices
@@ -142,7 +242,7 @@ type Index struct {
 	DocsCount string `json:"docs.count"`
 }
 
-func containsDocuments(esClient esClient.Client, indexPattern string) error {
+func ContainsDocuments(esClient esClient.Client, indexPattern string) error {
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/_cat/indices/%s?format=json", indexPattern), nil) //nolint:noctx
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary
- The `eck_stack_mon_user_role` was missing index privileges for the `logs-elastic*` index pattern
- This caused the Filebeat sidecar to fail indexing querylog events to the monitoring cluster with a 403 `security_exception` on `logs-elasticsearch.querylog-default`
- Uses `logs-elastic*` rather than a narrow `logs-elasticsearch.querylog-*` pattern to future-proof the role for additional ES log datasets that will follow the same naming convention (per discussion with @consulthys)

Relates to #9268, follows up on #9291

## Test plan
- [x] Deploy ES 9.4.0-SNAPSHOT with stack monitoring (sidecar) pointing to a monitoring cluster
- [x] Verify Filebeat sidecar config includes querylog fileset
- [x] Enable `elasticsearch.querylog.enabled: true` cluster setting
- [x] Run queries and verify querylog events are successfully indexed in `logs-elasticsearch.querylog-default` on the monitoring cluster (10 docs confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)