### PR TITLE
fix dynamic watch leak on autoops resource selector change

### DIFF
--- a/pkg/controller/autoops/controller.go
+++ b/pkg/controller/autoops/controller.go
@@ -243,6 +243,8 @@ func (r *AgentPolicyReconciler) onDelete(ctx context.Context, obj types.Namespac
 	// Cleanup API keys for each ES cluster referenced by the secrets
 	for _, secret := range secrets.Items {
 		// Remove dynamic watch registered for this secret (CA or API key)
+		// Safety-net for in-scope secrets at policy deletion,
+		// selector-change cleanup is handled in cleanupOrphanedSecrets
 		r.dynamicWatches.Secrets.RemoveHandlerForKey(secret.Name)
 
 		esName, hasESName := secret.Labels["elasticsearch.k8s.elastic.co/name"]

--- a/pkg/controller/autoops/gc.go
+++ b/pkg/controller/autoops/gc.go
@@ -240,19 +240,19 @@ func cleanupOrphanedConfigMaps(
 	return nil
 }
 
-// cleanupOrphanedSecrets removes secrets (CA, client cert, and API key) for ES clusters that no longer match the selector.
-func cleanupOrphanedSecrets(
+// cleanupOrphanedSecrets removes secrets (CA, client cert, and API key) for ES clusters that no longer
+// match the selector. The dynamic watch registered for each managed secret is also removed; otherwise
+// it would linger until policy deletion, by which time the secret is gone and onDelete's
+// label-driven enumeration can't find it.
+func (r *AgentPolicyReconciler) cleanupOrphanedSecrets(
 	ctx context.Context,
 	log logr.Logger,
-	c k8s.Client,
-	esClientProvider commonesclient.Provider,
-	dialer net.Dialer,
 	policy autoopsv1alpha1.AutoOpsAgentPolicy,
 	matchLabels client.MatchingLabels,
 	matchingESset sets.Set[types.NamespacedName],
 ) error {
 	var secrets corev1.SecretList
-	if err := c.List(ctx, &secrets, client.InNamespace(policy.Namespace), matchLabels); err != nil {
+	if err := r.Client.List(ctx, &secrets, client.InNamespace(policy.Namespace), matchLabels); err != nil {
 		return err
 	}
 
@@ -266,16 +266,20 @@ func cleanupOrphanedSecrets(
 		if secretType, exists := secret.Labels[policySecretTypeLabelKey]; exists && secretType == "api-key" {
 			// Try to get the ES cluster to clean up API key
 			var es esv1.Elasticsearch
-			if err := c.Get(ctx, esNN, &es); err == nil {
+			if err := r.Client.Get(ctx, esNN, &es); err == nil {
 				// ES cluster exists, try to clean up API key
-				if err := cleanupAutoOpsESAPIKey(ctx, c, esClientProvider, dialer, policy.Namespace, policy.Name, es); err != nil {
+				if err := cleanupAutoOpsESAPIKey(ctx, r.Client, r.esClientProvider, r.params.Dialer, policy.Namespace, policy.Name, es); err != nil {
 					log.Error(err, "while cleaning up API key for ES cluster, continuing with secret deletion", "es_namespace", esNN.Namespace, "es_name", esNN.Name)
 				}
 			}
 		}
 
+		// Remove the dynamic watch keyed by secret name (registered in
+		// reconcileAutoOpsESCASecret / reconcileAutoOpsESClientCertSecret).
+		r.dynamicWatches.Secrets.RemoveHandlerForKey(secret.Name)
+
 		log.Info("Deleting orphaned Secret", "secret", secret.Name, "es_namespace", esNN.Namespace, "es_name", esNN.Name)
-		if err := c.Delete(ctx, secret); err != nil && !apierrors.IsNotFound(err) {
+		if err := r.Client.Delete(ctx, secret); err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	}

--- a/pkg/controller/autoops/gc_test.go
+++ b/pkg/controller/autoops/gc_test.go
@@ -8,11 +8,14 @@ import (
 	"context"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	autoopsv1alpha1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/autoops/v1alpha1"
@@ -20,32 +23,12 @@ import (
 	esv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/elasticsearch/v1"
 	commonapikey "github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/apikey"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/scheme"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/watches"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
 )
 
 func TestGarbageCollector_DoGarbageCollection(t *testing.T) {
 	scheme.SetupScheme()
-
-	// Helper to create a secret with policy labels
-	createSecret := func(name, namespace, policyName, policyNamespace, esName, esNamespace, secretType string) *corev1.Secret {
-		labels := map[string]string{
-			PolicyNameLabelKey:                  policyName,
-			policyNamespaceLabelKey:             policyNamespace,
-			commonapikey.MetadataKeyESName:      esName,
-			commonapikey.MetadataKeyESNamespace: esNamespace,
-			commonv1.TypeLabelName:              autoOpsAgentType,
-		}
-		if secretType != "" {
-			labels[policySecretTypeLabelKey] = secretType
-		}
-		return &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: namespace,
-				Labels:    labels,
-			},
-		}
-	}
 
 	// Helper to create a configmap with policy labels
 	createConfigMap := func(name, namespace, policyName, policyNamespace, esName, esNamespace string) *corev1.ConfigMap {
@@ -119,7 +102,7 @@ func TestGarbageCollector_DoGarbageCollection(t *testing.T) {
 			objects: []client.Object{
 				createPolicy("policy-1", "ns-1"),
 				createES("es-1", "ns-1"),
-				createSecret("secret-1", "ns-1", "policy-1", "ns-1", "es-1", "ns-1", apiKeySecretType),
+				newPolicySecret("secret-1", "ns-1", "policy-1", "ns-1", "es-1", "ns-1", apiKeySecretType),
 				createConfigMap("configmap-1", "ns-1", "policy-1", "ns-1", "es-1", "ns-1"),
 				createDeployment("deployment-1", "ns-1", "policy-1", "ns-1", "es-1", "ns-1"),
 			},
@@ -132,7 +115,7 @@ func TestGarbageCollector_DoGarbageCollection(t *testing.T) {
 			objects: []client.Object{
 				// No policy exists, but resources reference it
 				createES("es-1", "ns-1"),
-				createSecret("secret-1", "ns-1", "deleted-policy", "ns-1", "es-1", "ns-1", apiKeySecretType),
+				newPolicySecret("secret-1", "ns-1", "deleted-policy", "ns-1", "es-1", "ns-1", apiKeySecretType),
 				// ConfigMaps and Deployments have owner references, so Kubernetes GC handles them.
 				// We still create them here to verify the GC doesn't error on their presence.
 				createConfigMap("configmap-1", "ns-1", "deleted-policy", "ns-1", "es-1", "ns-1"),
@@ -148,11 +131,11 @@ func TestGarbageCollector_DoGarbageCollection(t *testing.T) {
 				createPolicy("existing-policy", "ns-1"),
 				createES("es-1", "ns-1"),
 				// Resources for existing policy
-				createSecret("secret-existing", "ns-1", "existing-policy", "ns-1", "es-1", "ns-1", apiKeySecretType),
+				newPolicySecret("secret-existing", "ns-1", "existing-policy", "ns-1", "es-1", "ns-1", apiKeySecretType),
 				createConfigMap("configmap-existing", "ns-1", "existing-policy", "ns-1", "es-1", "ns-1"),
 				createDeployment("deployment-existing", "ns-1", "existing-policy", "ns-1", "es-1", "ns-1"),
 				// Orphaned resources for deleted policy
-				createSecret("secret-orphaned", "ns-1", "deleted-policy", "ns-1", "es-1", "ns-1", apiKeySecretType),
+				newPolicySecret("secret-orphaned", "ns-1", "deleted-policy", "ns-1", "es-1", "ns-1", apiKeySecretType),
 				createConfigMap("configmap-orphaned", "ns-1", "deleted-policy", "ns-1", "es-1", "ns-1"),
 				createDeployment("deployment-orphaned", "ns-1", "deleted-policy", "ns-1", "es-1", "ns-1"),
 			},
@@ -164,8 +147,8 @@ func TestGarbageCollector_DoGarbageCollection(t *testing.T) {
 			name: "cleanup CA secrets as well as API key secrets",
 			objects: []client.Object{
 				createES("es-1", "ns-1"),
-				createSecret("api-key-secret", "ns-1", "deleted-policy", "ns-1", "es-1", "ns-1", apiKeySecretType),
-				createSecret("ca-secret", "ns-1", "deleted-policy", "ns-1", "es-1", "ns-1", caSecretType),
+				newPolicySecret("api-key-secret", "ns-1", "deleted-policy", "ns-1", "es-1", "ns-1", apiKeySecretType),
+				newPolicySecret("ca-secret", "ns-1", "deleted-policy", "ns-1", "es-1", "ns-1", caSecretType),
 			},
 			wantSecrets:     0,
 			wantConfigMaps:  0,
@@ -308,5 +291,76 @@ func TestESFromLabels(t *testing.T) {
 			got := esFromLabels(tt.labels)
 			require.Equal(t, tt.want, got)
 		})
+	}
+}
+
+func TestAgentPolicyReconciler_cleanupOrphanedSecrets_removesWatchHandlers(t *testing.T) {
+	scheme.SetupScheme()
+
+	policy := autoopsv1alpha1.AutoOpsAgentPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "policy-1", Namespace: "ns-1"},
+	}
+
+	// Two secrets simulating CA + client cert for an ES that is no longer selected.
+	orphanedCASecret := newPolicySecret("policy-1-autoops-ca-orphaned", "ns-1", "policy-1", "ns-1", "es-orphaned", "ns-2", caSecretType)
+	orphanedClientCertSecret := newPolicySecret("policy-1-autoops-cc-orphaned", "ns-1", "policy-1", "ns-1", "es-orphaned", "ns-2", clientCertSecretType)
+
+	// A secret for an ES that is still selected — its watch must be preserved.
+	keepSecret := newPolicySecret("policy-1-autoops-ca-keep", "ns-1", "policy-1", "ns-1", "es-keep", "ns-3", caSecretType)
+
+	k8sClient := k8s.NewFakeClient(orphanedCASecret, orphanedClientCertSecret, keepSecret)
+	dynWatches := watches.NewDynamicWatches()
+
+	// Pre-register dynamic watches for all three secrets to mirror what
+	// reconcileAutoOpsESCASecret / reconcileAutoOpsESClientCertSecret would have done.
+	watcher := k8s.ExtractNamespacedName(&policy)
+	preRegistered := []string{orphanedCASecret.Name, orphanedClientCertSecret.Name, keepSecret.Name}
+	for _, name := range preRegistered {
+		require.NoError(t, watches.WatchUserProvidedSecrets(watcher, dynWatches, name, []string{name}))
+	}
+	require.ElementsMatch(t, preRegistered, dynWatches.Secrets.Registrations())
+
+	r := &AgentPolicyReconciler{
+		Client:         k8sClient,
+		dynamicWatches: dynWatches,
+	}
+
+	matchLabels := client.MatchingLabels{PolicyNameLabelKey: "policy-1"}
+	matchingESSet := sets.New(types.NamespacedName{Name: "es-keep", Namespace: "ns-3"})
+
+	require.NoError(t, r.cleanupOrphanedSecrets(context.Background(), logr.Discard(), policy, matchLabels, matchingESSet))
+
+	// Orphaned secrets are deleted, keep secret is preserved.
+	deleted := []string{orphanedCASecret.Name, orphanedClientCertSecret.Name}
+	for _, secretName := range deleted {
+		var got corev1.Secret
+		err := k8sClient.Get(context.Background(), types.NamespacedName{Namespace: "ns-1", Name: secretName}, &got)
+		require.True(t, apierrors.IsNotFound(err), "secret %s should be deleted", secretName)
+	}
+	var keep corev1.Secret
+	require.NoError(t, k8sClient.Get(context.Background(), types.NamespacedName{Namespace: "ns-1", Name: keepSecret.Name}, &keep))
+
+	// Watch handlers for the orphaned secrets are removed; the keep one remains.
+	require.ElementsMatch(t, []string{keepSecret.Name}, dynWatches.Secrets.Registrations())
+}
+
+// newPolicySecret builds a minimal Secret carrying the labels cleanupOrphanedSecrets matches on.
+func newPolicySecret(name, namespace, policyName, policyNamespace, esName, esNamespace, secretType string) *corev1.Secret {
+	labels := map[string]string{
+		PolicyNameLabelKey:                  policyName,
+		policyNamespaceLabelKey:             policyNamespace,
+		commonapikey.MetadataKeyESName:      esName,
+		commonapikey.MetadataKeyESNamespace: esNamespace,
+		commonv1.TypeLabelName:              autoOpsAgentType,
+	}
+	if secretType != "" {
+		labels[policySecretTypeLabelKey] = secretType
+	}
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
 	}
 }

--- a/pkg/controller/autoops/reconcile.go
+++ b/pkg/controller/autoops/reconcile.go
@@ -267,8 +267,8 @@ func (r *AgentPolicyReconciler) cleanupOrphanedResourcesForPolicy(
 		return fmt.Errorf("while cleaning up configmaps: %w", err)
 	}
 
-	// Cleanup both CA secrets and API Key.
-	if err := cleanupOrphanedSecrets(ctx, log, r.Client, r.esClientProvider, r.params.Dialer, policy, matchLabels, esSet); err != nil {
+	// Cleanup CA, client cert, and API key secrets.
+	if err := r.cleanupOrphanedSecrets(ctx, log, policy, matchLabels, esSet); err != nil {
 		return fmt.Errorf("while cleaning up secrets: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

The autoops controller registers a per-secret dynamic watch in `reconcileAutoOpsESCASecret` and `reconcileAutoOpsESClientCertSecret`, keyed by the secret name. When an Elasticsearch cluster falls out of an `AutoOpsAgentPolicy.spec.resourceSelector`, `cleanupOrphanedSecrets` (`pkg/controller/autoops/gc.go`) deleted the orphaned CA / client cert secret but never removed the corresponding watch entry.

`onDelete` (`pkg/controller/autoops/controller.go`) cleans watches on policy deletion by enumerating labeled secrets - but orphaned secrets are already gone at that point, so their watch keys are never visited and leak for the policy's lifetime. The leak size is proportional to selector churn (distinct ES clusters that have ever matched and later been excluded).

Fixes https://github.com/elastic/cloud-on-k8s/issues/9433

## Changes

- Converted `cleanupOrphanedSecrets` from a standalone function to a method on `*AgentPolicyReconciler`. This drops three parameters (`client`, `esClientProvider`, `dialer`) - they now come from the receiver - and gives the function access to `r.dynamicWatches`.
- Added `r.dynamicWatches.Secrets.RemoveHandlerForKey(secret.Name)` immediately before the orphaned `r.Client.Delete(ctx, secret)` call. One line covers both CA and client cert watches since both reconcilers share the same `watchName == secret.Name` convention.
- Updated the single caller in `pkg/controller/autoops/reconcile.go`.