### PR TITLE
[3.4] tolerate brief red health during client auth mutation tests (#9355)

### DIFF
--- a/test/e2e/es/client_auth_test.go
+++ b/test/e2e/es/client_auth_test.go
@@ -37,7 +37,8 @@ func TestClientAuthRequiredTransition(t *testing.T) {
 
 	// Start with client_authentication disabled (default)
 	initialBuilder := elasticsearch.NewBuilder(esName).
-		WithESMasterDataNodes(3, elasticsearch.DefaultResources)
+		WithESMasterDataNodes(3, elasticsearch.DefaultResources).
+		TolerateMutationChecksFailures()
 
 	initialWithLicense := test.LicenseTestBuilder(initialBuilder)
 

--- a/test/e2e/kb/client_auth_test.go
+++ b/test/e2e/kb/client_auth_test.go
@@ -40,7 +40,8 @@ func TestClientAuthRequiredTransition(t *testing.T) {
 
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources).
-		WithClientAuthenticationRequired()
+		WithClientAuthenticationRequired().
+		TolerateMutationChecksFailures()
 
 	kbBuilder := kibana.NewBuilder(name).
 		WithElasticsearchRef(esBuilder.Ref()).


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.4`:
 - [tolerate brief red health during client auth mutation tests (#9355)](https://github.com/elastic/cloud-on-k8s/pull/9355)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)