### PR TITLE
Fix the documentation link on operatorhub

### DIFF
--- a/hack/operatorhub/templates/csv.tpl
+++ b/hack/operatorhub/templates/csv.tpl
@@ -394,7 +394,7 @@ spec:
   - logstash
   links:
   - name: Documentation
-    url: https://www.elastic.co/guide/en/cloud-on-k8s/{{ .ShortVersion }}/index.html
+    url: https://www.elastic.co/docs/deploy-manage/deploy/cloud-on-k8s
   maintainers:
   - email: eck@elastic.co
     name: Elastic


### PR DESCRIPTION
The documentation link here: https://operatorhub.io/operator/elastic-cloud-eck points to https://www.elastic.co/guide/en/cloud-on-k8s/3.3/index.html, which is a 404. I don't see a way to specifically go to a version of 3.x on the docs page, so this adjusts it to go to the latest, which will allow the user to then select a more appropriate version, which seems a better option that the current 404.