### PR TITLE
classify transient K8s API server errors as potential network errors in e2e ES client

### DIFF
--- a/test/e2e/test/elasticsearch/http_client.go
+++ b/test/e2e/test/elasticsearch/http_client.go
@@ -50,8 +50,14 @@ func NewElasticsearchClient(es esv1.Elasticsearch, k *test.K8sClient) (client.Cl
 		// (see https://stackoverflow.com/questions/22761562/portable-way-to-detect-different-kinds-of-network-error-in-golang),
 		// so here we do the opposite: catch expected apiserver errors, and consider the rest as network errors.
 		switch err.(type) { //nolint:errorlint
-		case *k8serrors.StatusError, *k8serrors.UnexpectedObjectError:
-			// explicit apiserver error, consider as a failure for most checks
+		case *k8serrors.StatusError:
+			// Transient API server errors (500, 503, 504, 429) are infrastructure-level
+			// failures, treat them the same as network errors.
+			if k8serrors.IsInternalError(err) || k8serrors.IsServerTimeout(err) || k8serrors.IsServiceUnavailable(err) || k8serrors.IsTooManyRequests(err) {
+				return nil, &potentialNetworkError{err: err}
+			}
+			return nil, err
+		case *k8serrors.UnexpectedObjectError:
 			return nil, err
 		default:
 			// likely a network error, can be acceptable as a transient state depending on the check


### PR DESCRIPTION
## Summary

Classify transient Kubernetes API server errors (500 Internal, 503 Service Unavailable, 504 Timeout, 429 Too Many Requests) as `potentialNetworkError` in the e2e ES client factory.

Previously, all `*k8serrors.StatusError` responses were treated as "real" failures. This caused the node shutdown watcher to record transient API server errors as test failures, even though the actual ES upgrade completed successfully.

Observed in `TestAgentVersionUpgradeToLatest8x` ([build 1251, stack-8-19-14-sn](https://buildkite.com/elastic/cloud-on-k8s-operator-nightly/builds/1251)):
```
rpc error: code = Internal desc = Internal error encountered.
```
I suspect that this was a transient gRPC error from the API server/etcd. The upgrade succeeded (3/3 nodes upgraded, health green, `ReconciliationComplete=True`), but the watcher classified the transient error as non-recoverable and failed the test.