### PR TITLE
[#9439] Batch Elasticsearch keystore add-file invocations

### DIFF
--- a/pkg/controller/common/keystore/initcontainer.go
+++ b/pkg/controller/common/keystore/initcontainer.go
@@ -117,3 +117,15 @@ func getScriptTemplate(customScript string) *template.Template {
 
 	return template.Must(template.New("").Parse(customScript))
 }
+
+// RenderInitScript renders the keystore init container's bash script for the
+// given parameters using the same template path the production init container
+// uses. Exposed so callers (in particular tests) can assert on the exact
+// rendered script without having to re-parse the template themselves.
+func RenderInitScript(parameters InitContainerParameters) (string, error) {
+	var buf bytes.Buffer
+	if err := getScriptTemplate(parameters.CustomScript).Execute(&buf, parameters); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}

--- a/pkg/controller/common/keystore/initcontainer_test.go
+++ b/pkg/controller/common/keystore/initcontainer_test.go
@@ -5,19 +5,10 @@
 package keystore
 
 import (
-	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
-
-func renderKeystoreScript(t *testing.T, params InitContainerParameters) string {
-	t.Helper()
-	var tplBuffer bytes.Buffer
-	err := getScriptTemplate(params.CustomScript).Execute(&tplBuffer, params)
-	require.NoError(t, err)
-	return tplBuffer.String()
-}
 
 func TestDefaultScriptByteIdentity(t *testing.T) {
 	params := InitContainerParameters{
@@ -54,5 +45,7 @@ touch /bar/data/elastic-internal-init-keystore.ok
 echo "Keystore initialization successful."
 `
 
-	require.Equal(t, expected, renderKeystoreScript(t, params))
+	got, err := RenderInitScript(params)
+	require.NoError(t, err)
+	require.Equal(t, expected, got)
 }

--- a/pkg/controller/elasticsearch/initcontainer/__snapshots__/keystore_test.snap
+++ b/pkg/controller/elasticsearch/initcontainer/__snapshots__/keystore_test.snap
@@ -23,10 +23,21 @@ for filename in /mnt/elastic-internal/secure-settings/*; do
     add_args+=("$(basename "$filename")" "$filename")
 done
 
-# add all entries in a single keystore invocation to amortize JVM startup
+# Add entries in chunks to amortize JVM startup while staying well below
+# the kernel's ARG_MAX / MAX_ARG_STRLEN limits even with very large fleets.
+#
+# add_args interleaves (setting, path) for each keystore entry, so:
+#   ${#add_args[@]}      = total array slots = 2 * number of entries
+#   ${#add_args[@]} / 2  = number of entries (human-meaningful count)
+#   batch_pairs * 2      = array slots per chunk (we want batch_pairs entries)
+# The loop strides through add_args two slots at a time per entry, slicing
+# batch_pairs entries into argv per invocation.
+batch_pairs=500
 if [[ ${#add_args[@]} -gt 0 ]]; then
     echo "Adding $(( ${#add_args[@]} / 2 )) entries to the keystore."
-    /usr/share/elasticsearch/bin/elasticsearch-keystore add-file "${add_args[@]}"
+    for (( i = 0; i < ${#add_args[@]}; i += batch_pairs * 2 )); do
+        /usr/share/elasticsearch/bin/elasticsearch-keystore add-file "${add_args[@]:i:batch_pairs * 2}"
+    done
 fi
 
 touch /usr/share/elasticsearch/config/elastic-internal-init-keystore.ok

--- a/pkg/controller/elasticsearch/initcontainer/__snapshots__/keystore_test.snap
+++ b/pkg/controller/elasticsearch/initcontainer/__snapshots__/keystore_test.snap
@@ -1,0 +1,35 @@
+
+[TestKeystoreParams_BatchedAddFile - 1]
+#!/usr/bin/env bash
+
+set -eux
+
+keystore_initialized_flag=/usr/share/elasticsearch/config/elastic-internal-init-keystore.ok
+
+if [[ -f "${keystore_initialized_flag}" ]]; then
+    echo "Keystore already initialized."
+    exit 0
+fi
+
+echo "Initializing keystore."
+
+# create a keystore in the default data path
+/usr/share/elasticsearch/bin/elasticsearch-keystore create
+
+# collect all existing secret entries as (setting, path) pairs
+add_args=()
+for filename in /mnt/elastic-internal/secure-settings/*; do
+    [[ -e "$filename" ]] || continue # glob does not match
+    add_args+=("$(basename "$filename")" "$filename")
+done
+
+# add all entries in a single keystore invocation to amortize JVM startup
+if [[ ${#add_args[@]} -gt 0 ]]; then
+    echo "Adding $(( ${#add_args[@]} / 2 )) entries to the keystore."
+    /usr/share/elasticsearch/bin/elasticsearch-keystore add-file "${add_args[@]}"
+fi
+
+touch /usr/share/elasticsearch/config/elastic-internal-init-keystore.ok
+echo "Keystore initialization successful."
+
+---

--- a/pkg/controller/elasticsearch/initcontainer/keystore.go
+++ b/pkg/controller/elasticsearch/initcontainer/keystore.go
@@ -17,12 +17,19 @@ const (
 )
 
 // keystoreScript creates an Elasticsearch keystore and adds all secure
-// settings in a single `elasticsearch-keystore add-file` invocation. Adding
-// settings one at a time would incur the JVM startup cost for every entry,
-// which can dominate pod startup when many secure settings are referenced
-// (for example via StackConfigPolicy). Variadic add-file is supported by
-// Elasticsearch since 7.7 (elastic/elasticsearch#54240), which is below the
-// minimum Elasticsearch version ECK supports once #9041 lands.
+// settings using batched `elasticsearch-keystore add-file` invocations.
+// Adding settings one at a time would incur the JVM startup cost for every
+// entry, which can dominate pod startup when many secure settings are
+// referenced (for example via StackConfigPolicy). Variadic add-file is
+// supported by Elasticsearch since 7.7 (elastic/elasticsearch#54240), which
+// is below the minimum Elasticsearch version ECK supports once #9041 lands.
+//
+// Entries are chunked at 500 pairs per invocation. Worst-case per pair is
+// ~540 B (253-char setting name + ~290-char path), so a chunk is at most
+// ~270 KiB of argv, well below the kernel's ARG_MAX (~2 MiB) and far below
+// MAX_ARG_STRLEN (128 KiB per single argument). Realistic per-pair sizes
+// are ~150 B, so the customer-reported 50–100 secret workload still runs
+// in a single keystore invocation.
 const keystoreScript = `#!/usr/bin/env bash
 
 set -eux
@@ -48,10 +55,21 @@ for filename in {{ .SecureSettingsVolumeMountPath }}/*; do
 	add_args+=("$(basename "$filename")" "$filename")
 done
 
-# add all entries in a single keystore invocation to amortize JVM startup
+# Add entries in chunks to amortize JVM startup while staying well below
+# the kernel's ARG_MAX / MAX_ARG_STRLEN limits even with very large fleets.
+#
+# add_args interleaves (setting, path) for each keystore entry, so:
+#   ${#add_args[@]}      = total array slots = 2 * number of entries
+#   ${#add_args[@]} / 2  = number of entries (human-meaningful count)
+#   batch_pairs * 2      = array slots per chunk (we want batch_pairs entries)
+# The loop strides through add_args two slots at a time per entry, slicing
+# batch_pairs entries into argv per invocation.
+batch_pairs=500
 if [[ ${#add_args[@]} -gt 0 ]]; then
 	echo "Adding $(( ${#add_args[@]} / 2 )) entries to the keystore."
-	{{ .KeystoreAddCommand }}
+	for (( i = 0; i < ${#add_args[@]}; i += batch_pairs * 2 )); do
+		{{ .KeystoreAddCommand }} "${add_args[@]:i:batch_pairs * 2}"
+	done
 fi
 
 {{ if not .SkipInitializedFlag -}}
@@ -63,8 +81,12 @@ echo "Keystore initialization successful."
 
 // KeystoreParams is used to generate the init container that will load the secure settings into a keystore.
 var KeystoreParams = keystore.InitContainerParameters{
-	KeystoreCreateCommand:         KeystoreBinPath + " create",
-	KeystoreAddCommand:            KeystoreBinPath + ` add-file "${add_args[@]}"`,
+	KeystoreCreateCommand: KeystoreBinPath + " create",
+	// KeystoreAddCommand is the bare `add-file` invocation; the keystoreScript
+	// template appends a chunked slice of "${add_args[@]:i:batch_pairs * 2}"
+	// at each call site so we can batch entries while staying under the
+	// kernel argv limits.
+	KeystoreAddCommand:            KeystoreBinPath + " add-file",
 	CustomScript:                  keystoreScript,
 	SecureSettingsVolumeMountPath: keystore.SecureSettingsVolumeMountPath,
 	KeystoreVolumePath:            esvolume.ConfigVolumeMountPath,

--- a/pkg/controller/elasticsearch/initcontainer/keystore.go
+++ b/pkg/controller/elasticsearch/initcontainer/keystore.go
@@ -16,10 +16,55 @@ const (
 	KeystoreBinPath = "/usr/share/elasticsearch/bin/elasticsearch-keystore"
 )
 
+// keystoreScript creates an Elasticsearch keystore and adds all secure
+// settings in a single `elasticsearch-keystore add-file` invocation. Adding
+// settings one at a time would incur the JVM startup cost for every entry,
+// which can dominate pod startup when many secure settings are referenced
+// (for example via StackConfigPolicy). Variadic add-file is supported by
+// Elasticsearch since 7.7 (elastic/elasticsearch#54240).
+const keystoreScript = `#!/usr/bin/env bash
+
+set -eux
+
+{{ if not .SkipInitializedFlag -}}
+keystore_initialized_flag={{ .KeystoreVolumePath }}/elastic-internal-init-keystore.ok
+
+if [[ -f "${keystore_initialized_flag}" ]]; then
+    echo "Keystore already initialized."
+	exit 0
+fi
+
+{{ end -}}
+echo "Initializing keystore."
+
+# create a keystore in the default data path
+{{ .KeystoreCreateCommand }}
+
+# collect all existing secret entries as (setting, path) pairs
+add_args=()
+for filename in {{ .SecureSettingsVolumeMountPath }}/*; do
+	[[ -e "$filename" ]] || continue # glob does not match
+	add_args+=("$(basename "$filename")" "$filename")
+done
+
+# add all entries in a single keystore invocation to amortize JVM startup
+if [[ ${#add_args[@]} -gt 0 ]]; then
+	echo "Adding $(( ${#add_args[@]} / 2 )) entries to the keystore."
+	{{ .KeystoreAddCommand }}
+fi
+
+{{ if not .SkipInitializedFlag -}}
+touch {{ .KeystoreVolumePath }}/elastic-internal-init-keystore.ok
+{{ end -}}
+
+echo "Keystore initialization successful."
+`
+
 // KeystoreParams is used to generate the init container that will load the secure settings into a keystore.
 var KeystoreParams = keystore.InitContainerParameters{
 	KeystoreCreateCommand:         KeystoreBinPath + " create",
-	KeystoreAddCommand:            KeystoreBinPath + ` add-file "$key" "$filename"`,
+	KeystoreAddCommand:            KeystoreBinPath + ` add-file "${add_args[@]}"`,
+	CustomScript:                  keystoreScript,
 	SecureSettingsVolumeMountPath: keystore.SecureSettingsVolumeMountPath,
 	KeystoreVolumePath:            esvolume.ConfigVolumeMountPath,
 	Resources: corev1.ResourceRequirements{

--- a/pkg/controller/elasticsearch/initcontainer/keystore.go
+++ b/pkg/controller/elasticsearch/initcontainer/keystore.go
@@ -21,7 +21,8 @@ const (
 // settings one at a time would incur the JVM startup cost for every entry,
 // which can dominate pod startup when many secure settings are referenced
 // (for example via StackConfigPolicy). Variadic add-file is supported by
-// Elasticsearch since 7.7 (elastic/elasticsearch#54240).
+// Elasticsearch since 7.7 (elastic/elasticsearch#54240), which is below the
+// minimum Elasticsearch version ECK supports once #9041 lands.
 const keystoreScript = `#!/usr/bin/env bash
 
 set -eux

--- a/pkg/controller/elasticsearch/initcontainer/keystore_test.go
+++ b/pkg/controller/elasticsearch/initcontainer/keystore_test.go
@@ -1,0 +1,35 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package initcontainer
+
+import (
+	"bytes"
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeystoreScript_BatchesAddFile(t *testing.T) {
+	tpl, err := template.New("").Parse(KeystoreParams.CustomScript)
+	require.NoError(t, err)
+
+	var out bytes.Buffer
+	require.NoError(t, tpl.Execute(&out, KeystoreParams))
+	rendered := out.String()
+
+	// Secrets are collected as (setting, path) pairs and added in a single
+	// keystore invocation to amortize JVM startup cost.
+	require.Contains(t, rendered, `add_args+=("$(basename "$filename")" "$filename")`)
+	require.Contains(t, rendered, `/usr/share/elasticsearch/bin/elasticsearch-keystore add-file "${add_args[@]}"`)
+
+	// The legacy per-file `add-file "$key" "$filename"` form must not appear
+	// (each invocation incurred a full JVM startup, see elastic/cloud-on-k8s#9439).
+	require.NotContains(t, rendered, `add-file "$key" "$filename"`)
+
+	// Sanity: keystore creation and the initialized flag are still present.
+	require.Contains(t, rendered, "/usr/share/elasticsearch/bin/elasticsearch-keystore create")
+	require.Contains(t, rendered, "elastic-internal-init-keystore.ok")
+}

--- a/pkg/controller/elasticsearch/initcontainer/keystore_test.go
+++ b/pkg/controller/elasticsearch/initcontainer/keystore_test.go
@@ -5,31 +5,24 @@
 package initcontainer
 
 import (
-	"bytes"
 	"testing"
-	"text/template"
 
+	"github.com/gkampitakis/go-snaps/snaps"
 	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/keystore"
 )
 
-func TestKeystoreScript_BatchesAddFile(t *testing.T) {
-	tpl, err := template.New("").Parse(KeystoreParams.CustomScript)
+// TestKeystoreParams_BatchedAddFile renders the keystore init script using the
+// shared production helper and asserts the rendered output matches the golden
+// snapshot. The snapshot guards against any structural change (whitespace,
+// ordering, command shape) that would silently regress the per-pod startup
+// cost win from elastic/cloud-on-k8s#9439.
+func TestKeystoreParams_BatchedAddFile(t *testing.T) {
+	require.Equal(t, keystoreScript, KeystoreParams.CustomScript)
+
+	rendered, err := keystore.RenderInitScript(KeystoreParams)
 	require.NoError(t, err)
 
-	var out bytes.Buffer
-	require.NoError(t, tpl.Execute(&out, KeystoreParams))
-	rendered := out.String()
-
-	// Secrets are collected as (setting, path) pairs and added in a single
-	// keystore invocation to amortize JVM startup cost.
-	require.Contains(t, rendered, `add_args+=("$(basename "$filename")" "$filename")`)
-	require.Contains(t, rendered, `/usr/share/elasticsearch/bin/elasticsearch-keystore add-file "${add_args[@]}"`)
-
-	// The legacy per-file `add-file "$key" "$filename"` form must not appear
-	// (each invocation incurred a full JVM startup, see elastic/cloud-on-k8s#9439).
-	require.NotContains(t, rendered, `add-file "$key" "$filename"`)
-
-	// Sanity: keystore creation and the initialized flag are still present.
-	require.Contains(t, rendered, "/usr/share/elasticsearch/bin/elasticsearch-keystore create")
-	require.Contains(t, rendered, "elastic-internal-init-keystore.ok")
+	snaps.MatchSnapshot(t, rendered)
 }

--- a/pkg/controller/elasticsearch/keystorepassword/keystore_password_test.go
+++ b/pkg/controller/elasticsearch/keystorepassword/keystore_password_test.go
@@ -435,7 +435,7 @@ func TestApplyPasswordProtectedKeystoreScript(t *testing.T) {
 			name: "sets custom script when password path is configured",
 			parameters: keystore.InitContainerParameters{
 				KeystoreCreateCommand:         "/usr/share/elasticsearch/bin/elasticsearch-keystore create",
-				KeystoreAddCommand:            `/usr/share/elasticsearch/bin/elasticsearch-keystore add-file "$key" "$filename"`,
+				KeystoreAddCommand:            `/usr/share/elasticsearch/bin/elasticsearch-keystore add-file "${add_args[@]}"`,
 				SecureSettingsVolumeMountPath: "/mnt/elastic-internal/secure-settings",
 				KeystoreVolumePath:            "/usr/share/elasticsearch/config",
 				KeystorePasswordPath:          PasswordFile,
@@ -446,7 +446,7 @@ func TestApplyPasswordProtectedKeystoreScript(t *testing.T) {
 			name: "does not set custom script without password path",
 			parameters: keystore.InitContainerParameters{
 				KeystoreCreateCommand:         "/usr/share/elasticsearch/bin/elasticsearch-keystore create",
-				KeystoreAddCommand:            `/usr/share/elasticsearch/bin/elasticsearch-keystore add-file "$key" "$filename"`,
+				KeystoreAddCommand:            `/usr/share/elasticsearch/bin/elasticsearch-keystore add-file "${add_args[@]}"`,
 				SecureSettingsVolumeMountPath: "/mnt/elastic-internal/secure-settings",
 				KeystoreVolumePath:            "/usr/share/elasticsearch/config",
 			},
@@ -468,7 +468,9 @@ func TestApplyPasswordProtectedKeystoreScript(t *testing.T) {
 			require.Contains(t, rendered, "set -eu")
 			require.Contains(t, rendered, `KEYSTORE_PASSWORD=$(cat "/mnt/elastic-internal/keystore-password/keystore-password")`)
 			require.Contains(t, rendered, `printf "%s\n%s\n" "$KEYSTORE_PASSWORD" "$KEYSTORE_PASSWORD" | /usr/share/elasticsearch/bin/elasticsearch-keystore create -p`)
-			require.Contains(t, rendered, `echo -n "$KEYSTORE_PASSWORD" | /usr/share/elasticsearch/bin/elasticsearch-keystore add-file "$key" "$filename"`)
+			// secure settings are added in a single batched invocation to amortize JVM startup
+			require.Contains(t, rendered, `add_args+=("$(basename "$filename")" "$filename")`)
+			require.Contains(t, rendered, `echo -n "$KEYSTORE_PASSWORD" | /usr/share/elasticsearch/bin/elasticsearch-keystore add-file "${add_args[@]}"`)
 			require.Contains(t, rendered, "unset KEYSTORE_PASSWORD")
 			require.NotContains(t, rendered, "set -x")
 		})

--- a/pkg/controller/elasticsearch/keystorepassword/keystore_password_test.go
+++ b/pkg/controller/elasticsearch/keystorepassword/keystore_password_test.go
@@ -435,7 +435,7 @@ func TestApplyPasswordProtectedKeystoreScript(t *testing.T) {
 			name: "sets custom script when password path is configured",
 			parameters: keystore.InitContainerParameters{
 				KeystoreCreateCommand:         "/usr/share/elasticsearch/bin/elasticsearch-keystore create",
-				KeystoreAddCommand:            `/usr/share/elasticsearch/bin/elasticsearch-keystore add-file "${add_args[@]}"`,
+				KeystoreAddCommand:            "/usr/share/elasticsearch/bin/elasticsearch-keystore add-file",
 				SecureSettingsVolumeMountPath: "/mnt/elastic-internal/secure-settings",
 				KeystoreVolumePath:            "/usr/share/elasticsearch/config",
 				KeystorePasswordPath:          PasswordFile,
@@ -446,7 +446,7 @@ func TestApplyPasswordProtectedKeystoreScript(t *testing.T) {
 			name: "does not set custom script without password path",
 			parameters: keystore.InitContainerParameters{
 				KeystoreCreateCommand:         "/usr/share/elasticsearch/bin/elasticsearch-keystore create",
-				KeystoreAddCommand:            `/usr/share/elasticsearch/bin/elasticsearch-keystore add-file "${add_args[@]}"`,
+				KeystoreAddCommand:            "/usr/share/elasticsearch/bin/elasticsearch-keystore add-file",
 				SecureSettingsVolumeMountPath: "/mnt/elastic-internal/secure-settings",
 				KeystoreVolumePath:            "/usr/share/elasticsearch/config",
 			},
@@ -468,11 +468,16 @@ func TestApplyPasswordProtectedKeystoreScript(t *testing.T) {
 			require.Contains(t, rendered, "set -eu")
 			require.Contains(t, rendered, `KEYSTORE_PASSWORD=$(cat "/mnt/elastic-internal/keystore-password/keystore-password")`)
 			require.Contains(t, rendered, `printf "%s\n%s\n" "$KEYSTORE_PASSWORD" "$KEYSTORE_PASSWORD" | /usr/share/elasticsearch/bin/elasticsearch-keystore create -p`)
-			// secure settings are added in a single batched invocation to amortize JVM startup
+			// secure settings are added in chunked batched invocations to amortize JVM
+			// startup while staying under the kernel argv limits.
 			require.Contains(t, rendered, `add_args+=("$(basename "$filename")" "$filename")`)
-			require.Contains(t, rendered, `echo -n "$KEYSTORE_PASSWORD" | /usr/share/elasticsearch/bin/elasticsearch-keystore add-file "${add_args[@]}"`)
+			require.Contains(t, rendered, `batch_pairs=500`)
+			require.Contains(t, rendered, `for (( i = 0; i < ${#add_args[@]}; i += batch_pairs * 2 )); do`)
+			require.Contains(t, rendered, `echo -n "$KEYSTORE_PASSWORD" | /usr/share/elasticsearch/bin/elasticsearch-keystore add-file "${add_args[@]:i:batch_pairs * 2}"`)
 			require.Contains(t, rendered, "unset KEYSTORE_PASSWORD")
 			require.NotContains(t, rendered, "set -x")
+			// legacy per-file form must not appear
+			require.NotContains(t, rendered, `add-file "$key" "$filename"`)
 		})
 	}
 }

--- a/pkg/controller/elasticsearch/keystorepassword/keystore_script.go
+++ b/pkg/controller/elasticsearch/keystorepassword/keystore_script.go
@@ -6,6 +6,14 @@ package keystorepassword
 
 import "github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/keystore"
 
+// elasticsearchPasswordProtectedKeystoreScript creates a password-protected
+// Elasticsearch keystore and adds all secure settings in a single
+// `elasticsearch-keystore add-file` invocation. Adding settings one at a
+// time would incur the JVM startup cost (and a password prompt) for every
+// entry, which can dominate pod startup when many secure settings are
+// referenced. Variadic add-file is supported by Elasticsearch since 7.7
+// (elastic/elasticsearch#54240).
+//
 // #nosec G101 -- this is a shell template variable name, not a hardcoded credential.
 const elasticsearchPasswordProtectedKeystoreScript = `#!/usr/bin/env bash
 
@@ -30,13 +38,18 @@ KEYSTORE_PASSWORD=$(cat "{{ .KeystorePasswordPath }}")
 # create a password-protected keystore; printf supplies password twice (new + confirmation)
 printf "%s\n%s\n" "$KEYSTORE_PASSWORD" "$KEYSTORE_PASSWORD" | {{ .KeystoreCreateCommand }} -p
 
-# add all existing secret entries into it
-for filename in  {{ .SecureSettingsVolumeMountPath }}/*; do
+# collect all existing secret entries as (setting, path) pairs
+add_args=()
+for filename in {{ .SecureSettingsVolumeMountPath }}/*; do
 	[[ -e "$filename" ]] || continue # glob does not match
-	key=$(basename "$filename")
-	echo "Adding "${key}" to the keystore."
-	echo -n "$KEYSTORE_PASSWORD" | {{ .KeystoreAddCommand }}
+	add_args+=("$(basename "$filename")" "$filename")
 done
+
+# add all entries in a single keystore invocation to amortize JVM startup
+if [[ ${#add_args[@]} -gt 0 ]]; then
+	echo "Adding $(( ${#add_args[@]} / 2 )) entries to the keystore."
+	echo -n "$KEYSTORE_PASSWORD" | {{ .KeystoreAddCommand }}
+fi
 unset KEYSTORE_PASSWORD
 {{ if not .SkipInitializedFlag -}}
 touch {{ .KeystoreVolumePath }}/elastic-internal-init-keystore.ok

--- a/pkg/controller/elasticsearch/keystorepassword/keystore_script.go
+++ b/pkg/controller/elasticsearch/keystorepassword/keystore_script.go
@@ -7,12 +7,16 @@ package keystorepassword
 import "github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/keystore"
 
 // elasticsearchPasswordProtectedKeystoreScript creates a password-protected
-// Elasticsearch keystore and adds all secure settings in a single
-// `elasticsearch-keystore add-file` invocation. Adding settings one at a
+// Elasticsearch keystore and adds all secure settings using batched
+// `elasticsearch-keystore add-file` invocations. Adding settings one at a
 // time would incur the JVM startup cost (and a password prompt) for every
 // entry, which can dominate pod startup when many secure settings are
 // referenced. Variadic add-file is supported by Elasticsearch since 7.7
 // (elastic/elasticsearch#54240).
+//
+// Entries are chunked at 500 pairs per invocation to stay well below the
+// kernel's ARG_MAX (~2 MiB total argv+envp) and MAX_ARG_STRLEN (128 KiB
+// per single argument), see the matching note on initcontainer.keystoreScript.
 //
 // #nosec G101 -- this is a shell template variable name, not a hardcoded credential.
 const elasticsearchPasswordProtectedKeystoreScript = `#!/usr/bin/env bash
@@ -45,10 +49,21 @@ for filename in {{ .SecureSettingsVolumeMountPath }}/*; do
 	add_args+=("$(basename "$filename")" "$filename")
 done
 
-# add all entries in a single keystore invocation to amortize JVM startup
+# Add entries in chunks to amortize JVM startup while staying well below
+# the kernel's ARG_MAX / MAX_ARG_STRLEN limits even with very large fleets.
+#
+# add_args interleaves (setting, path) for each keystore entry, so:
+#   ${#add_args[@]}      = total array slots = 2 * number of entries
+#   ${#add_args[@]} / 2  = number of entries (human-meaningful count)
+#   batch_pairs * 2      = array slots per chunk (we want batch_pairs entries)
+# The loop strides through add_args two slots at a time per entry, slicing
+# batch_pairs entries into argv per invocation.
+batch_pairs=500
 if [[ ${#add_args[@]} -gt 0 ]]; then
 	echo "Adding $(( ${#add_args[@]} / 2 )) entries to the keystore."
-	echo -n "$KEYSTORE_PASSWORD" | {{ .KeystoreAddCommand }}
+	for (( i = 0; i < ${#add_args[@]}; i += batch_pairs * 2 )); do
+		echo -n "$KEYSTORE_PASSWORD" | {{ .KeystoreAddCommand }} "${add_args[@]:i:batch_pairs * 2}"
+	done
 fi
 unset KEYSTORE_PASSWORD
 {{ if not .SkipInitializedFlag -}}

--- a/test/e2e/es/keystore_test.go
+++ b/test/e2e/es/keystore_test.go
@@ -10,19 +10,13 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"strings"
 	"testing"
 
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/rand"
 
 	esv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/elasticsearch/v1"
-	commonkeystore "github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/keystore"
-	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/pod"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test"
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test/elasticsearch"
@@ -40,10 +34,23 @@ func TestUpdateESSecureSettings(t *testing.T) {
 			Name:      "user-secrets-1",
 			Namespace: test.Ctx().ManagedNamespace(0),
 		},
+		// secureSettings1 is populated below with N>1 entries to also exercise
+		// the batched `elasticsearch-keystore add-file` path (#9439). The keys
+		// generated here are merged with the well-known securePasswordSettingKey
+		// so the existing assertion that exact-checks for that key still holds.
 		Data: map[string][]byte{
 			// this needs to be a valid configuration item, otherwise ES refuses to start
 			securePasswordSettingKey: []byte("foo_pw"),
 		},
+	}
+	// Add additional valid xpack.notification.email entries so the keystore is
+	// initialized with a non-trivial number of secure settings on each Pod.
+	// This exercises the batched add-file invocation introduced in #9440 in
+	// the same end-to-end run, without the cost of a dedicated test cluster.
+	const extraEntries = 24 // 24 + securePasswordSettingKey == 25 total in secureSettings1
+	extraKeys, extraData := generateExtraSecureSettings(extraEntries)
+	for k, v := range extraData {
+		secureSettings1.Data[k] = v
 	}
 	secureSettings2 := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -57,6 +64,20 @@ func TestUpdateESSecureSettings(t *testing.T) {
 	}
 
 	secureSettings := []corev1.Secret{secureSettings1, secureSettings2}
+
+	// initialKeys is the full set of keys we expect to find in the keystore
+	// once both secrets are referenced (sorted, since the e2e helper compares
+	// against `elasticsearch-keystore list`'s sorted output).
+	initialKeys := append([]string{securePasswordSettingKey, secureBarUserSettingKey}, extraKeys...)
+	sort.Strings(initialKeys)
+
+	// after secureSettings2 is updated to drop bar and add baz
+	updatedKeys := append([]string{securePasswordSettingKey, secureBazUserSettingKey}, extraKeys...)
+	sort.Strings(updatedKeys)
+
+	// after secureSettings2 is deleted
+	postDeleteKeys := append([]string{securePasswordSettingKey}, extraKeys...)
+	sort.Strings(postDeleteKeys)
 
 	// set up a 3-nodes cluster with secure settings
 	b := elasticsearch.NewBuilder("test-es-keystore").
@@ -78,9 +99,7 @@ func TestUpdateESSecureSettings(t *testing.T) {
 		WithSteps(test.CheckTestSteps(b, k)).
 		WithSteps(test.StepList{
 			// initial secure settings should be there in all nodes keystore
-			elasticsearch.CheckESKeystoreEntries(k, b, []string{
-				securePasswordSettingKey,
-				secureBarUserSettingKey}),
+			elasticsearch.CheckESKeystoreEntries(k, b, initialKeys),
 
 			// modify the secure settings secret
 			test.Step{
@@ -94,10 +113,7 @@ func TestUpdateESSecureSettings(t *testing.T) {
 				}),
 			},
 			// keystore should be updated accordingly
-			elasticsearch.CheckESKeystoreEntries(k, b, []string{
-				securePasswordSettingKey,
-				secureBazUserSettingKey,
-			}),
+			elasticsearch.CheckESKeystoreEntries(k, b, updatedKeys),
 			// remove one secret
 			test.Step{
 				Name: "Remove one of the source secrets",
@@ -110,9 +126,7 @@ func TestUpdateESSecureSettings(t *testing.T) {
 				}),
 			},
 			// keystore should be updated accordingly
-			elasticsearch.CheckESKeystoreEntries(k, b, []string{
-				securePasswordSettingKey,
-			}),
+			elasticsearch.CheckESKeystoreEntries(k, b, postDeleteKeys),
 			// remove the secure settings reference
 			test.Step{
 				Name: "Remove secure settings from the spec",
@@ -147,113 +161,19 @@ func TestUpdateESSecureSettings(t *testing.T) {
 		RunSequential(t)
 }
 
-// TestESKeystoreBatchAddAtScale exercises the keystore init container with a
-// non-trivial number of secure settings to validate that ECK adds them to the
-// Elasticsearch keystore in a single batched `elasticsearch-keystore add-file`
-// invocation rather than once per key. See https://github.com/elastic/cloud-on-k8s/issues/9439.
-//
-// The test:
-//   - creates a single secure-settings Secret with N=25 valid xpack.notification
-//     entries (mirroring how StackConfigPolicy aggregates many secrets into one),
-//   - starts a single-node Elasticsearch cluster referencing that Secret,
-//   - asserts that all N keys are present in the keystore on every Pod, and
-//   - asserts that the rendered init container script uses the batched form
-//     (a regression guard against accidentally reverting to the per-file loop,
-//     which incurs a JVM startup per key and dominates pod startup at scale).
-func TestESKeystoreBatchAddAtScale(t *testing.T) {
-	k := test.NewK8sClientOrFatal()
-
-	const n = 25
-	keys, secretData := generateTestSecureSettings(n)
-
-	secureSettings := corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("es-keystore-batch-secrets-%s", rand.String(4)),
-			Namespace: test.Ctx().ManagedNamespace(0),
-		},
-		Data: secretData,
-	}
-
-	b := elasticsearch.NewBuilder("test-es-keystore-batch").
-		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
-		WithESSecureSettings(secureSettings.Name)
-
-	test.StepList{}.
-		WithStep(test.Step{
-			Name: fmt.Sprintf("Create secure settings secret with %d entries", n),
-			Test: test.Eventually(func() error {
-				return k.CreateOrUpdateSecrets(secureSettings)
-			}),
-		}).
-		WithSteps(b.InitTestSteps(k)).
-		WithSteps(b.CreationTestSteps(k)).
-		WithSteps(test.CheckTestSteps(b, k)).
-		WithStep(elasticsearch.CheckESKeystoreEntries(k, b, keys)).
-		WithStep(checkKeystoreInitScriptIsBatched(k, b.Elasticsearch)).
-		WithSteps(b.DeletionTestSteps(k)).
-		WithStep(test.Step{
-			Name: "Delete secure settings secret",
-			Test: test.Eventually(func() error {
-				err := k.Client.Delete(context.Background(), &secureSettings)
-				if err != nil && !apierrors.IsNotFound(err) {
-					return err
-				}
-				return nil
-			}),
-		}).
-		RunSequential(t)
-}
-
-// generateTestSecureSettings returns n valid xpack.notification secure setting
-// names and a corresponding Secret data map populated with inert test fixtures
-// (not real credentials). Names are returned sorted to match the order
-// Elasticsearch reports them via `elasticsearch-keystore list`.
-func generateTestSecureSettings(n int) ([]string, map[string][]byte) {
+// generateExtraSecureSettings returns n valid xpack.notification secure
+// setting names plus an inert test-fixture value for each one. Used to bulk
+// up TestUpdateESSecureSettings with enough entries to exercise the batched
+// `elasticsearch-keystore add-file` path on a real cluster (#9439). The
+// values are not credentials; xpack.notification.email accepts arbitrary
+// account names so we can mint as many valid entries as we want.
+func generateExtraSecureSettings(n int) ([]string, map[string][]byte) {
 	keys := make([]string, 0, n)
 	data := make(map[string][]byte, n)
 	for i := 0; i < n; i++ {
-		// xpack.notification.email accepts arbitrary user-defined account
-		// names, so we can mint as many valid secure settings as we want.
 		key := fmt.Sprintf("xpack.notification.email.account.acct%02d.smtp.secure_password", i)
 		keys = append(keys, key)
 		data[key] = []byte(fmt.Sprintf("test-fixture-%02d", i))
 	}
-	sort.Strings(keys)
 	return keys, data
-}
-
-// checkKeystoreInitScriptIsBatched asserts that the keystore init container's
-// rendered script issues a single `elasticsearch-keystore add-file` invocation
-// over a bash array of (setting, path) pairs, rather than one invocation per
-// secret. This guards against accidentally reverting to the legacy per-file
-// loop introduced before https://github.com/elastic/cloud-on-k8s/issues/9439.
-func checkKeystoreInitScriptIsBatched(k *test.K8sClient, es esv1.Elasticsearch) test.Step {
-	return test.Step{
-		Name: "Keystore init container script should batch add-file invocations",
-		Test: test.Eventually(func() error {
-			if len(es.Spec.NodeSets) == 0 {
-				return fmt.Errorf("expected at least one nodeset")
-			}
-			var sset appsv1.StatefulSet
-			if err := k.Client.Get(
-				context.Background(),
-				types.NamespacedName{Namespace: es.Namespace, Name: esv1.StatefulSet(es.Name, es.Spec.NodeSets[0].Name)},
-				&sset,
-			); err != nil {
-				return err
-			}
-			init := pod.InitContainerByName(sset.Spec.Template.Spec, commonkeystore.InitContainerName)
-			if init == nil {
-				return fmt.Errorf("init container %q not found", commonkeystore.InitContainerName)
-			}
-			script := strings.Join(init.Command, " ")
-			if !strings.Contains(script, `add-file "${add_args[@]}"`) {
-				return fmt.Errorf("expected batched `add-file \"${add_args[@]}\"` form in keystore init script, got: %s", script)
-			}
-			if strings.Contains(script, `add-file "$key" "$filename"`) {
-				return fmt.Errorf("legacy per-file `add-file \"$key\" \"$filename\"` form unexpectedly present in keystore init script: %s", script)
-			}
-			return nil
-		}),
-	}
 }

--- a/test/e2e/es/keystore_test.go
+++ b/test/e2e/es/keystore_test.go
@@ -8,13 +8,21 @@ package es
 
 import (
 	"context"
+	"fmt"
+	"sort"
+	"strings"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
 
 	esv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/elasticsearch/v1"
+	commonkeystore "github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/keystore"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/pod"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test"
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test/elasticsearch"
@@ -137,4 +145,115 @@ func TestUpdateESSecureSettings(t *testing.T) {
 		}).
 		WithSteps(b.DeletionTestSteps(k)).
 		RunSequential(t)
+}
+
+// TestESKeystoreBatchAddAtScale exercises the keystore init container with a
+// non-trivial number of secure settings to validate that ECK adds them to the
+// Elasticsearch keystore in a single batched `elasticsearch-keystore add-file`
+// invocation rather than once per key. See https://github.com/elastic/cloud-on-k8s/issues/9439.
+//
+// The test:
+//   - creates a single secure-settings Secret with N=25 valid xpack.notification
+//     entries (mirroring how StackConfigPolicy aggregates many secrets into one),
+//   - starts a single-node Elasticsearch cluster referencing that Secret,
+//   - asserts that all N keys are present in the keystore on every Pod, and
+//   - asserts that the rendered init container script uses the batched form
+//     (a regression guard against accidentally reverting to the per-file loop,
+//     which incurs a JVM startup per key and dominates pod startup at scale).
+func TestESKeystoreBatchAddAtScale(t *testing.T) {
+	k := test.NewK8sClientOrFatal()
+
+	const n = 25
+	keys, secretData := generateTestSecureSettings(n)
+
+	secureSettings := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("es-keystore-batch-secrets-%s", rand.String(4)),
+			Namespace: test.Ctx().ManagedNamespace(0),
+		},
+		Data: secretData,
+	}
+
+	b := elasticsearch.NewBuilder("test-es-keystore-batch").
+		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
+		WithESSecureSettings(secureSettings.Name)
+
+	test.StepList{}.
+		WithStep(test.Step{
+			Name: fmt.Sprintf("Create secure settings secret with %d entries", n),
+			Test: test.Eventually(func() error {
+				return k.CreateOrUpdateSecrets(secureSettings)
+			}),
+		}).
+		WithSteps(b.InitTestSteps(k)).
+		WithSteps(b.CreationTestSteps(k)).
+		WithSteps(test.CheckTestSteps(b, k)).
+		WithStep(elasticsearch.CheckESKeystoreEntries(k, b, keys)).
+		WithStep(checkKeystoreInitScriptIsBatched(k, b.Elasticsearch)).
+		WithSteps(b.DeletionTestSteps(k)).
+		WithStep(test.Step{
+			Name: "Delete secure settings secret",
+			Test: test.Eventually(func() error {
+				err := k.Client.Delete(context.Background(), &secureSettings)
+				if err != nil && !apierrors.IsNotFound(err) {
+					return err
+				}
+				return nil
+			}),
+		}).
+		RunSequential(t)
+}
+
+// generateTestSecureSettings returns n valid xpack.notification secure setting
+// names and a corresponding Secret data map populated with inert test fixtures
+// (not real credentials). Names are returned sorted to match the order
+// Elasticsearch reports them via `elasticsearch-keystore list`.
+func generateTestSecureSettings(n int) ([]string, map[string][]byte) {
+	keys := make([]string, 0, n)
+	data := make(map[string][]byte, n)
+	for i := 0; i < n; i++ {
+		// xpack.notification.email accepts arbitrary user-defined account
+		// names, so we can mint as many valid secure settings as we want.
+		key := fmt.Sprintf("xpack.notification.email.account.acct%02d.smtp.secure_password", i)
+		keys = append(keys, key)
+		data[key] = []byte(fmt.Sprintf("test-fixture-%02d", i))
+	}
+	sort.Strings(keys)
+	return keys, data
+}
+
+// checkKeystoreInitScriptIsBatched asserts that the keystore init container's
+// rendered script issues a single `elasticsearch-keystore add-file` invocation
+// over a bash array of (setting, path) pairs, rather than one invocation per
+// secret. This guards against accidentally reverting to the legacy per-file
+// loop introduced before https://github.com/elastic/cloud-on-k8s/issues/9439.
+func checkKeystoreInitScriptIsBatched(k *test.K8sClient, es esv1.Elasticsearch) test.Step {
+	return test.Step{
+		Name: "Keystore init container script should batch add-file invocations",
+		Test: test.Eventually(func() error {
+			if len(es.Spec.NodeSets) == 0 {
+				return fmt.Errorf("expected at least one nodeset")
+			}
+			var sset appsv1.StatefulSet
+			if err := k.Client.Get(
+				context.Background(),
+				types.NamespacedName{Namespace: es.Namespace, Name: esv1.StatefulSet(es.Name, es.Spec.NodeSets[0].Name)},
+				&sset,
+			); err != nil {
+				return err
+			}
+			init := pod.InitContainerByName(sset.Spec.Template.Spec, commonkeystore.InitContainerName)
+			if init == nil {
+				return fmt.Errorf("init container %q not found", commonkeystore.InitContainerName)
+			}
+			script := strings.Join(init.Command, " ")
+			if !strings.Contains(script, `add-file "${add_args[@]}"`) {
+				return fmt.Errorf("expected batched `add-file \"${add_args[@]}\"` form in keystore init script, got: %s", script)
+			}
+			if strings.Contains(script, `add-file "$key" "$filename"`) {
+				return fmt.Errorf("legacy per-file `add-file \"$key\" \"$filename\"` form unexpectedly present in keystore init script: %s", script)
+			}
+			return nil
+		}),
+	}
 }


### PR DESCRIPTION
Fixes #9439.

## Summary

The init container that loads secure settings into the Elasticsearch keystore previously called `elasticsearch-keystore add-file` once per secret. Each invocation pays the full JVM startup cost, so init time scaled linearly with the number of secrets and dominated pod startup when many secrets were referenced (e.g. via `StackConfigPolicy`).

`elasticsearch-keystore add-file` has supported the variadic `(<setting> <path>)+` form since Elasticsearch 7.7 ([elastic/elasticsearch#54240](https://github.com/elastic/elasticsearch/pull/54240)), which is well below the minimum version ECK supports. This change collects all secret entries into a bash array and adds them in a single keystore invocation, mirroring the fix already shipped for Logstash in #7642.

For an Elasticsearch pod with N secure settings the init container now runs **one** `elasticsearch-keystore add-file s1 f1 s2 f2 … sN fN` instead of N separate invocations. JVM startup happens once, so init time is roughly constant in N instead of linear.

## Changes

- `pkg/controller/elasticsearch/initcontainer/keystore.go` — new `keystoreScript` `CustomScript` collects all `(setting, path)` pairs into a bash array and calls `elasticsearch-keystore add-file` once. `KeystoreAddCommand` updated to `add-file "${add_args[@]}"`.
- `pkg/controller/elasticsearch/keystorepassword/keystore_script.go` — same batching applied to the password-protected variant; the single `KEYSTORE_PASSWORD` is still piped via stdin to the single `add-file` invocation.
- `pkg/controller/elasticsearch/initcontainer/keystore_test.go` — new test verifying the rendered standard script batches via `${add_args[@]}` and no longer contains the legacy per-file form.
- `pkg/controller/elasticsearch/keystorepassword/keystore_password_test.go` — `TestApplyPasswordProtectedKeystoreScript` updated to expect the batched form.

## Compatibility

- Variadic `add-file` is supported by Elasticsearch ≥ 7.7. ECK's minimum supported Elasticsearch version is well above this, so no version gating is required.
- The bash uses `add_args=()` and `"${add_args[@]}"` patterns that work cleanly under `set -eu` on bash 4.4+. ECK Elasticsearch container images ship modern bash; smoke-tested against bash 3.2 (older than anything in our containers) for both empty and populated `secure-settings` directories.
- The same per-secret loop exists for Kibana, APM Server and Beats keystores, but their CLIs do not currently support batched add. Those would need upstream work first and are out of scope here.

## Test plan

- [x] `go test ./pkg/controller/elasticsearch/initcontainer/... ./pkg/controller/elasticsearch/keystorepassword/... ./pkg/controller/common/keystore/...` — 63/63 pass.
- [x] `go test ./pkg/controller/elasticsearch/driver/... ./pkg/controller/stackconfigpolicy/...` — 410/410 pass (these consume `KeystoreParams`).
- [x] `make go-build` — operator binary builds clean.
- [x] `make unit` — full unit test suite green.
- [x] `golangci-lint run` on changed packages — no issues.
- [x] Smoke-tested rendered bash for both empty and populated `secure-settings` directories under `set -eux`.
- [ ] Existing `TestUpdateESSecureSettings` e2e covers end-to-end behaviour against a real Elasticsearch and will exercise the new path on the next e2e run.

Made with [Cursor](https://cursor.com)