### PR TITLE
present client certificate in legacy es readiness probe when client authentication is enabled

### DIFF
--- a/pkg/controller/elasticsearch/nodespec/readiness_probe.go
+++ b/pkg/controller/elasticsearch/nodespec/readiness_probe.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	esv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/http"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/label"
@@ -88,8 +89,8 @@ else
 fi
 
 # setup client certificate authentication if certificates are available
-CLIENT_CERT_PATH="` + volume.InternalClientCertMountPath + `/tls.crt"
-CLIENT_KEY_PATH="` + volume.InternalClientCertMountPath + `/tls.key"
+CLIENT_CERT_PATH="` + volume.InternalClientCertMountPath + `/` + certificates.CertFileName + `"
+CLIENT_KEY_PATH="` + volume.InternalClientCertMountPath + `/` + certificates.KeyFileName + `"
 if [ -f "${CLIENT_CERT_PATH}" ]; then
   CLIENT_CERT="--cert ${CLIENT_CERT_PATH} --key ${CLIENT_KEY_PATH}"
 else

--- a/pkg/controller/elasticsearch/nodespec/readiness_probe.go
+++ b/pkg/controller/elasticsearch/nodespec/readiness_probe.go
@@ -87,6 +87,15 @@ else
   BASIC_AUTH=''
 fi
 
+# setup client certificate authentication if certificates are available
+CLIENT_CERT_PATH="` + volume.InternalClientCertMountPath + `/tls.crt"
+CLIENT_KEY_PATH="` + volume.InternalClientCertMountPath + `/tls.key"
+if [ -f "${CLIENT_CERT_PATH}" ]; then
+  CLIENT_CERT="--cert ${CLIENT_CERT_PATH} --key ${CLIENT_KEY_PATH}"
+else
+  CLIENT_CERT=''
+fi
+
 # Check if we are using IPv6
 if [[ $POD_IP =~ .*:.* ]]; then
   LOOPBACK="[::1]"
@@ -98,7 +107,7 @@ fi
 # we are turning globbing off to allow for unescaped [] in case of IPv6
 ENDPOINT="${READINESS_PROBE_PROTOCOL:-https}://${LOOPBACK}:9200/"
 ORIGIN_HEADER="` + http.InternalProductRequestHeaderString + `"
-status=$(curl -o /dev/null -w "%{http_code}" --max-time ${READINESS_PROBE_TIMEOUT} -H "${ORIGIN_HEADER}" -XGET -g -s -k ${BASIC_AUTH} $ENDPOINT)
+status=$(curl -o /dev/null -w "%{http_code}" --max-time ${READINESS_PROBE_TIMEOUT} -H "${ORIGIN_HEADER}" -XGET -g -s -k ${BASIC_AUTH} ${CLIENT_CERT} $ENDPOINT)
 curl_rc=$?
 
 if [[ ${curl_rc} -ne 0 ]]; then


### PR DESCRIPTION
## Summary

The legacy readiness probe script (used for ES < 8.2.0) fails when client certificate authentication is enabled because the `curl` command does not present a client certificate. This was missed in #9229 which added mTLS support to the pre-stop hook and lifecycle scripts but not to the legacy readiness probe.

This fix adds client certificate handling to the legacy readiness probe script, presenting the operator's internal client certificate when available.