### PR TITLE
[3.4] Add release notes for 3.4 release (#9326)

### DIFF
--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -14,6 +14,33 @@ Breaking changes can impact your Elastic applications, potentially disrupting no
 % **Action**<br> Steps for mitigating deprecation impact.
 % ::::
 
+## 3.4.0 [elastic-cloud-kubernetes-340-breaking-changes]
+
+::::{dropdown} Rolling restart of {{es}} pods during operator upgrade
+ECK 3.4.0 includes changes that modify the {{es}} pod spec, triggering a rolling restart of all {{es}} pods during the operator upgrade. These changes include setting `seccompProfile` to `RuntimeDefault` and updated pre-stop hook and readiness probe scripts for client certificate authentication support.
+
+**Impact**<br> All {{es}} pods will be restarted as part of the operator upgrade.
+
+**Action**<br> No action required. Be aware that {{es}} pods will restart during the upgrade.
+::::
+
+::::{dropdown} Rolling restart of {{product.kibana}} pods during operator upgrade and potential OOM risk for low memory limits
+ECK 3.4.0 includes changes that modify the {{product.kibana}} pod spec, triggering a rolling restart of {{product.kibana}} pods during the operator upgrade. These changes include setting `seccompProfile` to `RuntimeDefault`, a new default security context on the init container, and an increase of the default memory limit from 1Gi to 2Gi. The memory limit increase addresses OOM crashes for {{product.kibana}} 9.4.0+ where the 1Gi limit does not provide enough headroom for plugin initialization.
+
+**Impact**<br> {{product.kibana}} pods will be restarted as part of the operator upgrade. Pods without explicit memory limits will consume up to 2Gi of memory instead of 1Gi.
+
+**Action**<br> Ensure that cluster nodes have sufficient memory to accommodate the increased default. If you have explicitly set a memory limit in the {{product.kibana}} `podTemplate`, the memory limit change does not affect you. However, if you have set a memory limit lower than 2Gi, be aware that {{product.kibana}} 9.4.0+ may experience OOM crashes due to the increased V8 heap usage.
+::::
+
+::::{dropdown} Default PVC handling change for {{es}} volumes
+ECK 3.4.0 unifies how the operator handles default volume claim templates. Previously, the operator only skipped adding a default PVC when a non-PVC volume (such as `emptyDir` or `hostPath`) with the same name existed. Now, it skips the default PVC whenever any volume with the same name exists, including user-provided PVCs.
+
+**Impact**<br> If you defined custom PVC volumes in `podTemplate.spec.volumes` with the same name as a default volume (for example `elasticsearch-data`), those custom volumes were previously ignored and default volumes were provisioned instead. After upgrading, the operator will attempt to use your custom PVC volumes, which may cause a StatefulSet update rejection by Kubernetes.
+
+**Action**<br> If you encounter a StatefulSet update error after upgrading, remove the custom PVC entries from `podTemplate.spec.volumes` that overlap with default volume names.
+::::
+
+
 ## 3.3.2 [elastic-cloud-kubernetes-332-breaking-changes]
 
 There are no breaking changes for ECK 3.3.2

--- a/docs/release-notes/deprecations.md
+++ b/docs/release-notes/deprecations.md
@@ -17,6 +17,10 @@ Review the deprecated functionality for Elastic Cloud on Kubernetes. While depre
 % **Action**<br> Steps for mitigating deprecation impact.
 % ::::
 
+## 3.4.0 [elastic-cloud-kubernetes-340-deprecations]
+
+There are no deprecations for ECK 3.4.0
+
 ## 3.3.2 [elastic-cloud-kubernetes-332-deprecations]
 
 There are no deprecations for ECK 3.3.2

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -9,6 +9,92 @@ mapped_pages:
 
 Review the changes, fixes, and more in each release of Elastic Cloud on Kubernetes.
 
+## 3.4.0 [elastic-cloud-kubernetes-340-release-notes]
+
+### Release Highlights
+
+#### {{es}} client certificate authentication support
+
+ECK now supports configuring {{es}} to require client certificates for authentication. This allows you to enforce mutual TLS (mTLS) between clients and {{es}}, strengthening security by requiring both the client and server to present valid certificates. Currently, {{es}} and {{product.kibana}} support this feature - {{product.kibana}} can be configured to present client certificates when connecting to {{es}}. Support for the remaining components that connect to {{es}} (Beats, Elastic Agent, APM Server, Logstash, and so on) will follow in future releases. For more details, refer to the [client certificate authentication documentation](docs-content://deploy-manage/security/k8s-es-client-certificate-auth.md).
+
+#### Rolling restarts of {{es}} clusters
+
+ECK now supports triggering rolling restarts of {{es}} clusters through a new annotation-based mechanism. This enables operators to gracefully restart all nodes in a cluster without manual intervention, useful for troubleshooting. The [rolling restart documentation](docs-content://deploy-manage/deploy/cloud-on-k8s/nodes-orchestration.md#cluster-rolling-restart) provides more details.
+
+#### Simplified zone awareness configuration
+
+ECK simplifies the configuration of zone awareness for {{es}} clusters, reducing the amount of boilerplate configuration needed to set up topology-aware allocation. For more details, refer to the [zone awareness documentation](docs-content://deploy-manage/deploy/cloud-on-k8s/advanced-elasticsearch-node-scheduling.md#k8s-zone-awareness).
+
+#### ECK container image signing
+
+ECK container images are now signed using [Sigstore cosign](https://docs.sigstore.dev/cosign/). This allows users to verify the authenticity and integrity of ECK operator images before deployment, strengthening the supply chain security of their Kubernetes clusters.
+
+#### Automatic password-protected keystore for {{es}} in FIPS mode
+
+ECK now automatically manages a password-protected keystore for {{es}} when FIPS mode is enabled. When `xpack.security.fips_mode.enabled` is set to `true` in the {{es}} configuration, the operator generates, stores, and configures a password-protected keystore — eliminating the need for manual `podTemplate` overrides. This feature activates for {{es}} 9.4.0+ and respects any existing user-provided keystore password configuration. For more details, refer to the [{{es}} FIPS keystore password documentation](docs-content://deploy-manage/deploy/cloud-on-k8s/deploy-fips-compatible-version-of-eck.md#k8s-fips-keystore-password).
+
+### Features and enhancements [elastic-cloud-kubernetes-340-features-and-enhancements]
+
+- Implement client certificate required support for {{es}} [#9229](https://github.com/elastic/cloud-on-k8s/pull/9229)
+- Implement {{product.kibana}} support for presenting client certificates to {{es}} [#9230](https://github.com/elastic/cloud-on-k8s/pull/9230)
+- Support rolling restarts of {{es}} clusters [#9172](https://github.com/elastic/cloud-on-k8s/pull/9172)
+- Simplify zone awareness [#9148](https://github.com/elastic/cloud-on-k8s/pull/9148)
+- Operator-managed FIPS keystore password support for {{es}} [#9287](https://github.com/elastic/cloud-on-k8s/pull/9287) (issue: [#9171](https://github.com/elastic/cloud-on-k8s/issues/9171))
+- Surface webhook warnings; Refactor webhooks to use controller-runtime's Validator [#9235](https://github.com/elastic/cloud-on-k8s/pull/9235)
+- Add `extraObjects` support to ECK Helm charts [#9069](https://github.com/elastic/cloud-on-k8s/pull/9069)
+- Add `kubeAPIServerPort` configuration option to Helm chart [#8980](https://github.com/elastic/cloud-on-k8s/pull/8980)
+- Set `seccompProfile` to `RuntimeDefault` [#9012](https://github.com/elastic/cloud-on-k8s/pull/9012)
+- Validate user-supplied HTTP CA certificate [#8992](https://github.com/elastic/cloud-on-k8s/pull/8992)
+- Sign ECK container images (v2) [#9078](https://github.com/elastic/cloud-on-k8s/pull/9078)
+- Improve license signature verification error to diagnose wrong license type [#9262](https://github.com/elastic/cloud-on-k8s/pull/9262)
+- Improve AutoOpsAgentPolicy status reporting [#9095](https://github.com/elastic/cloud-on-k8s/pull/9095)
+- Support `runAsNonRoot` true for recent versions of EPR [#8974](https://github.com/elastic/cloud-on-k8s/pull/8974)
+- Reduce operator memory footprint by stripping managed fields from informer caches [#9321](https://github.com/elastic/cloud-on-k8s/pull/9321)
+- Add version-gated querylog fileset to Filebeat sidecar config [#9291](https://github.com/elastic/cloud-on-k8s/pull/9291)
+- Bump default {{product.kibana}} memory limit from 1Gi to 2Gi [#9328](https://github.com/elastic/cloud-on-k8s/pull/9328)
+- Add image digest support to eck-operator Helm chart [#9362](https://github.com/elastic/cloud-on-k8s/pull/9362)
+
+### Fixes [elastic-cloud-kubernetes-340-fixes]
+
+- Prevent StackConfigPolicy controller from performing unnecessary file-settings secret updates on every reconciliation [#9316](https://github.com/elastic/cloud-on-k8s/pull/9316)
+- Correct NetworkPolicy namespace selector label for soft multi-tenancy [#9153](https://github.com/elastic/cloud-on-k8s/pull/9153)
+- Prevent using a nodeSet name while the equivalent StatefulSet already exists [#9036](https://github.com/elastic/cloud-on-k8s/pull/9036)
+- Skip default PVC if volume with same name exists [#9199](https://github.com/elastic/cloud-on-k8s/pull/9199) (issue: [#8744](https://github.com/elastic/cloud-on-k8s/issues/8744))
+- Avoid empty reconcile requests in StackConfigPolicy secret watch [#9179](https://github.com/elastic/cloud-on-k8s/pull/9179)
+- Make remote-ca secret generation failures non-blocking [#9271](https://github.com/elastic/cloud-on-k8s/pull/9271)
+- Garbage collect Agent soft-owned secrets on deletion [#9090](https://github.com/elastic/cloud-on-k8s/pull/9090)
+- Detect stale CA in certificate chain and trigger certificates reissuance [#9197](https://github.com/elastic/cloud-on-k8s/pull/9197)
+- Skip per-shard replica checks for GREEN clusters in `require_started_replica` predicate [#9188](https://github.com/elastic/cloud-on-k8s/pull/9188)
+- Handle server side default for `TrafficDistribution` [#8994](https://github.com/elastic/cloud-on-k8s/pull/8994)
+- Set default security context to {{product.kibana}} init container [#9218](https://github.com/elastic/cloud-on-k8s/pull/9218)
+- Validate user-supplied CA for the transport layer of {{es}} [#8953](https://github.com/elastic/cloud-on-k8s/pull/8953)
+- Align DaemonSet `UpdateReconciled` with Deployment reconciler [#9256](https://github.com/elastic/cloud-on-k8s/pull/9256) (issue: [#9246](https://github.com/elastic/cloud-on-k8s/issues/9246))
+
+### Documentation improvements [elastic-cloud-kubernetes-340-documentation-improvements]
+
+- Add recipe for manual mTLS configuration [#9124](https://github.com/elastic/cloud-on-k8s/pull/9124)
+- Mention `PodTopologyLabelsAdmission` in {{es}} sample [#9035](https://github.com/elastic/cloud-on-k8s/pull/9035)
+- Logstash Chart improvements [#9087](https://github.com/elastic/cloud-on-k8s/pull/9087)
+
+:::{dropdown} Updated dependencies
+
+- Go 1.25.8 => 1.26.2
+- github.com/elastic/go-ucfg v0.8.9-0.20251017163010-3520930bed4f => v0.9.1
+- github.com/gkampitakis/go-snaps v0.5.19 => v0.5.21
+- github.com/google/go-containerregistry v0.20.7 => v0.21.4
+- github.com/hashicorp/vault/api v1.22.0 => v1.23.0
+- go.elastic.co/apm/v2 v2.7.2 => v2.7.6
+- golang.org/x/crypto v0.46.0 => v0.49.0
+- k8s.io/api v0.35.0 => v0.35.3
+- k8s.io/apimachinery v0.35.0 => v0.35.3
+- k8s.io/client-go v0.35.0 => v0.35.3
+- k8s.io/klog/v2 v2.130.1 => v2.140.0
+- sigs.k8s.io/controller-runtime v0.22.4 => v0.23.3
+- sigs.k8s.io/controller-tools v0.20.0 => v0.20.1
+- New direct dependencies: cloud.google.com/go/auth, cloud.google.com/go/storage, github.com/Azure/azure-sdk-for-go/sdk/storage/azblob, github.com/aws/aws-sdk-go-v2, google.golang.org/api
+
+:::
+
 ## 3.3.2 [elastic-cloud-kubernetes-332-release-notes]
 
 ### Release Highlights

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -17,6 +17,10 @@ Known issues are significant defects or limitations that may impact your impleme
 
 :::
 
+## 3.4.0 [elastic-cloud-kubernetes-340-known-issues]
+
+There are no known issues in ECK 3.4.0
+
 ## 3.3.2 [elastic-cloud-kubernetes-332-known-issues]
 
 There are no known issues in ECK 3.3.2


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.4`:
 - [Add release notes for 3.4 release (#9326)](https://github.com/elastic/cloud-on-k8s/pull/9326)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)