### PR TITLE
tolerate brief red health during client auth mutation tests

### DIFF
--- a/test/e2e/apm/client_auth_test.go
+++ b/test/e2e/apm/client_auth_test.go
@@ -35,7 +35,8 @@ func TestClientAuthRequiredTransition(t *testing.T) {
 
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources).
-		WithClientAuthenticationRequired()
+		WithClientAuthenticationRequired().
+		TolerateMutationChecksFailures()
 
 	apmBuilder := apmserver.NewBuilder(name).
 		WithElasticsearchRef(esBuilder.Ref()).
@@ -100,7 +101,8 @@ func TestClientAuthRequiredCustomCertificate(t *testing.T) {
 
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources).
-		WithClientAuthenticationRequired()
+		WithClientAuthenticationRequired().
+		TolerateMutationChecksFailures()
 
 	apmBuilder := apmserver.NewBuilder(name).
 		WithElasticsearchRef(commonv1.ObjectSelector{

--- a/test/e2e/beat/client_auth_test.go
+++ b/test/e2e/beat/client_auth_test.go
@@ -37,7 +37,8 @@ func TestClientAuthRequiredTransition(t *testing.T) {
 
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources).
-		WithClientAuthenticationRequired()
+		WithClientAuthenticationRequired().
+		TolerateMutationChecksFailures()
 
 	fileBeatConfig := E2EFilebeatConfig
 	if !SupportsFingerprintIdentity(version.MustParse(test.Ctx().ElasticStackVersion)) {
@@ -116,7 +117,8 @@ func TestClientAuthRequiredCustomCertificate(t *testing.T) {
 
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources).
-		WithClientAuthenticationRequired()
+		WithClientAuthenticationRequired().
+		TolerateMutationChecksFailures()
 
 	fileBeatConfig := E2EFilebeatConfig
 	if !SupportsFingerprintIdentity(version.MustParse(test.Ctx().ElasticStackVersion)) {

--- a/test/e2e/ent/client_auth_test.go
+++ b/test/e2e/ent/client_auth_test.go
@@ -35,7 +35,8 @@ func TestClientAuthRequiredTransition(t *testing.T) {
 
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources).
-		WithClientAuthenticationRequired()
+		WithClientAuthenticationRequired().
+		TolerateMutationChecksFailures()
 
 	entBuilder := enterprisesearch.NewBuilder(name).
 		WithElasticsearchRef(esBuilder.Ref()).
@@ -97,7 +98,8 @@ func TestClientAuthRequiredCustomCertificate(t *testing.T) {
 
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources).
-		WithClientAuthenticationRequired()
+		WithClientAuthenticationRequired().
+		TolerateMutationChecksFailures()
 
 	entBuilder := enterprisesearch.NewBuilder(name).
 		WithElasticsearchRef(commonv1.ObjectSelector{

--- a/test/e2e/es/client_auth_test.go
+++ b/test/e2e/es/client_auth_test.go
@@ -37,7 +37,8 @@ func TestClientAuthRequiredTransition(t *testing.T) {
 
 	// Start with client_authentication disabled (default)
 	initialBuilder := elasticsearch.NewBuilder(esName).
-		WithESMasterDataNodes(3, elasticsearch.DefaultResources)
+		WithESMasterDataNodes(3, elasticsearch.DefaultResources).
+		TolerateMutationChecksFailures()
 
 	initialWithLicense := test.LicenseTestBuilder(initialBuilder)
 

--- a/test/e2e/kb/client_auth_test.go
+++ b/test/e2e/kb/client_auth_test.go
@@ -40,7 +40,8 @@ func TestClientAuthRequiredTransition(t *testing.T) {
 
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources).
-		WithClientAuthenticationRequired()
+		WithClientAuthenticationRequired().
+		TolerateMutationChecksFailures()
 
 	kbBuilder := kibana.NewBuilder(name).
 		WithElasticsearchRef(esBuilder.Ref()).

--- a/test/e2e/logstash/client_auth_test.go
+++ b/test/e2e/logstash/client_auth_test.go
@@ -35,7 +35,8 @@ func TestClientAuthRequiredTransition(t *testing.T) {
 
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources).
-		WithClientAuthenticationRequired()
+		WithClientAuthenticationRequired().
+		TolerateMutationChecksFailures()
 
 	lsBuilder := logstash.NewBuilder(name).
 		WithNodeCount(1).
@@ -162,7 +163,8 @@ func TestClientAuthRequiredCustomCertificate(t *testing.T) {
 
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources).
-		WithClientAuthenticationRequired()
+		WithClientAuthenticationRequired().
+		TolerateMutationChecksFailures()
 
 	lsBuilder := logstash.NewBuilder(name).
 		WithNodeCount(1).


### PR DESCRIPTION
This PR adds some toleration to mutation check failures in the respective client auth transition e2e tests. In particular, such a client auth transition triggers a rolling restart shortly after cluster creation, before shard allocation fully stabilises. This can cause a transient red health window (~20-30s) when a node holding primaries is restarted. 