### PR TITLE
[AutoOps] Add `sending_queue` configuration to configmap

### DIFF
--- a/pkg/controller/autoops/configmap.go
+++ b/pkg/controller/autoops/configmap.go
@@ -78,7 +78,7 @@ exporters:
     headers:
       Authorization: "AutoOpsToken ${env:AUTOOPS_TOKEN}"
     endpoint: ${env:AUTOOPS_OTEL_URL}
-	sending_queue:
+    sending_queue:
       batch:
         flush_timeout: 11s
         min_size: 1048576
@@ -87,7 +87,7 @@ exporters:
       block_on_overflow: true
       enabled: true
       queue_size: 52428800
-	  sizer: bytes
+      sizer: bytes
 service:
   extensions: [healthcheckv2]
   pipelines:

--- a/pkg/controller/autoops/configmap.go
+++ b/pkg/controller/autoops/configmap.go
@@ -78,6 +78,16 @@ exporters:
     headers:
       Authorization: "AutoOpsToken ${env:AUTOOPS_TOKEN}"
     endpoint: ${env:AUTOOPS_OTEL_URL}
+	sending_queue:
+      batch:
+        flush_timeout: 11s
+        min_size: 1048576
+        max_size: 4194304
+        sizer: bytes
+      block_on_overflow: true
+      enabled: true
+      queue_size: 52428800
+	  sizer: bytes
 service:
   extensions: [healthcheckv2]
   pipelines:

--- a/pkg/controller/autoops/configmap_test.go
+++ b/pkg/controller/autoops/configmap_test.go
@@ -23,6 +23,16 @@ exporters:
     endpoint: ${env:AUTOOPS_OTEL_URL}
     headers:
       Authorization: AutoOpsToken ${env:AUTOOPS_TOKEN}
+    sending_queue:
+      batch:
+        flush_timeout: 11s
+        min_size: 1048576
+        max_size: 4194304
+        sizer: bytes
+      block_on_overflow: true
+      enabled: true
+      queue_size: 52428800
+      sizer: bytes
 extensions:
   healthcheckv2:
     component_health:

--- a/pkg/controller/autoops/configmap_test.go
+++ b/pkg/controller/autoops/configmap_test.go
@@ -102,6 +102,16 @@ exporters:
     endpoint: ${env:AUTOOPS_OTEL_URL}
     headers:
       Authorization: AutoOpsToken ${env:AUTOOPS_TOKEN}
+    sending_queue:
+      batch:
+        flush_timeout: 11s
+        min_size: 1048576
+        max_size: 4194304
+        sizer: bytes
+      block_on_overflow: true
+      enabled: true
+      queue_size: 52428800
+      sizer: bytes
 extensions:
   healthcheckv2:
     component_health:


### PR DESCRIPTION
Adding the sending queue configuration allows the exporter to batch the request so that it does not exceed 4 MiB.

`otlp_http` has a default 4 MB limit, so large clusters can exceed that and cause their entire batch to be rejected.