### PR TITLE
[#9435] Update `WithTemplateHash` functions to hash based on the `Spec` and not the whole object

### DIFF
--- a/pkg/controller/common/daemonset/reconcile.go
+++ b/pkg/controller/common/daemonset/reconcile.go
@@ -88,6 +88,6 @@ func Reconcile(
 // WithTemplateHash returns a new DaemonSet with a hash of its template to ease comparisons.
 func WithTemplateHash(d appsv1.DaemonSet) appsv1.DaemonSet {
 	dCopy := *d.DeepCopy()
-	dCopy.Labels = hash.SetTemplateHashLabel(dCopy.Labels, dCopy)
+	dCopy.Labels = hash.SetTemplateHashLabel(dCopy.Labels, dCopy.Spec)
 	return dCopy
 }

--- a/pkg/controller/common/daemonset/reconcile_test.go
+++ b/pkg/controller/common/daemonset/reconcile_test.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
 package daemonset
 
 import (

--- a/pkg/controller/common/daemonset/reconcile_test.go
+++ b/pkg/controller/common/daemonset/reconcile_test.go
@@ -1,0 +1,45 @@
+package daemonset
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/hash"
+)
+
+func TestWithTemplateHash(t *testing.T) {
+	d := appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "daemon",
+			Namespace: "ns",
+		},
+		Spec: appsv1.DaemonSetSpec{
+			UpdateStrategy: appsv1.DaemonSetUpdateStrategy{},
+		},
+	}
+
+	withHash := WithTemplateHash(d)
+	// the label should be set
+	require.NotEmpty(t, withHash.Labels[hash.TemplateHashLabelName])
+	// original object should be kept unmodified
+	require.Empty(t, d.Labels)
+
+	// label should be consistent
+	withSameHash := WithTemplateHash(d)
+	require.Equal(t, withHash.Labels[hash.TemplateHashLabelName], withSameHash.Labels[hash.TemplateHashLabelName])
+
+	// label should be the same if no spec changed
+	withSameHash = WithTemplateHash(withSameHash)
+	require.Equal(t, withHash.Labels[hash.TemplateHashLabelName], withSameHash.Labels[hash.TemplateHashLabelName])
+
+	// label should be different if the spec changed
+	d.Spec.UpdateStrategy = appsv1.DaemonSetUpdateStrategy{
+		Type: appsv1.RollingUpdateDaemonSetStrategyType,
+	}
+	withDifferentHash := WithTemplateHash(d)
+	require.NotEmpty(t, withDifferentHash.Labels[hash.TemplateHashLabelName])
+	require.NotEqual(t, withHash.Labels[hash.TemplateHashLabelName], withDifferentHash.Labels[hash.TemplateHashLabelName])
+}

--- a/pkg/controller/common/deployment/reconcile.go
+++ b/pkg/controller/common/deployment/reconcile.go
@@ -90,6 +90,6 @@ func Reconcile(
 // WithTemplateHash returns a new deployment with a hash of its template to ease comparisons.
 func WithTemplateHash(d appsv1.Deployment) appsv1.Deployment {
 	dCopy := *d.DeepCopy()
-	dCopy.Labels = hash.SetTemplateHashLabel(dCopy.Labels, dCopy)
+	dCopy.Labels = hash.SetTemplateHashLabel(dCopy.Labels, dCopy.Spec)
 	return dCopy
 }

--- a/pkg/controller/common/deployment/reconcile_test.go
+++ b/pkg/controller/common/deployment/reconcile_test.go
@@ -36,8 +36,12 @@ func TestWithTemplateHash(t *testing.T) {
 	// original object should be kept unmodified
 	require.Empty(t, d.Labels)
 
-	// label should stay the same if no spec change
+	// label should be consistent
 	withSameHash := WithTemplateHash(d)
+	require.Equal(t, withHash.Labels[hash.TemplateHashLabelName], withSameHash.Labels[hash.TemplateHashLabelName])
+
+	// label should be the same if no spec changed
+	withSameHash = WithTemplateHash(withSameHash)
 	require.Equal(t, withHash.Labels[hash.TemplateHashLabelName], withSameHash.Labels[hash.TemplateHashLabelName])
 
 	// label should be different if the spec changed

--- a/pkg/controller/common/statefulset/reconcile.go
+++ b/pkg/controller/common/statefulset/reconcile.go
@@ -107,7 +107,7 @@ func Reconcile(
 // WithTemplateHash returns a new StatefulSet with a hash of its template to ease comparisons.
 func WithTemplateHash(d appsv1.StatefulSet) appsv1.StatefulSet {
 	dCopy := *d.DeepCopy()
-	dCopy.Labels = hash.SetTemplateHashLabel(dCopy.Labels, dCopy)
+	dCopy.Labels = hash.SetTemplateHashLabel(dCopy.Labels, dCopy.Spec)
 	return dCopy
 }
 

--- a/pkg/controller/common/statefulset/reconcile_test.go
+++ b/pkg/controller/common/statefulset/reconcile_test.go
@@ -36,8 +36,12 @@ func TestWithTemplateHash(t *testing.T) {
 	// original object should be kept unmodified
 	require.Empty(t, d.Labels)
 
-	// label should stay the same if no spec change
+	// label should be consistent
 	withSameHash := WithTemplateHash(d)
+	require.Equal(t, withHash.Labels[hash.TemplateHashLabelName], withSameHash.Labels[hash.TemplateHashLabelName])
+
+	// label should be the same if no spec changed
+	withSameHash = WithTemplateHash(withSameHash)
 	require.Equal(t, withHash.Labels[hash.TemplateHashLabelName], withSameHash.Labels[hash.TemplateHashLabelName])
 
 	// label should be different if the spec changed


### PR DESCRIPTION
Fixes: #9435

---                                                                                                                                                                                                                                                                                                                       
  ## Summary                                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                            
  Fixes https://github.com/elastic/cloud-on-k8s/issues/9435.                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                            
  The `WithTemplateHash` functions for `Deployment`, `DaemonSet`, and `StatefulSet` were computing the `common.k8s.elastic.co/template-hash` label by hashing the entire object, including its `Labels` field. Because the label being written is itself part of the object being hashed, this creates a circular dependency: the hash  
  computed on reconciliation always differs from the hash already stored on the resource, causing an unnecessary update on every reconciliation loop.
                                                                                                                                                                                                                                                                                                                            
  The Elasticsearch-specific `StatefulSet` path has always hashed only `StatefulSet.Spec`, which is the correct approach. This PR aligns the common reconcilers with that pattern by changing all three `WithTemplateHash` functions to hash only the Spec field.                                                                 
   
  ## Changes                                                                                                                                                                                                                                                                                                                   
                  
  - `pkg/controller/common/deployment/reconcile.go`: hash `Deployment.Spec` instead of the full `Deployment` object.                                                                                                                                                                                                              
  - `pkg/controller/common/daemonset/reconcile.go`: hash `DaemonSet.Spec` instead of the full `DaemonSet` object.
  - `pkg/controller/common/statefulset/reconcile.go`: hash `StatefulSet.Spec` instead of the full `StatefulSet` object.                                                                                                                                                                                                           
  - Tests updated/added for all three to assert that calling `WithTemplateHash` on an already-hashed object produces the same hash (idempotency), which was the failing case before this fix.
                                                                                                                                                                                                                                                                                                                            
  ## Testing         
                                                                                                                                                                                                                                                                                                                            
  - Unit tests for `WithTemplateHash` in all three packages now include an idempotency assertion: applying `WithTemplateHash` to an object that already carries the label must produce the same hash value.                                                                                                                     
  - The existing assertions (hash is set, original object is unmodified, hash changes when spec changes) are preserved.
