### PR TITLE
[3.4] [AutoOps] Add `sending_queue` configuration to configmap (#9391)

### DIFF
--- a/pkg/controller/autoops/configmap.go
+++ b/pkg/controller/autoops/configmap.go
@@ -78,6 +78,16 @@ exporters:
     headers:
       Authorization: "AutoOpsToken ${env:AUTOOPS_TOKEN}"
     endpoint: ${env:AUTOOPS_OTEL_URL}
+    sending_queue:
+      batch:
+        flush_timeout: 11s
+        min_size: 1048576
+        max_size: 4194304
+        sizer: bytes
+      block_on_overflow: true
+      enabled: true
+      queue_size: 52428800
+      sizer: bytes
 service:
   extensions: [healthcheckv2]
   pipelines:

--- a/pkg/controller/autoops/configmap_test.go
+++ b/pkg/controller/autoops/configmap_test.go
@@ -23,6 +23,16 @@ exporters:
     endpoint: ${env:AUTOOPS_OTEL_URL}
     headers:
       Authorization: AutoOpsToken ${env:AUTOOPS_TOKEN}
+    sending_queue:
+      batch:
+        flush_timeout: 11s
+        min_size: 1048576
+        max_size: 4194304
+        sizer: bytes
+      block_on_overflow: true
+      enabled: true
+      queue_size: 52428800
+      sizer: bytes
 extensions:
   healthcheckv2:
     component_health:
@@ -92,6 +102,16 @@ exporters:
     endpoint: ${env:AUTOOPS_OTEL_URL}
     headers:
       Authorization: AutoOpsToken ${env:AUTOOPS_TOKEN}
+    sending_queue:
+      batch:
+        flush_timeout: 11s
+        min_size: 1048576
+        max_size: 4194304
+        sizer: bytes
+      block_on_overflow: true
+      enabled: true
+      queue_size: 52428800
+      sizer: bytes
 extensions:
   healthcheckv2:
     component_health:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.4`:
 - [[AutoOps] Add `sending_queue` configuration to configmap (#9391)](https://github.com/elastic/cloud-on-k8s/pull/9391)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)