### PR TITLE
[3.4] Add image digest support to eck-operator Helm chart (#9362)

### DIFF
--- a/deploy/eck-operator/templates/_helpers.tpl
+++ b/deploy/eck-operator/templates/_helpers.tpl
@@ -428,3 +428,30 @@ RBAC permissions to read node labels
   - list
   - watch
 {{- end -}}
+
+
+{{/*
+Render the full operator image reference, including optional UBI/FIPS suffix,
+tag (defaulting to chart appVersion), and optional digest pin.
+
+Digest validation: if image.digest is set, it must start with "sha256:" to
+produce a valid OCI image reference. An invalid format will cause `helm template`
+to fail with a descriptive error rather than rendering a silently broken image string.
+
+Usage:
+  image: {{ include "eck-operator.imageReference" . | quote }}
+*/}}
+{{- define "eck-operator.imageReference" -}}
+{{- $repo := .Values.image.repository -}}
+{{- if .Values.config.ubiOnly -}}{{- $repo = printf "%s-ubi" $repo -}}{{- end -}}
+{{- if .Values.image.fips -}}{{- $repo = printf "%s-fips" $repo -}}{{- end -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag -}}
+{{- if .Values.image.digest -}}
+  {{- if not (hasPrefix "sha256:" .Values.image.digest) -}}
+    {{- fail (printf "image.digest must start with 'sha256:' but got: %s" .Values.image.digest) -}}
+  {{- end -}}
+  {{- printf "%s:%s@%s" $repo $tag .Values.image.digest -}}
+{{- else -}}
+  {{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/eck-operator/templates/statefulset.yaml
+++ b/deploy/eck-operator/templates/statefulset.yaml
@@ -55,7 +55,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-        - image: "{{ .Values.image.repository }}{{- if .Values.config.ubiOnly -}}-ubi{{- end -}}{{- if .Values.image.fips -}}-fips{{- end -}}:{{ default .Chart.AppVersion .Values.image.tag }}"
+        - image: {{ include "eck-operator.imageReference" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           name: manager
           args:

--- a/deploy/eck-operator/templates/tests/statefulset_test.yaml
+++ b/deploy/eck-operator/templates/tests/statefulset_test.yaml
@@ -40,6 +40,151 @@ tests:
         equal:
           path: spec.template.spec.containers[0].image
           value: "docker.elastic.co/eck/eck-operator-ubi:2.16.1"
+  - it: ECK image, fips + ubi, default tag from chart appVersion
+    set:
+      config.ubiOnly: true
+      image.fips: true
+    asserts:
+      - template: statefulset.yaml
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.elastic.co/eck/eck-operator-ubi-fips:3.4.0"
+  - it: ECK image, no fips, no ubi, default tag from chart appVersion
+    asserts:
+      - template: statefulset.yaml
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.elastic.co/eck/eck-operator:3.4.0"
+  - it: ECK image, fips, no ubi, default tag from chart appVersion
+    set:
+      image.fips: true
+    asserts:
+      - template: statefulset.yaml
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.elastic.co/eck/eck-operator-fips:3.4.0"
+  - it: ECK image, no fips, ubi, default tag from chart appVersion
+    set:
+      config.ubiOnly: true
+    asserts:
+      - template: statefulset.yaml
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.elastic.co/eck/eck-operator-ubi:3.4.0"
+  - it: ECK image, explicit tag + null digest should omit digest
+    set:
+      image.tag: "2.16.1"
+      image.digest: null
+    asserts:
+      - template: statefulset.yaml
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.elastic.co/eck/eck-operator:2.16.1"
+  - it: ECK image, default tag + null digest should omit digest
+    set:
+      image.digest: null
+    asserts:
+      - template: statefulset.yaml
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.elastic.co/eck/eck-operator:3.4.0"
+  - it: ECK image, fips + ubi, explicit tag + digest
+    set:
+      config.ubiOnly: true
+      image.fips: true
+      image.tag: "2.16.1"
+      image.digest: "sha256:abc123"
+    asserts:
+      - template: statefulset.yaml
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.elastic.co/eck/eck-operator-ubi-fips:2.16.1@sha256:abc123"
+  - it: ECK image, no fips, no ubi, explicit tag + digest
+    set:
+      image.tag: "2.16.1"
+      image.digest: "sha256:abc123"
+    asserts:
+      - template: statefulset.yaml
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.elastic.co/eck/eck-operator:2.16.1@sha256:abc123"
+  - it: ECK image, fips, no ubi, explicit tag + digest
+    set:
+      image.fips: true
+      image.tag: "2.16.1"
+      image.digest: "sha256:abc123"
+    asserts:
+      - template: statefulset.yaml
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.elastic.co/eck/eck-operator-fips:2.16.1@sha256:abc123"
+  - it: ECK image, no fips, ubi, explicit tag + digest
+    set:
+      config.ubiOnly: true
+      image.tag: "2.16.1"
+      image.digest: "sha256:abc123"
+    asserts:
+      - template: statefulset.yaml
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.elastic.co/eck/eck-operator-ubi:2.16.1@sha256:abc123"
+  - it: ECK image, fips + ubi, default tag + digest
+    set:
+      config.ubiOnly: true
+      image.fips: true
+      image.digest: "sha256:abc123"
+    asserts:
+      - template: statefulset.yaml
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.elastic.co/eck/eck-operator-ubi-fips:3.4.0@sha256:abc123"
+  - it: ECK image, no fips, no ubi, default tag + digest
+    set:
+      image.digest: "sha256:abc123"
+    asserts:
+      - template: statefulset.yaml
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.elastic.co/eck/eck-operator:3.4.0@sha256:abc123"
+  - it: ECK image, fips, no ubi, default tag + digest
+    set:
+      image.fips: true
+      image.digest: "sha256:abc123"
+    asserts:
+      - template: statefulset.yaml
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.elastic.co/eck/eck-operator-fips:3.4.0@sha256:abc123"
+  - it: ECK image, no fips, ubi, default tag + digest
+    set:
+      config.ubiOnly: true
+      image.digest: "sha256:abc123"
+    asserts:
+      - template: statefulset.yaml
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.elastic.co/eck/eck-operator-ubi:3.4.0@sha256:abc123"
+  - it: ECK image, digest omitted by default (null) should produce tag-only reference
+    asserts:
+      - template: statefulset.yaml
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.elastic.co/eck/eck-operator:3.4.0"
+  - it: ECK image, invalid digest format should fail with descriptive error
+    set:
+      image.digest: "notasha256digest"
+    asserts:
+      - template: statefulset.yaml
+        failedTemplate:
+          errorMessage: "image.digest must start with 'sha256:' but got: notasha256digest"
+  - it: ECK image, digest without sha256 prefix should fail
+    set:
+      image.tag: "2.16.1"
+      image.digest: "abc123"
+    asserts:
+      - template: statefulset.yaml
+        failedTemplate:
+          errorMessage: "image.digest must start with 'sha256:' but got: abc123"
   - it: should have automount service account tokens set by default
     asserts:
       - template: statefulset.yaml

--- a/deploy/eck-operator/values.yaml
+++ b/deploy/eck-operator/values.yaml
@@ -24,6 +24,12 @@ image:
   pullPolicy: IfNotPresent
   # tag is the container image tag. If not defined, defaults to chart appVersion.
   tag: null
+  # digest pins the image to a specific content digest for immutable image references.
+  # When set, the rendered image reference becomes repo:tag@sha256:<hex>.
+  # Must be in the format sha256:<hex> (64 hex characters).
+  # Example:
+  #   digest: sha256:8c933444cb78d632d2d15851daf7bcb1fc4ec57689bb4aebf7b3353e6bf395a9
+  digest: null
   # fips specifies whether the operator will use a FIPS compliant container image for its own StatefulSet image.
   # This setting does not apply to Elastic Stack applications images.
   # Can be combined with config.ubiOnly.

--- a/deploy/eck-stack/charts/eck-agent/templates/tests/elastic-agent_test.yaml
+++ b/deploy/eck-stack/charts/eck-agent/templates/tests/elastic-agent_test.yaml
@@ -196,6 +196,58 @@ tests:
             - secretName: eck-agent-secret
             revisionHistoryLimit: 4
             serviceAccountName: elastic-agent
+  - it: values.spec.image should render properly
+    set:
+      spec:
+        daemonSet: {}
+        image: my.registry.com/elastic/agent:9.4.0
+    asserts:
+      - equal:
+          path: spec.image
+          value: my.registry.com/elastic/agent:9.4.0
+  - it: values.image should render properly
+    set:
+      daemonSet: {}
+      image: my.registry.com/elastic/agent:9.4.0
+    asserts:
+      - equal:
+          path: spec.image
+          value: my.registry.com/elastic/agent:9.4.0
+  - it: values.spec.image should take precedence over values.image
+    set:
+      spec:
+        daemonSet: {}
+        image: quay.io/elastic/agent:9.4.0
+      image: my.registry.com/elastic/agent:9.4.0
+    asserts:
+      - equal:
+          path: spec.image
+          value: quay.io/elastic/agent:9.4.0
+  - it: values.spec.image null should fallback to values.image
+    set:
+      spec:
+        daemonSet: {}
+        image: null
+      image: my.registry.com/elastic/agent:9.4.0
+    asserts:
+      - equal:
+          path: spec.image
+          value: my.registry.com/elastic/agent:9.4.0
+  - it: values.image with digest should render properly
+    set:
+      daemonSet: {}
+      image: my.registry.com/elastic/agent:9.4.0@sha256:abc123
+    asserts:
+      - equal:
+          path: spec.image
+          value: my.registry.com/elastic/agent:9.4.0@sha256:abc123
+  - it: values.image null should omit spec.image
+    set:
+      daemonSet: {}
+      image: null
+    asserts:
+      - notExists:
+          path: spec.image
   - it: not setting version should fail
     set:
       version: ""

--- a/deploy/eck-stack/charts/eck-agent/values.yaml
+++ b/deploy/eck-stack/charts/eck-agent/values.yaml
@@ -29,8 +29,10 @@ labels: {}
 annotations: {}
 
 # Elastic Agent image to deploy.
-#
+# Supports both tag and digest formats.
 # image: docker.elastic.co/beats/elastic-agent:9.4.0
+# image: docker.elastic.co/beats/elastic-agent:9.4.0@sha256:<digest>
+# image: docker.elastic.co/beats/elastic-agent@sha256:<digest>
 
 # ** Deprecation Notice **
 # The previous versions of this Helm Chart simply used the `spec` field here

--- a/deploy/eck-stack/charts/eck-apm-server/templates/tests/apmserver_test.yaml
+++ b/deploy/eck-stack/charts/eck-apm-server/templates/tests/apmserver_test.yaml
@@ -94,3 +94,29 @@ tests:
       - equal:
           path: spec.elasticsearchRef.namespace
           value: default
+  - it: should render image properly
+    set:
+      elasticsearchRef:
+        name: eck-elasticsearch
+      image: my.registry.com/elastic/apm-server:9.4.0
+    asserts:
+      - equal:
+          path: spec.image
+          value: my.registry.com/elastic/apm-server:9.4.0
+  - it: should render image with digest properly
+    set:
+      elasticsearchRef:
+        name: eck-elasticsearch
+      image: my.registry.com/elastic/apm-server:9.4.0@sha256:abc123
+    asserts:
+      - equal:
+          path: spec.image
+          value: my.registry.com/elastic/apm-server:9.4.0@sha256:abc123
+  - it: should omit image when null
+    set:
+      elasticsearchRef:
+        name: eck-elasticsearch
+      image: null
+    asserts:
+      - notExists:
+          path: spec.image

--- a/deploy/eck-stack/charts/eck-apm-server/values.yaml
+++ b/deploy/eck-stack/charts/eck-apm-server/values.yaml
@@ -20,9 +20,11 @@
 #
 version: 9.4.0
 
-# APM Server Docker image to deploy
-#
-# image:
+# APM Server Docker image to deploy.
+# Supports both tag and digest formats.
+# image: docker.elastic.co/apm/apm-server:9.4.0-SNAPSHOT
+# image: docker.elastic.co/apm/apm-server:9.4.0-SNAPSHOT@sha256:<digest>
+# image: docker.elastic.co/apm/apm-server@sha256:<digest>
 
 # Used to check access from the current resource to a resource (for ex. a remote Elasticsearch cluster) in a different namespace.
 # Can only be used if ECK is enforcing RBAC on references.

--- a/deploy/eck-stack/charts/eck-autoops-agent-policy/values.yaml
+++ b/deploy/eck-stack/charts/eck-autoops-agent-policy/values.yaml
@@ -51,7 +51,10 @@ autoOpsRef: {}
 # config: {}
 
 # Image is the AutoOps Agent Docker image to deploy.
+# Supports both tag and digest formats.
 # image: "docker.elastic.co/elastic-agent/elastic-otel-collector-wolfi:9.4.0"
+# image: "docker.elastic.co/elastic-agent/elastic-otel-collector-wolfi:9.4.0@sha256:<digest>"
+# image: "docker.elastic.co/elastic-agent/elastic-otel-collector-wolfi@sha256:<digest>"
 
 # RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying Deployment.
 # revisionHistoryLimit: 2

--- a/deploy/eck-stack/charts/eck-beats/templates/tests/beats_test.yaml
+++ b/deploy/eck-stack/charts/eck-beats/templates/tests/beats_test.yaml
@@ -168,3 +168,61 @@ tests:
             - secretName: eck-beat-secret
             revisionHistoryLimit: 4
             serviceAccountName: elastic-beat
+  - it: values.spec.image should render properly
+    set:
+      spec:
+        type: filebeat
+        deployment: {}
+        image: my.registry.com/elastic/beats:9.4.0
+    asserts:
+      - equal:
+          path: spec.image
+          value: my.registry.com/elastic/beats:9.4.0
+  - it: values.image should render properly
+    set:
+      type: filebeat
+      deployment: {}
+      image: my.registry.com/elastic/beats:9.4.0
+    asserts:
+      - equal:
+          path: spec.image
+          value: my.registry.com/elastic/beats:9.4.0
+  - it: values.spec.image should take precedence over values.image
+    set:
+      spec:
+        type: filebeat
+        deployment: {}
+        image: quay.io/elastic/beats:9.4.0
+      image: my.registry.com/elastic/beats:9.4.0
+    asserts:
+      - equal:
+          path: spec.image
+          value: quay.io/elastic/beats:9.4.0
+  - it: values.spec.image null should fallback to values.image
+    set:
+      spec:
+        type: filebeat
+        deployment: {}
+        image: null
+      image: my.registry.com/elastic/beats:9.4.0
+    asserts:
+      - equal:
+          path: spec.image
+          value: my.registry.com/elastic/beats:9.4.0
+  - it: values.image with digest should render properly
+    set:
+      type: filebeat
+      deployment: {}
+      image: my.registry.com/elastic/beats:9.4.0@sha256:abc123
+    asserts:
+      - equal:
+          path: spec.image
+          value: my.registry.com/elastic/beats:9.4.0@sha256:abc123
+  - it: values.image null should omit spec.image
+    set:
+      type: filebeat
+      deployment: {}
+      image: null
+    asserts:
+      - notExists:
+          path: spec.image

--- a/deploy/eck-stack/charts/eck-beats/values.yaml
+++ b/deploy/eck-stack/charts/eck-beats/values.yaml
@@ -45,8 +45,10 @@ annotations: {}
 type: ""
 
 # Beats image to deploy.
-#
+# Supports both tag and digest formats.
 # image: docker.elastic.co/beats/metricbeat:9.4.0
+# image: docker.elastic.co/beats/metricbeat:9.4.0@sha256:<digest>
+# image: docker.elastic.co/beats/metricbeat@sha256:<digest>
 
 # Referenced resources are below and depending on the setup, at least elasticsearchRef is required for a functional Beat.
 # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-beat-configuration.html#k8s-beat-connect-es

--- a/deploy/eck-stack/charts/eck-elasticsearch/templates/tests/elasticsearch_test.yaml
+++ b/deploy/eck-stack/charts/eck-elasticsearch/templates/tests/elasticsearch_test.yaml
@@ -219,6 +219,19 @@ tests:
       - equal:
           path: spec.image
           value: my.registry.com/elastic/elasticsearch:9.4.0
+  - it: should render image with digest properly
+    set:
+      image: my.registry.com/elastic/elasticsearch:9.4.0@sha256:abc123
+    asserts:
+      - equal:
+          path: spec.image
+          value: my.registry.com/elastic/elasticsearch:9.4.0@sha256:abc123
+  - it: should omit image when null
+    set:
+      image: null
+    asserts:
+      - notExists:
+          path: spec.image
   - it: should render no podDisruptionBudget by default
     set:
     asserts:

--- a/deploy/eck-stack/charts/eck-elasticsearch/values.yaml
+++ b/deploy/eck-stack/charts/eck-elasticsearch/values.yaml
@@ -20,9 +20,11 @@
 #
 version: 9.4.0
 
-# Elasticsearch Docker image to deploy
-#
-# image:
+# Elasticsearch Docker image to deploy.
+# Supports both tag and digest formats.
+# image: docker.elastic.co/elasticsearch/elasticsearch:9.4.0-SNAPSHOT
+# image: docker.elastic.co/elasticsearch/elasticsearch:9.4.0-SNAPSHOT@sha256:<digest>
+# image: docker.elastic.co/elasticsearch/elasticsearch@sha256:<digest>
 
 # Labels that will be applied to Elasticsearch.
 #

--- a/deploy/eck-stack/charts/eck-enterprise-search/templates/tests/entsearch_test.yaml
+++ b/deploy/eck-stack/charts/eck-enterprise-search/templates/tests/entsearch_test.yaml
@@ -103,6 +103,32 @@ tests:
       - equal:
           path: spec.http.tls.certificate.secretName
           value: my-cert
+  - it: should render image properly
+    set:
+      elasticsearchRef:
+        name: eck-elasticsearch
+      image: my.registry.com/elastic/enterprise-search:8.19.0
+    asserts:
+      - equal:
+          path: spec.image
+          value: my.registry.com/elastic/enterprise-search:8.19.0
+  - it: should render image with digest properly
+    set:
+      elasticsearchRef:
+        name: eck-elasticsearch
+      image: my.registry.com/elastic/enterprise-search:8.19.0@sha256:abc123
+    asserts:
+      - equal:
+          path: spec.image
+          value: my.registry.com/elastic/enterprise-search:8.19.0@sha256:abc123
+  - it: should omit image when null
+    set:
+      elasticsearchRef:
+        name: eck-elasticsearch
+      image: null
+    asserts:
+      - notExists:
+          path: spec.image
   - it: not setting elasticsearchRef should fail
     set:
       volumeClaimDeletePolicy: invalid

--- a/deploy/eck-stack/charts/eck-enterprise-search/values.yaml
+++ b/deploy/eck-stack/charts/eck-enterprise-search/values.yaml
@@ -21,9 +21,11 @@
 # 8.19 should be the last minor version in the 8 line.
 version: 8.19.0
 
-# Enterprise Search Docker image to deploy
-#
-# image:
+# Enterprise Search Docker image to deploy.
+# Supports both tag and digest formats.
+# image: docker.elastic.co/enterprise-search/enterprise-search:8.19.0-SNAPSHOT
+# image: docker.elastic.co/enterprise-search/enterprise-search:8.19.0-SNAPSHOT@sha256:<digest>
+# image: docker.elastic.co/enterprise-search/enterprise-search@sha256:<digest>
 
 # Used to check access from the current resource to a resource (for ex. a remote Elasticsearch cluster) in a different namespace.
 # Can only be used if ECK is enforcing RBAC on references.

--- a/deploy/eck-stack/charts/eck-fleet-server/templates/tests/fleet-server_test.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/templates/tests/fleet-server_test.yaml
@@ -156,6 +156,58 @@ tests:
                   type: ClusterIP
             revisionHistoryLimit: 4
             serviceAccountName: elastic-fleet-server
+  - it: values.spec.image should render properly
+    set:
+      spec:
+        deployment: {}
+        image: my.registry.com/elastic/fleet-server:9.4.0
+    asserts:
+      - equal:
+          path: spec.image
+          value: my.registry.com/elastic/fleet-server:9.4.0
+  - it: values.image should render properly
+    set:
+      deployment: {}
+      image: my.registry.com/elastic/fleet-server:9.4.0
+    asserts:
+      - equal:
+          path: spec.image
+          value: my.registry.com/elastic/fleet-server:9.4.0
+  - it: values.spec.image should take precedence over values.image
+    set:
+      spec:
+        deployment: {}
+        image: quay.io/elastic/fleet-server:9.4.0
+      image: my.registry.com/elastic/fleet-server:9.4.0
+    asserts:
+      - equal:
+          path: spec.image
+          value: quay.io/elastic/fleet-server:9.4.0
+  - it: values.spec.image null should fallback to values.image
+    set:
+      spec:
+        deployment: {}
+        image: null
+      image: my.registry.com/elastic/fleet-server:9.4.0
+    asserts:
+      - equal:
+          path: spec.image
+          value: my.registry.com/elastic/fleet-server:9.4.0
+  - it: values.image with digest should render properly
+    set:
+      deployment: {}
+      image: my.registry.com/elastic/fleet-server:9.4.0@sha256:abc123
+    asserts:
+      - equal:
+          path: spec.image
+          value: my.registry.com/elastic/fleet-server:9.4.0@sha256:abc123
+  - it: values.image null should omit spec.image
+    set:
+      deployment: {}
+      image: null
+    asserts:
+      - notExists:
+          path: spec.image
   - it: not setting version should fail
     set:
       version: ""

--- a/deploy/eck-stack/charts/eck-fleet-server/values.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/values.yaml
@@ -29,8 +29,10 @@ labels: {}
 annotations: {}
 
 # Elastic Fleet Server Agent image to deploy.
-#
+# Supports both tag and digest formats.
 # image: docker.elastic.co/beats/elastic-agent:9.4.0
+# image: docker.elastic.co/beats/elastic-agent:9.4.0@sha256:<digest>
+# image: docker.elastic.co/beats/elastic-agent@sha256:<digest>
 
 # ** Deprecation Notice **
 # The previous versions of this Helm Chart simply used the `spec` field here

--- a/deploy/eck-stack/charts/eck-kibana/templates/tests/kibana_test.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/templates/tests/kibana_test.yaml
@@ -125,6 +125,50 @@ tests:
       - equal:
           path: spec.image
           value: quay.io/elastic/kibana:9.4.0
+  - it: values.spec.image should take precedence over values.image
+    set:
+      spec:
+        elasticsearchRef:
+          name: eck-elasticsearch
+        image: quay.io/elastic/kibana:9.4.0
+      image: my.registry.com/elastic/kibana:9.4.0
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: Kibana
+      - equal:
+          path: spec.image
+          value: quay.io/elastic/kibana:9.4.0
+  - it: values.spec.image null should fallback to values.image
+    set:
+      spec:
+        elasticsearchRef:
+          name: eck-elasticsearch
+        image: null
+      image: my.registry.com/elastic/kibana:9.4.0
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: Kibana
+      - equal:
+          path: spec.image
+          value: my.registry.com/elastic/kibana:9.4.0
+  - it: values.image with digest should work properly
+    set:
+      spec:
+        elasticsearchRef:
+          name: eck-elasticsearch
+      image: my.registry.com/elastic/kibana:9.4.0@sha256:abc123
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: Kibana
+      - equal:
+          path: spec.image
+          value: my.registry.com/elastic/kibana:9.4.0@sha256:abc123
   - it: not setting elasticsearchRef should fail
     asserts:
       - failedTemplate:

--- a/deploy/eck-stack/charts/eck-kibana/values.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/values.yaml
@@ -20,9 +20,11 @@
 #
 version: 9.4.0
 
-# Kibana Docker image to deploy
-#
+# Kibana Docker image to deploy.
+# Supports both tag and digest formats.
 # image: docker.elastic.co/kibana/kibana:9.4.0
+# image: docker.elastic.co/kibana/kibana:9.4.0@sha256:<digest>
+# image: docker.elastic.co/kibana/kibana@sha256:<digest>
 
 # Labels that will be applied to Kibana.
 #

--- a/deploy/eck-stack/charts/eck-logstash/templates/tests/logstash_test.yaml
+++ b/deploy/eck-stack/charts/eck-logstash/templates/tests/logstash_test.yaml
@@ -134,6 +134,19 @@ tests:
       - equal:
           path: spec.image
           value: my.registry.com/elastic/logstash:8.9.0
+  - it: should render image with digest properly
+    set:
+      image: my.registry.com/elastic/logstash:8.9.0@sha256:abc123
+    asserts:
+      - equal:
+          path: spec.image
+          value: my.registry.com/elastic/logstash:8.9.0@sha256:abc123
+  - it: should omit image when null
+    set:
+      image: null
+    asserts:
+      - notExists:
+          path: spec.image
   - it: should render serviceAccountName properly
     set:
       serviceAccountName: my-sa

--- a/deploy/eck-stack/charts/eck-logstash/values.yaml
+++ b/deploy/eck-stack/charts/eck-logstash/values.yaml
@@ -20,9 +20,11 @@
 #
 version: 9.4.0
 
-# Logstash Docker image to deploy
-#
-# image:
+# Logstash Docker image to deploy.
+# Supports both tag and digest formats.
+# image: docker.elastic.co/logstash/logstash:9.4.0-SNAPSHOT
+# image: docker.elastic.co/logstash/logstash:9.4.0-SNAPSHOT@sha256:<digest>
+# image: docker.elastic.co/logstash/logstash@sha256:<digest>
 
 # Used to check access from the current resource to a resource (for ex. a remote Elasticsearch cluster) in a different namespace.
 # Can only be used if ECK is enforcing RBAC on references.

--- a/deploy/eck-stack/charts/eck-package-registry/values.yaml
+++ b/deploy/eck-stack/charts/eck-package-registry/values.yaml
@@ -20,9 +20,11 @@
 #
 version: 9.2.2
 
-# Elastic Package Registry Docker image to deploy
-#
+# Elastic Package Registry Docker image to deploy.
+# Supports both tag and digest formats.
 # image: docker.elastic.co/package-registry/distribution:lite-9.2.2
+# image: docker.elastic.co/package-registry/distribution:lite-9.2.2@sha256:<digest>
+# image: docker.elastic.co/package-registry/distribution@sha256:<digest>
 
 # Labels that will be applied to Package Registry.
 #


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.4`:
 - [Add image digest support to eck-operator Helm chart (#9362)](https://github.com/elastic/cloud-on-k8s/pull/9362)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)