### PR TITLE
[3.4] copy mutationToleratedChecksFailureCount in ES builder DeepCopy (#9376)

### DIFF
--- a/test/e2e/test/elasticsearch/builder.go
+++ b/test/e2e/test/elasticsearch/builder.go
@@ -72,6 +72,7 @@ func (b Builder) DeepCopy() *Builder {
 		builderCopy.MutatedFrom = b.MutatedFrom.DeepCopy()
 	}
 	builderCopy.GlobalCA = b.GlobalCA
+	builderCopy.mutationToleratedChecksFailureCount = b.mutationToleratedChecksFailureCount
 	return &builderCopy
 }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.4`:
 - [copy mutationToleratedChecksFailureCount in ES builder DeepCopy (#9376)](https://github.com/elastic/cloud-on-k8s/pull/9376)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)