### PR TITLE
copy mutationToleratedChecksFailureCount in ES builder DeepCopy

### DIFF
--- a/test/e2e/test/elasticsearch/builder.go
+++ b/test/e2e/test/elasticsearch/builder.go
@@ -72,6 +72,7 @@ func (b Builder) DeepCopy() *Builder {
 		builderCopy.MutatedFrom = b.MutatedFrom.DeepCopy()
 	}
 	builderCopy.GlobalCA = b.GlobalCA
+	builderCopy.mutationToleratedChecksFailureCount = b.mutationToleratedChecksFailureCount
 	return &builderCopy
 }
 


### PR DESCRIPTION
## Summary

Fix `Builder.DeepCopy()` in the ES test builder to copy `mutationToleratedChecksFailureCount`. Without this, tests that call `TolerateMutationChecksFailures()` on an ES builder and then `DeepCopy()` it to create a mutated variant lose the tolerance setting - the copy defaults to 0, causing the continuous health check to fail on any red health blip during the mutation.

This is why `TestClientAuthRequiredTransition` in the `kb` may fail despite #9355 adding `TolerateMutationChecksFailures()`: the test does `esBuilder.DeepCopy().WithMutatedFrom(&esBuilder)` to create the mutated builder, which silently dropped the tolerance.