### PR TITLE
ci(docs): scope pull_request triggers to integration branches

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,6 +1,7 @@
 name: docs-build
 on:
   pull_request:
+    branches: [main]
     types: [opened, synchronize, reopened]
   push:
     branches:

--- a/.github/workflows/docs-preview-cleanup.yml
+++ b/.github/workflows/docs-preview-cleanup.yml
@@ -1,6 +1,7 @@
 name: docs-preview-cleanup
 on:
   pull_request_target:
+    branches: [main]
     types: [closed]
 permissions:
   contents: none


### PR DESCRIPTION
Scopes `docs-build` and `docs-preview-cleanup` `pull_request*` workflows to integration branches ([assembler.yml](https://github.com/elastic/docs-builder/blob/main/config/assembler.yml)).

Related: https://github.com/elastic/docs-eng-team/issues/569