### PR TITLE
[3.4] Add logs-elastic* index privileges to stack monitoring role (#9353)

### DIFF
--- a/pkg/controller/elasticsearch/user/roles.go
+++ b/pkg/controller/elasticsearch/user/roles.go
@@ -226,6 +226,15 @@ var (
 					Names:      []string{"filebeat-*"},
 					Privileges: []string{"manage", "read", "create_doc", "view_index_metadata", "create_index"},
 				},
+				{
+					// logs-elastic* covers data streams for ES-managed log datasets (e.g. logs-elasticsearch.querylog-*)
+					// that are shipped by the Filebeat sidecar starting with ES 9.4. Uses a broad pattern to
+					// accommodate additional datasets that will follow the same naming convention.
+					// auto_configure is required because data streams need it to create backing indices from
+					// the managed index template on first write.
+					Names:      []string{"logs-elastic*"},
+					Privileges: []string{"manage", "read", "create_doc", "view_index_metadata", "create_index", "auto_configure"},
+				},
 			},
 		},
 		FleetAdminUserRole: esclient.Role{

--- a/test/e2e/es/stack_monitoring_test.go
+++ b/test/e2e/es/stack_monitoring_test.go
@@ -53,7 +53,7 @@ func TestESStackMonitoring(t *testing.T) {
 
 	// checks that the sidecar beats have sent data in the monitoring clusters
 	steps := func(k *test.K8sClient) test.StepList {
-		return checks.MonitoredSteps(&monitored, k)
+		return append(checks.MonitoredSteps(&monitored, k), checks.QuerylogSteps(&monitored, &logs, k)...)
 	}
 
 	test.Sequence(nil, steps, metrics, logs, monitored).RunSequential(t)
@@ -199,8 +199,9 @@ func TestExternalESStackMonitoring(t *testing.T) {
 			},
 		}
 
-		c := checks.MonitoredSteps(&monitored, k)
-		return append(s, c...)
+		// QuerylogSteps not added here: the external monitoring user uses built-in roles
+		// (remote_monitoring_agent, etc.) that don't include logs-elastic* privileges.
+		return append(s, checks.MonitoredSteps(&monitored, k)...)
 	}
 
 	test.Sequence(nil, steps, monitoring, monitored).RunSequential(t)

--- a/test/e2e/test/checks/monitoring.go
+++ b/test/e2e/test/checks/monitoring.go
@@ -11,10 +11,12 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/types"
 
 	esv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/version"
 	esClient "github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/client"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test"
@@ -136,10 +138,182 @@ func (c stackMonitoringChecks) CheckFilebeatIndex() test.Step {
 		})}
 }
 
+// QuerylogSteps returns steps that enable query logging on the monitored ES cluster, generate
+// queries, verify that querylog events are indexed in the logs monitoring cluster, and then
+// disable query logging again. Returns nil on versions before 9.4 where querylog is not available.
+func QuerylogSteps(monitored, logs *elasticsearch.Builder, k *test.K8sClient) test.StepList {
+	v := version.MustParse(test.Ctx().ElasticStackVersion)
+	if !v.GTE(version.MinFor(9, 4, 0)) {
+		return nil
+	}
+	qc := querylogChecks{monitored: monitored, logs: logs, k8sClient: k}
+	return test.StepList{
+		qc.enableAndGenerateQueries(),
+		qc.checkQuerylogIndex(),
+		qc.disableQueryLog(),
+	}
+}
+
+type querylogChecks struct {
+	monitored *elasticsearch.Builder
+	logs      *elasticsearch.Builder
+	k8sClient *test.K8sClient
+}
+
+func (qc querylogChecks) clientFor(b *elasticsearch.Builder) (esClient.Client, error) {
+	es := esv1.Elasticsearch{}
+	ref := types.NamespacedName{Name: b.Elasticsearch.Name, Namespace: b.Elasticsearch.Namespace}
+	if err := qc.k8sClient.Client.Get(context.Background(), ref, &es); err != nil {
+		return nil, err
+	}
+	return elasticsearch.NewElasticsearchClient(es, qc.k8sClient)
+}
+
+func (qc querylogChecks) setQueryLog(enabled bool) error {
+	client, err := qc.clientFor(qc.monitored)
+	if err != nil {
+		return err
+	}
+	body := strings.NewReader(fmt.Sprintf(`{"persistent":{"elasticsearch.querylog.enabled":%v}}`, enabled))
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPut, "/_cluster/settings", body)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Request(context.Background(), req)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
+}
+
+func (qc querylogChecks) generateQueries() error {
+	client, err := qc.clientFor(qc.monitored)
+	if err != nil {
+		return err
+	}
+	// Index a document to ensure there is data to query — searches against an empty cluster
+	// (0 shards) do not generate querylog entries.
+	indexReq, err := http.NewRequestWithContext(context.Background(), http.MethodPut, "/querylog-test/_doc/1?refresh=true", strings.NewReader(`{"msg":"querylog-test"}`))
+	if err != nil {
+		return err
+	}
+	indexReq.Header.Set("Content-Type", "application/json")
+	indexResp, err := client.Request(context.Background(), indexReq)
+	if err != nil {
+		return err
+	}
+	indexResp.Body.Close()
+	// Run searches to generate querylog entries
+	for range 5 {
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/querylog-test/_search", strings.NewReader(`{"query":{"match_all":{}}}`))
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := client.Request(context.Background(), req)
+		if err != nil {
+			return err
+		}
+		resp.Body.Close()
+	}
+	return nil
+}
+
+func (qc querylogChecks) enableAndGenerateQueries() test.Step {
+	return test.Step{
+		Name: "Enable query logging and generate queries",
+		Test: test.Eventually(func() error {
+			if err := qc.setQueryLog(true); err != nil {
+				return err
+			}
+			return qc.generateQueries()
+		}),
+	}
+}
+
+func (qc querylogChecks) checkQuerylogIndex() test.Step {
+	return test.Step{
+		Name: "Check that querylog documents are indexed in logs-elasticsearch.querylog-default",
+		Test: test.Eventually(func() error {
+			// Keep generating queries on each retry to ensure Filebeat has data to ship
+			if err := qc.generateQueries(); err != nil {
+				return err
+			}
+			client, err := qc.clientFor(qc.logs)
+			if err != nil {
+				return err
+			}
+			return hasDocumentsInDataStream(client, "logs-elasticsearch.querylog-default")
+		}),
+	}
+}
+
+func (qc querylogChecks) disableQueryLog() test.Step {
+	return test.Step{
+		Name: "Disable query logging",
+		Test: test.Eventually(func() error {
+			return qc.setQueryLog(false)
+		}),
+	}
+}
+
 // Index partially models Elasticsearch cluster index returned by /_cat/indices
 type Index struct {
 	Index     string `json:"index"`
 	DocsCount string `json:"docs.count"`
+}
+
+// hasDocumentsInDataStream checks that a data stream exists and contains at least one document.
+// Uses the _data_stream API to verify existence and _search to check for documents, following
+// the same pattern as the agent e2e checks (see test/e2e/test/agent/checks.go).
+func hasDocumentsInDataStream(client esClient.Client, dataStream string) error {
+	// Check that the data stream exists
+	dsReq, err := http.NewRequestWithContext(context.Background(), http.MethodGet, fmt.Sprintf("/_data_stream/%s", dataStream), nil)
+	if err != nil {
+		return err
+	}
+	dsResp, err := client.Request(context.Background(), dsReq)
+	if err != nil {
+		return err
+	}
+	defer dsResp.Body.Close()
+	var dsResult struct {
+		DataStreams []struct {
+			Name string `json:"name"`
+		} `json:"data_streams"`
+	}
+	if err := json.NewDecoder(dsResp.Body).Decode(&dsResult); err != nil {
+		return err
+	}
+	if len(dsResult.DataStreams) == 0 {
+		return fmt.Errorf("data stream [%s] does not exist", dataStream)
+	}
+	// Check that there is at least one document
+	searchReq, err := http.NewRequestWithContext(context.Background(), http.MethodGet, fmt.Sprintf("/%s/_search?size=0", dataStream), nil)
+	if err != nil {
+		return err
+	}
+	searchResp, err := client.Request(context.Background(), searchReq)
+	if err != nil {
+		return err
+	}
+	defer searchResp.Body.Close()
+	var searchResult struct {
+		Hits struct {
+			Total struct {
+				Value int `json:"value"`
+			} `json:"total"`
+		} `json:"hits"`
+	}
+	if err := json.NewDecoder(searchResp.Body).Decode(&searchResult); err != nil {
+		return err
+	}
+	if searchResult.Hits.Total.Value == 0 {
+		return fmt.Errorf("data stream [%s] has no documents", dataStream)
+	}
+	return nil
 }
 
 func containsDocuments(esClient esClient.Client, indexPattern string) error {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.4`:
 - [Add logs-elastic* index privileges to stack monitoring role (#9353)](https://github.com/elastic/cloud-on-k8s/pull/9353)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)