### PR TITLE
[3.4] bump minSupportedOpenshiftVersion to v4.14 (#9423)

### DIFF
--- a/hack/operatorhub/config.yaml
+++ b/hack/operatorhub/config.yaml
@@ -47,9 +47,11 @@ packages:
   - outputPath: certified-operators
     packageName: elasticsearch-eck-operator-certified
     distributionChannel: certified-operators
-    # The minimum supported OpenShift version for ECK is 4.14 but we don't want to create unnecessary friction for users
-    # by excluding ECK from the 4.12 Operatorhub catalog as long as 4.12 is still within Red Hat extended maintenance.
-    minSupportedOpenshiftVersion: v4.12
+    # The minimum supported OpenShift version for ECK is 4.16 but we don't want to create unnecessary friction for users
+    # by excluding ECK from the 4.14 Operatorhub catalog as long as 4.14 is still within Red Hat maintenance.
+    # Note: once published, this value cannot be reverted to a previous (lower) OpenShift version in a future release
+    # https://github.com/redhat-openshift-ecosystem/certified-operators/pull/8381#issuecomment-4379446620.
+    minSupportedOpenshiftVersion: v4.14
     operatorRepo: registry.connect.redhat.com/elastic/eck-operator
     ubiOnly: true
     ## digestPinning should only be set to true for certified operator.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.4`:
 - [bump minSupportedOpenshiftVersion to v4.14 (#9423)](https://github.com/elastic/cloud-on-k8s/pull/9423)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)