### PR TITLE
[#9250] Update annotator.sh script for the `eck.k8s.elastic.co/pause-orchestration` annotation

### DIFF
--- a/hack/annotator/README.md
+++ b/hack/annotator/README.md
@@ -16,3 +16,5 @@ ANN_KEY="my.domain/annotation" ./annotator.sh ls
 # Remove the my.domain/annotation from all Elastic resources
 ANN_KEY="my.domain/annotation" PAUSE_SECS=10 ./annotator.sh remove
 ```
+
+Usage of this script with the `ANN_KEY` value of `eck.k8s.elastic.co/managed` is deprecated in favor of setting the value of the `eck.k8s.elastic.co/pause-orchestration` annotation.

--- a/hack/annotator/annotator.sh
+++ b/hack/annotator/annotator.sh
@@ -8,9 +8,17 @@
 
 set -euo pipefail
 
-ANN_KEY=${ANN_KEY:-"eck.k8s.elastic.co/managed"}
-ANN_VAL=${ANN_VAL:-"true"}
+
+ANN_KEY=${ANN_KEY:-"eck.k8s.elastic.co/pause-orchestration"}
+[ "$ANN_KEY" == "eck.k8s.elastic.co/pause-orchestration" ] && DEFAULT_ANN_VAL="false" || DEFAULT_ANN_VAL="true"
+ANN_VAL=${ANN_VAL:-$DEFAULT_ANN_VAL}
 PAUSE_SECS=${PAUSE_SECS:-"900"}
+
+if [ "${ANN_KEY}" == "eck.k8s.elastic.co/managed" ]; then
+        echo "WARNING: The '${ANN_KEY}' annotation is deprecated and will be removed in future versions."
+        echo "Please use the 'eck.k8s.elastic.co/pause-orchestration' annotation instead."
+fi
+echo "Running script with $ANN_KEY=$ANN_VAL"
 
 remove_all() {
     mapfile -t OBJECTS < <(kubectl get elastic --all-namespaces -o=jsonpath='{range .items[*]}{.kind}{"|"}{.metadata.name}{"|"}{.metadata.namespace}{"\n"}{end}')
@@ -35,7 +43,7 @@ add_all() {
 }
 
 list_all() {
-    TEMPLATE="{{ range .items }}{{ if index .metadata.annotations \"${ANN_KEY}\" }}{{ printf \"%s|%s|%s\\n\" .kind .metadata.name .metadata.namespace }}{{ end }}{{ end }}"
+    TEMPLATE="{{ range .items }}{{ if .metadata.annotations }}{{ if index .metadata.annotations \"${ANN_KEY}\" }}{{ printf \"%s|%s|%s\\n\" .kind .metadata.name .metadata.namespace }}{{ end }}{{ end }}{{ end }}"
     mapfile -t ANNOTATED < <(kubectl get elastic --all-namespaces -o=go-template="$TEMPLATE")
 
     printf "NAMESPACE\tTYPE\tNAME\n"


### PR DESCRIPTION
With the introduction of the `eck.k8s.elastic.co/pause-orchestration` annotation, this script needs to be updated with the assumption that this is a highly utilized script for managing the enabling/disabling of orchestration during maintenance.

See https://github.com/elastic/cloud-on-k8s/pull/9330 for the introduction of `eck.k8s.elastic.co/pause-orchestration`.

Relates to: https://github.com/elastic/cloud-on-k8s/issues/9250