### PR TITLE
Fix PR-comment pipeline trigger

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -136,8 +136,8 @@ steps:
       set -euo pipefail
       .buildkite/scripts/build/set-images.sh
       cd .buildkite/e2e/pipeline-gen && go build -o pipeline-gen
-      $$(echo ./pipeline-gen $$GITHUB_PR_COMMENT_VAR_ARGS) \
-        | buildkite-agent pipeline upload
+      read -ra args <<< "$$GITHUB_PR_COMMENT_VAR_ARGS"
+      ./pipeline-gen "$${args[@]}" | tee /dev/stderr | buildkite-agent pipeline upload
     agents:
       image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:a2cd6477
       memory: "2G"


### PR DESCRIPTION
> PR Description was generated using Claude Opus 4.7 

# Fix PR-comment pipeline trigger: safer arg parsing and proper failure propagation

## Problem

The previous command had two bugs:

```bash
$$(echo ./pipeline-gen $$GITHUB_PR_COMMENT_VAR_ARGS) \
  | buildkite-agent pipeline upload
```

1. **Unsafe shell substitution.** Wrapping the invocation in `$(echo ...)` ran the entire string through word-splitting *and* command substitution. Any glob, backtick, or unintended expansion in `GITHUB_PR_COMMENT_VAR_ARGS` (sourced from a PR comment) would be evaluated by the shell. It also relied on the escaped `$$` Buildkite interpolation in a way that obscured what was actually executed.
2. **Lost exit status under `pipefail`.** Even with `set -euo pipefail`, the failure of `pipeline-gen` was hidden: when it ran inside `$(echo ...)`, its exit code was discarded — `echo` always succeeds, so the pipeline saw a successful left-hand side and proceeded to upload whatever (possibly empty/partial) output had been produced. Real generation failures silently became green builds.

## Fix

```bash
read -ra args <<< "$$GITHUB_PR_COMMENT_VAR_ARGS"
./pipeline-gen "$${args[@]}" | tee /dev/stderr | buildkite-agent pipeline upload
```

(`$$` escapes Buildkite's pipeline-upload interpolation so the runtime shell sees `$GITHUB_PR_COMMENT_VAR_ARGS` and `${args[@]}`.)

- `read -ra` splits the comment args into an array using normal IFS rules — no command substitution, no glob expansion, no re-evaluation.
- `pipeline-gen` is invoked directly, so its exit code participates in the pipeline and `pipefail` actually fails the step when generation fails.
- `tee /dev/stderr` echoes the generated YAML to the build log for easier debugging without affecting the upload.

> Alternative could be `./pipeline-gen $$GITHUB_PR_COMMENT_VAR_ARGS | tee /dev/stderr | buildkite-agent pipeline upload`

## Note

This assumes PR comments do not contain environment-variable references that need a second level of expansion. `read -ra` does ordinary word-splitting only — it will not expand `$VAR` inside the comment text. If we ever need that, we'd have to reintroduce an explicit (and carefully scoped) expansion step rather than relying on `$(echo …)`.

