### PR TITLE
[3.4] bump single-node ES to 2 nodes in Kibana e2e tests (#9363)

### DIFF
--- a/test/e2e/kb/association_test.go
+++ b/test/e2e/kb/association_test.go
@@ -38,7 +38,7 @@ func TestCrossNSAssociation(t *testing.T) {
 
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithNamespace(esNamespace).
-		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources).
 		WithRestrictedSecurityContext()
 	kbBuilder := kibana.NewBuilder(name).
 		WithNamespace(kbNamespace).
@@ -65,7 +65,7 @@ func TestEntSearchAssociation(t *testing.T) {
 
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithNamespace(esKbNamespace).
-		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources).
 		WithRestrictedSecurityContext()
 	entBuilder := enterprisesearch.NewBuilder(name).
 		WithNamespace(entNamespace).
@@ -117,7 +117,7 @@ func TestKibanaAssociationWithNonExistentES(t *testing.T) {
 func TestKibanaAssociationWhenReferencedESDisappears(t *testing.T) {
 	name := "test-kb-del-referenced-es"
 	esBuilder := elasticsearch.NewBuilder(name).
-		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 	kbBuilder := kibana.NewBuilder(name).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithNodeCount(1)
@@ -191,7 +191,7 @@ func TestEPRAssociation(t *testing.T) {
 
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithNamespace(esKbNamespace).
-		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources).
 		WithRestrictedSecurityContext()
 	eprBuilder := epr.NewBuilder(name).
 		WithNamespace(eprNamespace).
@@ -210,7 +210,7 @@ func TestEPRAssociation(t *testing.T) {
 func TestKibanaAssociationWithNonExistentEPR(t *testing.T) {
 	name := "test-kb-assoc-non-existent-epr"
 	esBuilder := elasticsearch.NewBuilder(name).
-		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources).
 		WithRestrictedSecurityContext()
 	kbBuilder := kibana.NewBuilder(name).
 		WithElasticsearchRef(esBuilder.Ref()).

--- a/test/e2e/kb/client_auth_test.go
+++ b/test/e2e/kb/client_auth_test.go
@@ -115,7 +115,7 @@ func TestClientAuthRequiredCustomCertificate(t *testing.T) {
 	userCertSecretName := name + "-user-client-cert"
 
 	esBuilder := elasticsearch.NewBuilder(name).
-		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources).
 		WithClientAuthenticationRequired()
 
 	kbBuilder := kibana.NewBuilder(name).

--- a/test/e2e/kb/failure_test.go
+++ b/test/e2e/kb/failure_test.go
@@ -24,7 +24,7 @@ import (
 func TestKillKibanaPod(t *testing.T) {
 	name := "test-kill-kb-pod"
 	esBuilder := elasticsearch.NewBuilder(name).
-		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 	kbBuilder := kibana.NewBuilder(name).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithNodeCount(1)
@@ -40,7 +40,7 @@ func TestKillKibanaPod(t *testing.T) {
 func TestKillKibanaDeployment(t *testing.T) {
 	name := "test-kill-kb-deploy"
 	esBuilder := elasticsearch.NewBuilder(name).
-		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 	kbBuilder := kibana.NewBuilder(name).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithNodeCount(1)

--- a/test/e2e/kb/keystore_test.go
+++ b/test/e2e/kb/keystore_test.go
@@ -44,7 +44,7 @@ func TestUpdateKibanaSecureSettings(t *testing.T) {
 	// set up a 1-node Kibana deployment with secure settings
 	name := "test-kb-keystore"
 	esBuilder := elasticsearch.NewBuilder(name).
-		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 	kbBuilder := kibana.NewBuilder(name).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithNodeCount(1).

--- a/test/e2e/kb/resource_test.go
+++ b/test/e2e/kb/resource_test.go
@@ -31,7 +31,7 @@ func TestUpdateKibanaResources(t *testing.T) {
 	}
 	name := "test-kb-resources"
 	esBuilder := elasticsearch.NewBuilder(name).
-		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 	kbBuilder := kibana.NewBuilder(name).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithNodeCount(1).

--- a/test/e2e/kb/stack_monitoring_test.go
+++ b/test/e2e/kb/stack_monitoring_test.go
@@ -31,7 +31,7 @@ func TestKBStackMonitoring(t *testing.T) {
 	logs := elasticsearch.NewBuilder("test-kb-mon-logs").
 		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 	assocEs := elasticsearch.NewBuilder("test-kb-mon-a").
-		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 	monitored := kibana.NewBuilder("test-kb-mon-a").
 		WithElasticsearchRef(assocEs.Ref()).
 		WithNodeCount(1).
@@ -59,7 +59,7 @@ func TestKBStackMonitoringWithBasePath(t *testing.T) {
 	monitor := elasticsearch.NewBuilder("test-kb-monitor").
 		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 	assocEs := elasticsearch.NewBuilder("test-kb-mon-b").
-		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 	monitored := kibana.NewBuilder("test-kb-mon-b").
 		WithElasticsearchRef(assocEs.Ref()).
 		WithNodeCount(1).

--- a/test/e2e/kb/stackconfigpolicy_test.go
+++ b/test/e2e/kb/stackconfigpolicy_test.go
@@ -41,7 +41,7 @@ func TestStackConfigPolicyKibana(t *testing.T) {
 	// set up a 1-node Kibana deployment
 	name := "test-kb-scp"
 	esBuilder := elasticsearch.NewBuilder(name).
-		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 	kbBuilder := kibana.NewBuilder(name).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithNodeCount(1).WithLabel("label", "test-scp")
@@ -137,7 +137,7 @@ func TestStackConfigPolicyKibanaMultipleWeights(t *testing.T) {
 	// set up a 1-node Kibana deployment
 	name := "test-kb-scp-multi"
 	esBuilder := elasticsearch.NewBuilder(name).
-		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 	kbBuilder := kibana.NewBuilder(name).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithNodeCount(1).WithLabel("app", "kibana")

--- a/test/e2e/kb/standalone_test.go
+++ b/test/e2e/kb/standalone_test.go
@@ -68,7 +68,7 @@ func TestKibanaStandalone(t *testing.T) {
 	// set up a 1-node Kibana deployment manually connected to Elasticsearch
 	name := "test-kb-standalone"
 	esBuilder := elasticsearch.NewBuilder(name).
-		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources).
 		WithRestrictedSecurityContext()
 	esBuilder.Elasticsearch.Spec.Auth = esv1.Auth{
 		FileRealm: []esv1.FileRealmSource{

--- a/test/e2e/kb/telemetry_test.go
+++ b/test/e2e/kb/telemetry_test.go
@@ -25,7 +25,7 @@ import (
 func TestTelemetry(t *testing.T) {
 	name := "test-telemetry"
 	esBuilder := elasticsearch.NewBuilder(name).
-		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 	kbBuilder := kibana.NewBuilder(name).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithNodeCount(1)

--- a/test/e2e/kb/version_upgrade_test.go
+++ b/test/e2e/kb/version_upgrade_test.go
@@ -14,7 +14,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/common/v1"
-	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/reconcile"
 	kblabel "github.com/elastic/cloud-on-k8s/v3/pkg/controller/kibana/label"
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test"
@@ -30,7 +29,7 @@ func TestVersionUpgradeToLatest7x(t *testing.T) {
 
 	name := "test-version-upgrade-to-7x"
 	esBuilder := elasticsearch.NewBuilder(name).
-		WithESMasterDataNodes(minClusterSizeFromKibanaVersion(t, dstVersion), elasticsearch.DefaultResources).
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources).
 		WithVersion(dstVersion)
 
 	srcNodeCount := 3
@@ -65,23 +64,6 @@ func TestVersionUpgradeToLatest7x(t *testing.T) {
 	)
 }
 
-var (
-	noAutomaticIndexCreationKibanaVersion = version.MustParse("7.17.23")
-)
-
-// minClusterSizeFromKibanaVersion is a workaround for https://github.com/elastic/kibana/pull/158182
-func minClusterSizeFromKibanaVersion(t *testing.T, to string) int {
-	t.Helper()
-	dstVer, err := version.Parse(to)
-	if err != nil {
-		t.Fatalf("Failed to parse version '%s': %s", to, err)
-	}
-	if dstVer.LT(noAutomaticIndexCreationKibanaVersion) {
-		return 2
-	}
-	return 1
-}
-
 func TestVersionUpgradeAndRespecToLatest7x(t *testing.T) {
 	srcVersion := test.Ctx().ElasticStackVersion
 	dstVersion := test.LatestReleasedVersion7x
@@ -90,7 +72,7 @@ func TestVersionUpgradeAndRespecToLatest7x(t *testing.T) {
 
 	name := "test-upgrade-and-respec-to-7x"
 	esBuilder := elasticsearch.NewBuilder(name).
-		WithESMasterDataNodes(minClusterSizeFromKibanaVersion(t, dstVersion), elasticsearch.DefaultResources).
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources).
 		WithVersion(dstVersion)
 
 	srcNodeCount := 3
@@ -198,14 +180,8 @@ func TestVersionUpgradeAndRespecToLatest8x(t *testing.T) {
 	test.SkipInvalidUpgrade(t, srcVersion, dstVersion)
 
 	name := "test-upgrade-and-respec-to-8x"
-	esNodes := 1
-	// https://github.com/elastic/cloud-on-k8s/issues/7013
-	// Between 8.7 and 8.9 fleet indices are set with a replica which fails with a single node. In 8.10 indices were moved to datastreams.
-	if version.MustParse(test.Ctx().ElasticStackVersion).GTE(version.MinFor(8, 7, 0)) && version.MustParse(test.Ctx().ElasticStackVersion).LT(version.MinFor(8, 10, 0)) {
-		esNodes = 2
-	}
 	esBuilder := elasticsearch.NewBuilder(name).
-		WithESMasterDataNodes(esNodes, elasticsearch.DefaultResources).
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources).
 		WithVersion(dstVersion)
 
 	srcNodeCount := 3


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.4`:
 - [bump single-node ES to 2 nodes in Kibana e2e tests (#9363)](https://github.com/elastic/cloud-on-k8s/pull/9363)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)