### PR TITLE
Preserve secure settings annotation of file-settings secret on re-save

### DIFF
--- a/pkg/controller/elasticsearch/driver/shared/reconcile.go
+++ b/pkg/controller/elasticsearch/driver/shared/reconcile.go
@@ -363,7 +363,9 @@ func MaybeReconcileEmptyFileSettingsSecret(ctx context.Context, c k8s.Client, li
 			// introduced by the operator (e.g. the watched resources label) are propagated
 			// onto it. Save is a no-op when nothing has actually changed.
 			// Re-save only when the content of file is not corrupt to avoid overwriting with empty settings.
-			return false, fs.Save(ctx, c, es)
+			// Use WithAdditiveMetadata because the ES controller doesn't own all managed
+			// annotations (e.g. secure-settings-secrets is managed by the SCP controller).
+			return false, fs.Save(ctx, c, es, filesettings.WithAdditiveMetadata())
 		}
 
 		return false, nil

--- a/pkg/controller/elasticsearch/filesettings/secret_test.go
+++ b/pkg/controller/elasticsearch/filesettings/secret_test.go
@@ -278,6 +278,88 @@ func Test_SecureSettings_RoundTrip(t *testing.T) {
 	assert.Equal(t, []commonv1.NamespacedSecretSource{{Namespace: "otherNs", SecretName: "secure-settings-secret"}}, secureSettings)
 }
 
+func Test_Save_SecureSettingsAnnotation(t *testing.T) {
+	tests := []struct {
+		name                    string
+		useAdditiveMetadata     bool
+		wantAnnotationPreserved bool
+	}{
+		{
+			name:                    "WithAdditiveMetadata preserves annotation (ES controller)",
+			useAdditiveMetadata:     true,
+			wantAnnotationPreserved: true,
+		},
+		{
+			name:                    "without WithAdditiveMetadata removes annotation (SCP controller)",
+			useAdditiveMetadata:     false,
+			wantAnnotationPreserved: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			esNsn := types.NamespacedName{Namespace: "esNs", Name: "esName"}
+			es := esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{
+				Namespace: esNsn.Namespace,
+				Name:      esNsn.Name,
+				UID:       "test-uid",
+			}}
+
+			existingSettings := NewEmptySettings(1, false)
+			settingsBytes, err := json.Marshal(existingSettings)
+			require.NoError(t, err)
+
+			secureSettingsSources := []commonv1.NamespacedSecretSource{
+				{Namespace: "esNs", SecretName: "my-secure-settings"},
+			}
+			secureSettingsJSON, err := json.Marshal(secureSettingsSources)
+			require.NoError(t, err)
+
+			existingSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: esNsn.Namespace,
+					Name:      esv1.FileSettingsSecretName(esNsn.Name),
+					Annotations: map[string]string{
+						commonannotation.SettingsHashAnnotationName:          existingSettings.hash(),
+						commonannotation.SecureSettingsSecretsAnnotationName: string(secureSettingsJSON),
+					},
+				},
+				Data: map[string][]byte{SettingsSecretKey: settingsBytes},
+			}
+
+			fakeClient := k8s.NewFakeClient(&es, existingSecret)
+
+			fs, err := Load(context.Background(), fakeClient, esNsn, false, metadata.Metadata{})
+			require.NoError(t, err)
+
+			if tt.useAdditiveMetadata {
+				err = fs.Save(context.Background(), fakeClient, &es, WithAdditiveMetadata())
+			} else {
+				err = fs.Save(context.Background(), fakeClient, &es)
+			}
+			require.NoError(t, err)
+
+			var secret corev1.Secret
+			err = fakeClient.Get(context.Background(), types.NamespacedName{
+				Namespace: esNsn.Namespace,
+				Name:      esv1.FileSettingsSecretName(esNsn.Name),
+			}, &secret)
+			require.NoError(t, err)
+
+			secureSettings, err := getSecureSettings(secret)
+			require.NoError(t, err)
+
+			if tt.wantAnnotationPreserved {
+				assert.Equal(t, secureSettingsSources, secureSettings,
+					"secure-settings-secrets annotation should be preserved")
+			} else {
+				assert.Empty(t, secureSettings,
+					"secure-settings-secrets annotation should be removed")
+			}
+		})
+	}
+}
+
 func parseSettings(t *testing.T, secret corev1.Secret) Settings {
 	t.Helper()
 	var settings Settings


### PR DESCRIPTION
## Summary

Fixes a regression introduced in #9359 where the `policy.k8s.elastic.co/secure-settings-secrets` annotation was being stripped from the file-settings Secret when the ES controller re-saved it for label propagation.

**Root cause:** `MaybeReconcileEmptyFileSettingsSecret` called `fs.Save()` without `WithAdditiveMetadata()`. Since the ES controller doesn't own the secure-settings annotation (it's managed by the SCP controller), this caused the annotation to be removed from the Secret, breaking keystore reconciliation.

**Impact:** StackConfigPolicy `secureSettings` were not being added to the Elasticsearch keystore, causing the e2e test `TestStackConfigPolicy/Elasticsearch_secure_settings_should_eventually_be_set_in_all_nodes_keystore` to fail.

## Changes

- `MaybeReconcileEmptyFileSettingsSecret` now uses `WithAdditiveMetadata()` when re-saving the file-settings Secret for label propagation, preserving annotations managed by other controllers
- Added regression tests:
  - `Test_Save_SecureSettingsAnnotation` - table-driven test verifying WithAdditiveMetadata preserves the annotation (ES controller) and without it removes it (SCP controller)
