### PR TITLE
[3.4] tolerate mutation checks failures in TestMutationAndReversal (#9383)

### DIFF
--- a/test/e2e/es/mutation_test.go
+++ b/test/e2e/es/mutation_test.go
@@ -213,7 +213,11 @@ func TestMutationRollingDownscaleCombination(t *testing.T) {
 
 func TestMutationAndReversal(t *testing.T) {
 	b := elasticsearch.NewBuilder("test-reverted-mutation").
-		WithESMasterDataNodes(3, elasticsearch.DefaultResources)
+		WithESMasterDataNodes(3, elasticsearch.DefaultResources).
+		// Tolerate mutation check failures: the cluster can briefly go RED during
+		// the mutation when a node shuts down before a newly created replica is
+		// initialized. See https://github.com/elastic/cloud-on-k8s/issues/8267#issuecomment-4286465455.
+		TolerateMutationChecksFailures()
 
 	mutation := b.DeepCopy().
 		WithAdditionalConfig(map[string]map[string]interface{}{


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.4`:
 - [tolerate mutation checks failures in TestMutationAndReversal (#9383)](https://github.com/elastic/cloud-on-k8s/pull/9383)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)