### PR TITLE
bump minSupportedOpenshiftVersion to v4.14

### DIFF
--- a/hack/operatorhub/config.yaml
+++ b/hack/operatorhub/config.yaml
@@ -47,9 +47,9 @@ packages:
   - outputPath: certified-operators
     packageName: elasticsearch-eck-operator-certified
     distributionChannel: certified-operators
-    # The minimum supported OpenShift version for ECK is 4.14 but we don't want to create unnecessary friction for users
-    # by excluding ECK from the 4.12 Operatorhub catalog as long as 4.12 is still within Red Hat extended maintenance.
-    minSupportedOpenshiftVersion: v4.12
+    # The minimum supported OpenShift version for ECK is 4.16 but we don't want to create unnecessary friction for users
+    # by excluding ECK from the 4.14 Operatorhub catalog as long as 4.14 is still within Red Hat extended maintenance.
+    minSupportedOpenshiftVersion: v4.14
     operatorRepo: registry.connect.redhat.com/elastic/eck-operator
     ubiOnly: true
     ## digestPinning should only be set to true for certified operator.

--- a/hack/operatorhub/config.yaml
+++ b/hack/operatorhub/config.yaml
@@ -48,7 +48,9 @@ packages:
     packageName: elasticsearch-eck-operator-certified
     distributionChannel: certified-operators
     # The minimum supported OpenShift version for ECK is 4.16 but we don't want to create unnecessary friction for users
-    # by excluding ECK from the 4.14 Operatorhub catalog as long as 4.14 is still within Red Hat extended maintenance.
+    # by excluding ECK from the 4.14 Operatorhub catalog as long as 4.14 is still within Red Hat maintenance.
+    # Note: once published, this value cannot be reverted to a previous (lower) OpenShift version in a future release
+    # https://github.com/redhat-openshift-ecosystem/certified-operators/pull/8381#issuecomment-4379446620.
     minSupportedOpenshiftVersion: v4.14
     operatorRepo: registry.connect.redhat.com/elastic/eck-operator
     ubiOnly: true


### PR DESCRIPTION
This PR corrects the `minSupportedOpenshiftVersion` to be in line with the prior `3.3.0` release that bumped it to `v4.14` (https://github.com/elastic/cloud-on-k8s/pull/8988) but never got changed on `main`
