### PR TITLE
feat(olm): publish olm.skipRange to support sparse and air-gapped catalogs

### DIFF
--- a/hack/operatorhub/cmd/flags/flags.go
+++ b/hack/operatorhub/cmd/flags/flags.go
@@ -78,10 +78,14 @@ var (
 
 // Config is the configuration that matches the config.yaml
 type Config struct {
-	NewVersion   string `json:"newVersion"`
-	PrevVersion  string `json:"prevVersion"`
-	StackVersion string `json:"stackVersion"`
-	CRDs         []struct {
+	NewVersion     string `json:"newVersion"`
+	PrevVersion    string `json:"prevVersion"`
+	// MinSkipVersion is the oldest installed version that may upgrade directly to NewVersion via
+	// the olm.skipRange annotation, bypassing intermediate bundles. Only advance this when CRD
+	// schema compatibility from that version has been validated.
+	MinSkipVersion string `json:"minSkipVersion"`
+	StackVersion   string `json:"stackVersion"`
+	CRDs           []struct {
 		Name        string `json:"name"`
 		DisplayName string `json:"displayName"`
 		Description string `json:"description"`

--- a/hack/operatorhub/config.yaml
+++ b/hack/operatorhub/config.yaml
@@ -1,5 +1,10 @@
+# When bumping newVersion, also review minSkipVersion below.
 newVersion: 3.5.0-SNAPSHOT
 prevVersion: 3.4.0
+# minSkipVersion sets the lower bound of olm.skipRange, allowing direct upgrades from sparse/air-gapped
+# catalogs. 2.16.0 is the validated floor: no CRD storage version changes or breaking schema changes
+# exist between 2.16.0 and the current release. Do not lower this without re-validating CRD compatibility.
+minSkipVersion: 2.16.0
 stackVersion: 9.5.0-SNAPSHOT
 crds:
   - name: elasticsearches.elasticsearch.k8s.elastic.co

--- a/hack/operatorhub/internal/operatorhub/operatorhub.go
+++ b/hack/operatorhub/internal/operatorhub/operatorhub.go
@@ -376,6 +376,7 @@ type RenderParams struct {
 	NewVersion                   string
 	ShortVersion                 string
 	PrevVersion                  string
+	SkipRange                    string
 	StackVersion                 string
 	OperatorRepo                 string
 	OperatorRBAC                 string
@@ -449,10 +450,17 @@ func buildRenderParams(conf *flags.Config, packageIndex int, extracts *yamlExtra
 		tag = "@" + imageDigest
 	}
 
+	// olm.skipRange uses OLM's semver range syntax: lower bound inclusive, upper bound exclusive.
+	var skipRange string
+	if conf.MinSkipVersion != "" {
+		skipRange = fmt.Sprintf(">=%s <%s", conf.MinSkipVersion, conf.NewVersion)
+	}
+
 	return &RenderParams{
 		NewVersion:                   conf.NewVersion,
 		ShortVersion:                 strings.Join(versionParts[:2], "."),
 		PrevVersion:                  conf.PrevVersion,
+		SkipRange:                    skipRange,
 		StackVersion:                 conf.StackVersion,
 		OperatorRepo:                 conf.Packages[packageIndex].OperatorRepo,
 		AdditionalArgs:               additionalArgs,

--- a/hack/operatorhub/templates/csv.tpl
+++ b/hack/operatorhub/templates/csv.tpl
@@ -11,6 +11,9 @@ metadata:
     repository: https://github.com/elastic/cloud-on-k8s
     support: elastic.co
     operators.openshift.io/valid-subscription: "Elastic Basic license"
+    {{- if .SkipRange }}
+    olm.skipRange: '{{ .SkipRange }}'
+    {{- end }}
     features.operators.openshift.io/disconnected: "false"
     features.operators.openshift.io/fips-compliant: "false"
     features.operators.openshift.io/proxy-aware: "false"


### PR DESCRIPTION
## Summary

- Adds `olm.skipRange` annotation to the generated `ClusterServiceVersion`, allowing OLM
  to upgrade directly from any installed ECK version `>= 2.16.0` to the current bundle
  without requiring every intermediate bundle to be present in the index.
- Introduces `minSkipVersion` in `config.yaml` as the configurable lower bound, with a
  comment nudging reviewers to re-evaluate it when `newVersion` is bumped.

## Why 2.16.0

The lower bound was validated by diffing CRD manifests across all 2.16.x and 3.x releases:
- No CRD storage version changes (no conversion webhooks needed)
- No breaking schema changes (fields removed, types changed, required fields added)
- No version-gated migration logic in the operator
- Two new CRDs added in 3.x (AutoOps, PackageRegistry) are purely additive

2.16.0 is the oldest release in the last two major versions where a direct upgrade to the
current release is safe. Going below 2.16.0 would require a separate audit of 2.0.0–2.15.x.

## Generated output (example for 3.5.0)

```yaml
metadata:
  annotations:
    olm.skipRange: '>=2.16.0 <3.5.0'
```

Closes #9414