### PR TITLE
Map plain URLs to docs URLs

### DIFF
--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -14,3 +14,4 @@ toc:
 subs:
   eck:   "Elastic Cloud on Kubernetes"
   es:   "Elasticsearch"
+  es-apis: "https://www.elastic.co/docs/api/doc/elasticsearch/"

--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -6,6 +6,7 @@ exclude:
 cross_links:
   - apm-agent-go
   - docs-content
+  - elasticsearch
   - kibana
 toc:
   - toc: reference

--- a/docs/reference/api-reference/3_0_0.md
+++ b/docs/reference/api-reference/3_0_0.md
@@ -198,7 +198,7 @@ ApmServerSpec holds the specification of an APM Server.
 | *`version`* __string__ | Version of the APM Server. |
 | *`image`* __string__ | Image is the APM Server Docker image to deploy. |
 | *`count`* __integer__ | Count of APM Server instances to deploy. |
-| *`config`* __[Config](#config)__ | Config holds the APM Server configuration. See: https://www.elastic.co/guide/en/apm/server/current/configuring-howto-apm-server.html |
+| *`config`* __[Config](#config)__ | Config holds the APM Server configuration. See: [Configure APM Server](docs-content://solutions/observability/apm/apm-server/configure.md) |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for the APM Server resource. |
 | *`elasticsearchRef`* __[ObjectSelector](#objectselector)__ | ElasticsearchRef is a reference to the output Elasticsearch cluster running in the same Kubernetes cluster. |
 | *`kibanaRef`* __[ObjectSelector](#objectselector)__ | KibanaRef is a reference to a Kibana instance running in the same Kubernetes cluster.<br>It allows APM agent central configuration management in Kibana. |
@@ -247,7 +247,7 @@ ApmServerSpec holds the specification of an APM Server.
 | *`version`* __string__ | Version of the APM Server. |
 | *`image`* __string__ | Image is the APM Server Docker image to deploy. |
 | *`count`* __integer__ | Count of APM Server instances to deploy. |
-| *`config`* __[Config](#config)__ | Config holds the APM Server configuration. See: https://www.elastic.co/guide/en/apm/server/current/configuring-howto-apm-server.html |
+| *`config`* __[Config](#config)__ | Config holds the APM Server configuration. See: [Configure APM Server](docs-content://solutions/observability/apm/apm-server/configure.md) |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for the APM Server resource. |
 | *`elasticsearchRef`* __[ObjectSelector](#objectselector)__ | ElasticsearchRef is a reference to the output Elasticsearch cluster running in the same Kubernetes cluster. |
 | *`podTemplate`* __[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podtemplatespec-v1-core)__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the APM Server pods. |
@@ -1099,7 +1099,7 @@ ElasticsearchSpec holds the specification of an Elasticsearch cluster.
 | *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (for ex. a remote Elasticsearch cluster) in a different namespace.<br>Can only be used if ECK is enforcing RBAC on references. |
 | *`remoteClusters`* __[RemoteCluster](#remotecluster) array__ | RemoteClusters enables you to establish uni-directional connections to a remote Elasticsearch cluster. |
 | *`volumeClaimDeletePolicy`* __[VolumeClaimDeletePolicy](#volumeclaimdeletepolicy)__ | VolumeClaimDeletePolicy sets the policy for handling deletion of PersistentVolumeClaims for all NodeSets.<br>Possible values are DeleteOnScaledownOnly and DeleteOnScaledownAndClusterDeletion. Defaults to DeleteOnScaledownAndClusterDeletion. |
-| *`monitoring`* __[Monitoring](#monitoring)__ | Monitoring enables you to collect and ship log and monitoring data of this Elasticsearch cluster.<br>See https://www.elastic.co/guide/en/elasticsearch/reference/current/monitor-elasticsearch-cluster.html.<br>Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different<br>Elasticsearch monitoring clusters running in the same Kubernetes cluster. |
+| *`monitoring`* __[Monitoring](#monitoring)__ | Monitoring enables you to collect and ship log and monitoring data of this Elasticsearch cluster.<br>See [Stack monitoring](docs-content://deploy-manage/monitor/stack-monitoring.md).<br>Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different<br>Elasticsearch monitoring clusters running in the same Kubernetes cluster. |
 | *`revisionHistoryLimit`* __integer__ | RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying StatefulSets. |
 
 
@@ -1232,7 +1232,7 @@ RemoteCluster declares a remote Elasticsearch cluster connection.
 | --- | --- |
 | *`name`* __string__ | Name is the name of the remote cluster as it is set in the Elasticsearch settings.<br>The name is expected to be unique for each remote clusters. |
 | *`elasticsearchRef`* __[LocalObjectSelector](#localobjectselector)__ | ElasticsearchRef is a reference to an Elasticsearch cluster running within the same k8s cluster. |
-| *`apiKey`* __[RemoteClusterAPIKey](#remoteclusterapikey)__ | APIKey can be used to enable remote cluster access using Cross-Cluster API keys: https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-cross-cluster-api-key.html |
+| *`apiKey`* __[RemoteClusterAPIKey](#remoteclusterapikey)__ | APIKey can be used to enable remote cluster access using Cross-Cluster API keys: [Create cross-cluster API key]({{es-apis}}operation/operation-security-create-cross-cluster-api-key) |
 
 
 ### RemoteClusterAPIKey  [#remoteclusterapikey]
@@ -1251,7 +1251,7 @@ RemoteClusterAPIKey defines a remote cluster API Key.
 
 ### RemoteClusterAccess  [#remoteclusteraccess]
 
-RemoteClusterAccess models the API key specification as documented in https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-cross-cluster-api-key.html
+RemoteClusterAccess models the API key specification as documented in [Create cross-cluster API key]({{es-apis}}operation/operation-security-create-cross-cluster-api-key)
 
 :::{admonition} Appears In:
 * [RemoteClusterAPIKey](#remoteclusterapikey)
@@ -1718,13 +1718,13 @@ KibanaSpec holds the specification of a Kibana instance.
 | *`count`* __integer__ | Count of Kibana instances to deploy. |
 | *`elasticsearchRef`* __[ObjectSelector](#objectselector)__ | ElasticsearchRef is a reference to an Elasticsearch cluster running in the same Kubernetes cluster. |
 | *`enterpriseSearchRef`* __[ObjectSelector](#objectselector)__ | EnterpriseSearchRef is a reference to an EnterpriseSearch running in the same Kubernetes cluster.<br>Kibana provides the default Enterprise Search UI starting version 7.14. |
-| *`config`* __[Config](#config)__ | Config holds the Kibana configuration. See: https://www.elastic.co/guide/en/kibana/current/settings.html |
+| *`config`* __[Config](#config)__ | Config holds the Kibana configuration. See: [Kibana configuration reference](kibana://reference/configuration-reference.md) |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for Kibana. |
 | *`podTemplate`* __[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podtemplatespec-v1-core)__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Kibana pods |
 | *`revisionHistoryLimit`* __integer__ | RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying Deployment. |
 | *`secureSettings`* __[SecretSource](#secretsource) array__ | SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for Kibana. |
 | *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace.<br>Can only be used if ECK is enforcing RBAC on references. |
-| *`monitoring`* __[Monitoring](#monitoring)__ | Monitoring enables you to collect and ship log and monitoring data of this Kibana.<br>See https://www.elastic.co/guide/en/kibana/current/xpack-monitoring.html.<br>Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different<br>Elasticsearch monitoring clusters running in the same Kubernetes cluster. |
+| *`monitoring`* __[Monitoring](#monitoring)__ | Monitoring enables you to collect and ship log and monitoring data of this Kibana.<br>See [Stack monitoring](docs-content://deploy-manage/monitor/stack-monitoring.md).<br>Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different<br>Elasticsearch monitoring clusters running in the same Kubernetes cluster. |
 
 
 
@@ -1767,7 +1767,7 @@ KibanaSpec holds the specification of a Kibana instance.
 | *`image`* __string__ | Image is the Kibana Docker image to deploy. |
 | *`count`* __integer__ | Count of Kibana instances to deploy. |
 | *`elasticsearchRef`* __[ObjectSelector](#objectselector)__ | ElasticsearchRef is a reference to an Elasticsearch cluster running in the same Kubernetes cluster. |
-| *`config`* __[Config](#config)__ | Config holds the Kibana configuration. See: https://www.elastic.co/guide/en/kibana/current/settings.html |
+| *`config`* __[Config](#config)__ | Config holds the Kibana configuration. See: [Kibana configuration reference](kibana://reference/configuration-reference.md) |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for Kibana. |
 | *`podTemplate`* __[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podtemplatespec-v1-core)__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Kibana pods |
 | *`secureSettings`* __[SecretSource](#secretsource) array__ | SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for Kibana. |
@@ -1947,7 +1947,7 @@ MapsSpec holds the specification of an Elastic Maps Server instance.
 | *`image`* __string__ | Image is the Elastic Maps Server Docker image to deploy. |
 | *`count`* __integer__ | Count of Elastic Maps Server instances to deploy. |
 | *`elasticsearchRef`* __[ObjectSelector](#objectselector)__ | ElasticsearchRef is a reference to an Elasticsearch cluster running in the same Kubernetes cluster. |
-| *`config`* __[Config](#config)__ | Config holds the ElasticMapsServer configuration. See: https://www.elastic.co/guide/en/kibana/current/maps-connect-to-ems.html#elastic-maps-server-configuration |
+| *`config`* __[Config](#config)__ | Config holds the ElasticMapsServer configuration. See: [Connect to Elastic Maps Service](docs-content://explore-analyze/visualize/maps/maps-connect-to-ems.md#elastic-maps-server-configuration) |
 | *`configRef`* __[ConfigSource](#configsource)__ | ConfigRef contains a reference to an existing Kubernetes Secret holding the Elastic Maps Server configuration.<br>Configuration settings are merged and have precedence over settings specified in `config`. |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for Elastic Maps Server. |
 | *`podTemplate`* __[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podtemplatespec-v1-core)__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Elastic Maps Server pods |

--- a/docs/reference/api-reference/3_1_0.md
+++ b/docs/reference/api-reference/3_1_0.md
@@ -88,7 +88,7 @@ AgentSpec defines the desired state of the Agent
 | *`statefulSet`* __[StatefulSetSpec](#statefulsetspec)__ | StatefulSet specifies the Agent should be deployed as a StatefulSet, and allows providing its spec.<br>Cannot be used along with `daemonSet` or `deployment`. |
 | *`revisionHistoryLimit`* __integer__ | RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying DaemonSet or Deployment or StatefulSet. |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for the Agent in Fleet mode with Fleet Server enabled. |
-| *`mode`* __[AgentMode](#agentmode)__ | Mode specifies the runtime mode for the Agent. The configuration can be specified locally through<br>`config` or `configRef` (`standalone` mode), or come from Fleet during runtime (`fleet` mode). Starting with<br>version 8.13.0 Fleet-managed agents support advanced configuration via a local configuration file.<br>See https://www.elastic.co/docs/reference/fleet/advanced-kubernetes-managed-by-fleet<br>Defaults to `standalone` mode. |
+| *`mode`* __[AgentMode](#agentmode)__ | Mode specifies the runtime mode for the Agent. The configuration can be specified locally through<br>`config` or `configRef` (`standalone` mode), or come from Fleet during runtime (`fleet` mode). Starting with<br>version 8.13.0 Fleet-managed agents support advanced configuration via a local configuration file.<br>See [Advanced Elastic Agent configuration managed by Fleet](docs-content://reference/fleet/advanced-kubernetes-managed-by-fleet.md)<br>Defaults to `standalone` mode. |
 | *`fleetServerEnabled`* __boolean__ | FleetServerEnabled determines whether this Agent will launch Fleet Server. Don't set unless `mode` is set to `fleet`. |
 | *`policyID`* __string__ | PolicyID determines into which Agent Policy this Agent will be enrolled.<br>This field will become mandatory in a future release, default policies are deprecated since 8.1.0. |
 | *`kibanaRef`* __[ObjectSelector](#objectselector)__ | KibanaRef is a reference to Kibana where Fleet should be set up and this Agent should be enrolled. Don't set<br>unless `mode` is set to `fleet`. |
@@ -198,7 +198,7 @@ ApmServerSpec holds the specification of an APM Server.
 | *`version`* __string__ | Version of the APM Server. |
 | *`image`* __string__ | Image is the APM Server Docker image to deploy. |
 | *`count`* __integer__ | Count of APM Server instances to deploy. |
-| *`config`* __[Config](#config)__ | Config holds the APM Server configuration. See: https://www.elastic.co/guide/en/apm/server/current/configuring-howto-apm-server.html |
+| *`config`* __[Config](#config)__ | Config holds the APM Server configuration. See: [Configure APM Server](docs-content://solutions/observability/apm/apm-server/configure.md) |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for the APM Server resource. |
 | *`elasticsearchRef`* __[ObjectSelector](#objectselector)__ | ElasticsearchRef is a reference to the output Elasticsearch cluster running in the same Kubernetes cluster. |
 | *`kibanaRef`* __[ObjectSelector](#objectselector)__ | KibanaRef is a reference to a Kibana instance running in the same Kubernetes cluster.<br>It allows APM agent central configuration management in Kibana. |
@@ -247,7 +247,7 @@ ApmServerSpec holds the specification of an APM Server.
 | *`version`* __string__ | Version of the APM Server. |
 | *`image`* __string__ | Image is the APM Server Docker image to deploy. |
 | *`count`* __integer__ | Count of APM Server instances to deploy. |
-| *`config`* __[Config](#config)__ | Config holds the APM Server configuration. See: https://www.elastic.co/guide/en/apm/server/current/configuring-howto-apm-server.html |
+| *`config`* __[Config](#config)__ | Config holds the APM Server configuration. See: [Configure APM Server](docs-content://solutions/observability/apm/apm-server/configure.md) |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for the APM Server resource. |
 | *`elasticsearchRef`* __[ObjectSelector](#objectselector)__ | ElasticsearchRef is a reference to the output Elasticsearch cluster running in the same Kubernetes cluster. |
 | *`podTemplate`* __[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podtemplatespec-v1-core)__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the APM Server pods. |
@@ -1099,7 +1099,7 @@ ElasticsearchSpec holds the specification of an Elasticsearch cluster.
 | *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (for ex. a remote Elasticsearch cluster) in a different namespace.<br>Can only be used if ECK is enforcing RBAC on references. |
 | *`remoteClusters`* __[RemoteCluster](#remotecluster) array__ | RemoteClusters enables you to establish uni-directional connections to a remote Elasticsearch cluster. |
 | *`volumeClaimDeletePolicy`* __[VolumeClaimDeletePolicy](#volumeclaimdeletepolicy)__ | VolumeClaimDeletePolicy sets the policy for handling deletion of PersistentVolumeClaims for all NodeSets.<br>Possible values are DeleteOnScaledownOnly and DeleteOnScaledownAndClusterDeletion. Defaults to DeleteOnScaledownAndClusterDeletion. |
-| *`monitoring`* __[Monitoring](#monitoring)__ | Monitoring enables you to collect and ship log and monitoring data of this Elasticsearch cluster.<br>See https://www.elastic.co/guide/en/elasticsearch/reference/current/monitor-elasticsearch-cluster.html.<br>Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different<br>Elasticsearch monitoring clusters running in the same Kubernetes cluster. |
+| *`monitoring`* __[Monitoring](#monitoring)__ | Monitoring enables you to collect and ship log and monitoring data of this Elasticsearch cluster.<br>See [Stack monitoring](docs-content://deploy-manage/monitor/stack-monitoring.md).<br>Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different<br>Elasticsearch monitoring clusters running in the same Kubernetes cluster. |
 | *`revisionHistoryLimit`* __integer__ | RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying StatefulSets. |
 
 
@@ -1232,7 +1232,7 @@ RemoteCluster declares a remote Elasticsearch cluster connection.
 | --- | --- |
 | *`name`* __string__ | Name is the name of the remote cluster as it is set in the Elasticsearch settings.<br>The name is expected to be unique for each remote clusters. |
 | *`elasticsearchRef`* __[LocalObjectSelector](#localobjectselector)__ | ElasticsearchRef is a reference to an Elasticsearch cluster running within the same k8s cluster. |
-| *`apiKey`* __[RemoteClusterAPIKey](#remoteclusterapikey)__ | APIKey can be used to enable remote cluster access using Cross-Cluster API keys: https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-cross-cluster-api-key.html |
+| *`apiKey`* __[RemoteClusterAPIKey](#remoteclusterapikey)__ | APIKey can be used to enable remote cluster access using Cross-Cluster API keys: [Create cross-cluster API key]({{es-apis}}operation/operation-security-create-cross-cluster-api-key) |
 
 
 ### RemoteClusterAPIKey  [#remoteclusterapikey]
@@ -1251,7 +1251,7 @@ RemoteClusterAPIKey defines a remote cluster API Key.
 
 ### RemoteClusterAccess  [#remoteclusteraccess]
 
-RemoteClusterAccess models the API key specification as documented in https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-cross-cluster-api-key.html
+RemoteClusterAccess models the API key specification as documented in [Create cross-cluster API key]({{es-apis}}operation/operation-security-create-cross-cluster-api-key)
 
 :::{admonition} Appears In:
 * [RemoteClusterAPIKey](#remoteclusterapikey)
@@ -1718,13 +1718,13 @@ KibanaSpec holds the specification of a Kibana instance.
 | *`count`* __integer__ | Count of Kibana instances to deploy. |
 | *`elasticsearchRef`* __[ObjectSelector](#objectselector)__ | ElasticsearchRef is a reference to an Elasticsearch cluster running in the same Kubernetes cluster. |
 | *`enterpriseSearchRef`* __[ObjectSelector](#objectselector)__ | EnterpriseSearchRef is a reference to an EnterpriseSearch running in the same Kubernetes cluster.<br>Kibana provides the default Enterprise Search UI starting version 7.14. |
-| *`config`* __[Config](#config)__ | Config holds the Kibana configuration. See: https://www.elastic.co/guide/en/kibana/current/settings.html |
+| *`config`* __[Config](#config)__ | Config holds the Kibana configuration. See: [Kibana configuration reference](kibana://reference/configuration-reference.md) |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for Kibana. |
 | *`podTemplate`* __[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podtemplatespec-v1-core)__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Kibana pods |
 | *`revisionHistoryLimit`* __integer__ | RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying Deployment. |
 | *`secureSettings`* __[SecretSource](#secretsource) array__ | SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for Kibana. |
 | *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace.<br>Can only be used if ECK is enforcing RBAC on references. |
-| *`monitoring`* __[Monitoring](#monitoring)__ | Monitoring enables you to collect and ship log and monitoring data of this Kibana.<br>See https://www.elastic.co/guide/en/kibana/current/xpack-monitoring.html.<br>Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different<br>Elasticsearch monitoring clusters running in the same Kubernetes cluster. |
+| *`monitoring`* __[Monitoring](#monitoring)__ | Monitoring enables you to collect and ship log and monitoring data of this Kibana.<br>See [Stack monitoring](docs-content://deploy-manage/monitor/stack-monitoring.md).<br>Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different<br>Elasticsearch monitoring clusters running in the same Kubernetes cluster. |
 
 
 
@@ -1767,7 +1767,7 @@ KibanaSpec holds the specification of a Kibana instance.
 | *`image`* __string__ | Image is the Kibana Docker image to deploy. |
 | *`count`* __integer__ | Count of Kibana instances to deploy. |
 | *`elasticsearchRef`* __[ObjectSelector](#objectselector)__ | ElasticsearchRef is a reference to an Elasticsearch cluster running in the same Kubernetes cluster. |
-| *`config`* __[Config](#config)__ | Config holds the Kibana configuration. See: https://www.elastic.co/guide/en/kibana/current/settings.html |
+| *`config`* __[Config](#config)__ | Config holds the Kibana configuration. See: [Kibana configuration reference](kibana://reference/configuration-reference.md) |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for Kibana. |
 | *`podTemplate`* __[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podtemplatespec-v1-core)__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Kibana pods |
 | *`secureSettings`* __[SecretSource](#secretsource) array__ | SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for Kibana. |
@@ -1947,7 +1947,7 @@ MapsSpec holds the specification of an Elastic Maps Server instance.
 | *`image`* __string__ | Image is the Elastic Maps Server Docker image to deploy. |
 | *`count`* __integer__ | Count of Elastic Maps Server instances to deploy. |
 | *`elasticsearchRef`* __[ObjectSelector](#objectselector)__ | ElasticsearchRef is a reference to an Elasticsearch cluster running in the same Kubernetes cluster. |
-| *`config`* __[Config](#config)__ | Config holds the ElasticMapsServer configuration. See: https://www.elastic.co/guide/en/kibana/current/maps-connect-to-ems.html#elastic-maps-server-configuration |
+| *`config`* __[Config](#config)__ | Config holds the ElasticMapsServer configuration. See: [Connect to Elastic Maps Service](docs-content://explore-analyze/visualize/maps/maps-connect-to-ems.md#elastic-maps-server-configuration) |
 | *`configRef`* __[ConfigSource](#configsource)__ | ConfigRef contains a reference to an existing Kubernetes Secret holding the Elastic Maps Server configuration.<br>Configuration settings are merged and have precedence over settings specified in `config`. |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for Elastic Maps Server. |
 | *`podTemplate`* __[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podtemplatespec-v1-core)__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Elastic Maps Server pods |

--- a/docs/reference/api-reference/3_2_0.md
+++ b/docs/reference/api-reference/3_2_0.md
@@ -88,7 +88,7 @@ AgentSpec defines the desired state of the Agent
 | *`statefulSet`* __[StatefulSetSpec](#statefulsetspec)__ | StatefulSet specifies the Agent should be deployed as a StatefulSet, and allows providing its spec.<br>Cannot be used along with `daemonSet` or `deployment`. |
 | *`revisionHistoryLimit`* __integer__ | RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying DaemonSet or Deployment or StatefulSet. |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for the Agent in Fleet mode with Fleet Server enabled. |
-| *`mode`* __[AgentMode](#agentmode)__ | Mode specifies the runtime mode for the Agent. The configuration can be specified locally through<br>`config` or `configRef` (`standalone` mode), or come from Fleet during runtime (`fleet` mode). Starting with<br>version 8.13.0 Fleet-managed agents support advanced configuration via a local configuration file.<br>See https://www.elastic.co/docs/reference/fleet/advanced-kubernetes-managed-by-fleet<br>Defaults to `standalone` mode. |
+| *`mode`* __[AgentMode](#agentmode)__ | Mode specifies the runtime mode for the Agent. The configuration can be specified locally through<br>`config` or `configRef` (`standalone` mode), or come from Fleet during runtime (`fleet` mode). Starting with<br>version 8.13.0 Fleet-managed agents support advanced configuration via a local configuration file.<br>See [Advanced Elastic Agent configuration managed by Fleet](docs-content://reference/fleet/advanced-kubernetes-managed-by-fleet.md)<br>Defaults to `standalone` mode. |
 | *`fleetServerEnabled`* __boolean__ | FleetServerEnabled determines whether this Agent will launch Fleet Server. Don't set unless `mode` is set to `fleet`. |
 | *`policyID`* __string__ | PolicyID determines into which Agent Policy this Agent will be enrolled.<br>This field will become mandatory in a future release, default policies are deprecated since 8.1.0. |
 | *`kibanaRef`* __[ObjectSelector](#objectselector)__ | KibanaRef is a reference to Kibana where Fleet should be set up and this Agent should be enrolled. Don't set<br>unless `mode` is set to `fleet`. |
@@ -198,7 +198,7 @@ ApmServerSpec holds the specification of an APM Server.
 | *`version`* __string__ | Version of the APM Server. |
 | *`image`* __string__ | Image is the APM Server Docker image to deploy. |
 | *`count`* __integer__ | Count of APM Server instances to deploy. |
-| *`config`* __[Config](#config)__ | Config holds the APM Server configuration. See: https://www.elastic.co/guide/en/apm/server/current/configuring-howto-apm-server.html |
+| *`config`* __[Config](#config)__ | Config holds the APM Server configuration. See: [Configure APM Server](docs-content://solutions/observability/apm/apm-server/configure.md) |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for the APM Server resource. |
 | *`elasticsearchRef`* __[ObjectSelector](#objectselector)__ | ElasticsearchRef is a reference to the output Elasticsearch cluster running in the same Kubernetes cluster. |
 | *`kibanaRef`* __[ObjectSelector](#objectselector)__ | KibanaRef is a reference to a Kibana instance running in the same Kubernetes cluster.<br>It allows APM agent central configuration management in Kibana. |
@@ -247,7 +247,7 @@ ApmServerSpec holds the specification of an APM Server.
 | *`version`* __string__ | Version of the APM Server. |
 | *`image`* __string__ | Image is the APM Server Docker image to deploy. |
 | *`count`* __integer__ | Count of APM Server instances to deploy. |
-| *`config`* __[Config](#config)__ | Config holds the APM Server configuration. See: https://www.elastic.co/guide/en/apm/server/current/configuring-howto-apm-server.html |
+| *`config`* __[Config](#config)__ | Config holds the APM Server configuration. See: [Configure APM Server](docs-content://solutions/observability/apm/apm-server/configure.md) |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for the APM Server resource. |
 | *`elasticsearchRef`* __[ObjectSelector](#objectselector)__ | ElasticsearchRef is a reference to the output Elasticsearch cluster running in the same Kubernetes cluster. |
 | *`podTemplate`* __[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podtemplatespec-v1-core)__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the APM Server pods. |
@@ -1099,7 +1099,7 @@ ElasticsearchSpec holds the specification of an Elasticsearch cluster.
 | *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (for ex. a remote Elasticsearch cluster) in a different namespace.<br>Can only be used if ECK is enforcing RBAC on references. |
 | *`remoteClusters`* __[RemoteCluster](#remotecluster) array__ | RemoteClusters enables you to establish uni-directional connections to a remote Elasticsearch cluster. |
 | *`volumeClaimDeletePolicy`* __[VolumeClaimDeletePolicy](#volumeclaimdeletepolicy)__ | VolumeClaimDeletePolicy sets the policy for handling deletion of PersistentVolumeClaims for all NodeSets.<br>Possible values are DeleteOnScaledownOnly and DeleteOnScaledownAndClusterDeletion. Defaults to DeleteOnScaledownAndClusterDeletion. |
-| *`monitoring`* __[Monitoring](#monitoring)__ | Monitoring enables you to collect and ship log and monitoring data of this Elasticsearch cluster.<br>See https://www.elastic.co/guide/en/elasticsearch/reference/current/monitor-elasticsearch-cluster.html.<br>Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different<br>Elasticsearch monitoring clusters running in the same Kubernetes cluster. |
+| *`monitoring`* __[Monitoring](#monitoring)__ | Monitoring enables you to collect and ship log and monitoring data of this Elasticsearch cluster.<br>See [Stack monitoring](docs-content://deploy-manage/monitor/stack-monitoring.md).<br>Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different<br>Elasticsearch monitoring clusters running in the same Kubernetes cluster. |
 | *`revisionHistoryLimit`* __integer__ | RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying StatefulSets. |
 
 
@@ -1232,7 +1232,7 @@ RemoteCluster declares a remote Elasticsearch cluster connection.
 | --- | --- |
 | *`name`* __string__ | Name is the name of the remote cluster as it is set in the Elasticsearch settings.<br>The name is expected to be unique for each remote clusters. |
 | *`elasticsearchRef`* __[LocalObjectSelector](#localobjectselector)__ | ElasticsearchRef is a reference to an Elasticsearch cluster running within the same k8s cluster. |
-| *`apiKey`* __[RemoteClusterAPIKey](#remoteclusterapikey)__ | APIKey can be used to enable remote cluster access using Cross-Cluster API keys: https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-cross-cluster-api-key.html |
+| *`apiKey`* __[RemoteClusterAPIKey](#remoteclusterapikey)__ | APIKey can be used to enable remote cluster access using Cross-Cluster API keys: [Create cross-cluster API key]({{es-apis}}operation/operation-security-create-cross-cluster-api-key) |
 
 
 ### RemoteClusterAPIKey  [#remoteclusterapikey]
@@ -1251,7 +1251,7 @@ RemoteClusterAPIKey defines a remote cluster API Key.
 
 ### RemoteClusterAccess  [#remoteclusteraccess]
 
-RemoteClusterAccess models the API key specification as documented in https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-cross-cluster-api-key.html
+RemoteClusterAccess models the API key specification as documented in [Create cross-cluster API key]({{es-apis}}operation/operation-security-create-cross-cluster-api-key)
 
 :::{admonition} Appears In:
 * [RemoteClusterAPIKey](#remoteclusterapikey)
@@ -1718,13 +1718,13 @@ KibanaSpec holds the specification of a Kibana instance.
 | *`count`* __integer__ | Count of Kibana instances to deploy. |
 | *`elasticsearchRef`* __[ObjectSelector](#objectselector)__ | ElasticsearchRef is a reference to an Elasticsearch cluster running in the same Kubernetes cluster. |
 | *`enterpriseSearchRef`* __[ObjectSelector](#objectselector)__ | EnterpriseSearchRef is a reference to an EnterpriseSearch running in the same Kubernetes cluster.<br>Kibana provides the default Enterprise Search UI starting version 7.14. |
-| *`config`* __[Config](#config)__ | Config holds the Kibana configuration. See: https://www.elastic.co/guide/en/kibana/current/settings.html |
+| *`config`* __[Config](#config)__ | Config holds the Kibana configuration. See: [Kibana configuration reference](kibana://reference/configuration-reference.md) |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for Kibana. |
 | *`podTemplate`* __[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podtemplatespec-v1-core)__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Kibana pods |
 | *`revisionHistoryLimit`* __integer__ | RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying Deployment. |
 | *`secureSettings`* __[SecretSource](#secretsource) array__ | SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for Kibana. |
 | *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace.<br>Can only be used if ECK is enforcing RBAC on references. |
-| *`monitoring`* __[Monitoring](#monitoring)__ | Monitoring enables you to collect and ship log and monitoring data of this Kibana.<br>See https://www.elastic.co/guide/en/kibana/current/xpack-monitoring.html.<br>Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different<br>Elasticsearch monitoring clusters running in the same Kubernetes cluster. |
+| *`monitoring`* __[Monitoring](#monitoring)__ | Monitoring enables you to collect and ship log and monitoring data of this Kibana.<br>See [Stack monitoring](docs-content://deploy-manage/monitor/stack-monitoring.md).<br>Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different<br>Elasticsearch monitoring clusters running in the same Kubernetes cluster. |
 
 
 
@@ -1767,7 +1767,7 @@ KibanaSpec holds the specification of a Kibana instance.
 | *`image`* __string__ | Image is the Kibana Docker image to deploy. |
 | *`count`* __integer__ | Count of Kibana instances to deploy. |
 | *`elasticsearchRef`* __[ObjectSelector](#objectselector)__ | ElasticsearchRef is a reference to an Elasticsearch cluster running in the same Kubernetes cluster. |
-| *`config`* __[Config](#config)__ | Config holds the Kibana configuration. See: https://www.elastic.co/guide/en/kibana/current/settings.html |
+| *`config`* __[Config](#config)__ | Config holds the Kibana configuration. See: [Kibana configuration reference](kibana://reference/configuration-reference.md) |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for Kibana. |
 | *`podTemplate`* __[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podtemplatespec-v1-core)__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Kibana pods |
 | *`secureSettings`* __[SecretSource](#secretsource) array__ | SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for Kibana. |
@@ -1947,7 +1947,7 @@ MapsSpec holds the specification of an Elastic Maps Server instance.
 | *`image`* __string__ | Image is the Elastic Maps Server Docker image to deploy. |
 | *`count`* __integer__ | Count of Elastic Maps Server instances to deploy. |
 | *`elasticsearchRef`* __[ObjectSelector](#objectselector)__ | ElasticsearchRef is a reference to an Elasticsearch cluster running in the same Kubernetes cluster. |
-| *`config`* __[Config](#config)__ | Config holds the ElasticMapsServer configuration. See: https://www.elastic.co/guide/en/kibana/current/maps-connect-to-ems.html#elastic-maps-server-configuration |
+| *`config`* __[Config](#config)__ | Config holds the ElasticMapsServer configuration. See: [Connect to Elastic Maps Service](docs-content://explore-analyze/visualize/maps/maps-connect-to-ems.md#elastic-maps-server-configuration) |
 | *`configRef`* __[ConfigSource](#configsource)__ | ConfigRef contains a reference to an existing Kubernetes Secret holding the Elastic Maps Server configuration.<br>Configuration settings are merged and have precedence over settings specified in `config`. |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for Elastic Maps Server. |
 | *`podTemplate`* __[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podtemplatespec-v1-core)__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Elastic Maps Server pods |

--- a/docs/reference/api-reference/3_3_0.md
+++ b/docs/reference/api-reference/3_3_0.md
@@ -90,7 +90,7 @@ AgentSpec defines the desired state of the Agent
 | *`statefulSet`* __[StatefulSetSpec](#statefulsetspec)__ | StatefulSet specifies the Agent should be deployed as a StatefulSet, and allows providing its spec.<br>Cannot be used along with `daemonSet` or `deployment`. |
 | *`revisionHistoryLimit`* __integer__ | RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying DaemonSet or Deployment or StatefulSet. |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for the Agent in Fleet mode with Fleet Server enabled. |
-| *`mode`* __[AgentMode](#agentmode)__ | Mode specifies the runtime mode for the Agent. The configuration can be specified locally through<br>`config` or `configRef` (`standalone` mode), or come from Fleet during runtime (`fleet` mode). Starting with<br>version 8.13.0 Fleet-managed agents support advanced configuration via a local configuration file.<br>See https://www.elastic.co/docs/reference/fleet/advanced-kubernetes-managed-by-fleet<br>Defaults to `standalone` mode. |
+| *`mode`* __[AgentMode](#agentmode)__ | Mode specifies the runtime mode for the Agent. The configuration can be specified locally through<br>`config` or `configRef` (`standalone` mode), or come from Fleet during runtime (`fleet` mode). Starting with<br>version 8.13.0 Fleet-managed agents support advanced configuration via a local configuration file.<br>See [Advanced Elastic Agent configuration managed by Fleet](docs-content://reference/fleet/advanced-kubernetes-managed-by-fleet.md)<br>Defaults to `standalone` mode. |
 | *`fleetServerEnabled`* __boolean__ | FleetServerEnabled determines whether this Agent will launch Fleet Server. Don't set unless `mode` is set to `fleet`. |
 | *`policyID`* __string__ | PolicyID determines into which Agent Policy this Agent will be enrolled.<br>This field will become mandatory in a future release, default policies are deprecated since 8.1.0. |
 | *`kibanaRef`* __[ObjectSelector](#objectselector)__ | KibanaRef is a reference to Kibana where Fleet should be set up and this Agent should be enrolled. Don't set<br>unless `mode` is set to `fleet`. |
@@ -200,7 +200,7 @@ ApmServerSpec holds the specification of an APM Server.
 | *`version`* __string__ | Version of the APM Server. |
 | *`image`* __string__ | Image is the APM Server Docker image to deploy. |
 | *`count`* __integer__ | Count of APM Server instances to deploy. |
-| *`config`* __[Config](#config)__ | Config holds the APM Server configuration. See: https://www.elastic.co/guide/en/apm/server/current/configuring-howto-apm-server.html |
+| *`config`* __[Config](#config)__ | Config holds the APM Server configuration. See: [Configure APM Server](docs-content://solutions/observability/apm/apm-server/configure.md) |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for the APM Server resource. |
 | *`elasticsearchRef`* __[ObjectSelector](#objectselector)__ | ElasticsearchRef is a reference to the output Elasticsearch cluster running in the same Kubernetes cluster. |
 | *`kibanaRef`* __[ObjectSelector](#objectselector)__ | KibanaRef is a reference to a Kibana instance running in the same Kubernetes cluster.<br>It allows APM agent central configuration management in Kibana. |
@@ -249,7 +249,7 @@ ApmServerSpec holds the specification of an APM Server.
 | *`version`* __string__ | Version of the APM Server. |
 | *`image`* __string__ | Image is the APM Server Docker image to deploy. |
 | *`count`* __integer__ | Count of APM Server instances to deploy. |
-| *`config`* __[Config](#config)__ | Config holds the APM Server configuration. See: https://www.elastic.co/guide/en/apm/server/current/configuring-howto-apm-server.html |
+| *`config`* __[Config](#config)__ | Config holds the APM Server configuration. See: [Configure APM Server](docs-content://solutions/observability/apm/apm-server/configure.md) |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for the APM Server resource. |
 | *`elasticsearchRef`* __[ObjectSelector](#objectselector)__ | ElasticsearchRef is a reference to the output Elasticsearch cluster running in the same Kubernetes cluster. |
 | *`podTemplate`* __[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podtemplatespec-v1-core)__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the APM Server pods. |
@@ -1166,7 +1166,7 @@ ElasticsearchSpec holds the specification of an Elasticsearch cluster.
 | *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (for ex. a remote Elasticsearch cluster) in a different namespace.<br>Can only be used if ECK is enforcing RBAC on references. |
 | *`remoteClusters`* __[RemoteCluster](#remotecluster) array__ | RemoteClusters enables you to establish uni-directional connections to a remote Elasticsearch cluster. |
 | *`volumeClaimDeletePolicy`* __[VolumeClaimDeletePolicy](#volumeclaimdeletepolicy)__ | VolumeClaimDeletePolicy sets the policy for handling deletion of PersistentVolumeClaims for all NodeSets.<br>Possible values are DeleteOnScaledownOnly and DeleteOnScaledownAndClusterDeletion. Defaults to DeleteOnScaledownAndClusterDeletion. |
-| *`monitoring`* __[Monitoring](#monitoring)__ | Monitoring enables you to collect and ship log and monitoring data of this Elasticsearch cluster.<br>See https://www.elastic.co/guide/en/elasticsearch/reference/current/monitor-elasticsearch-cluster.html.<br>Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different<br>Elasticsearch monitoring clusters running in the same Kubernetes cluster. |
+| *`monitoring`* __[Monitoring](#monitoring)__ | Monitoring enables you to collect and ship log and monitoring data of this Elasticsearch cluster.<br>See [Stack monitoring](docs-content://deploy-manage/monitor/stack-monitoring.md).<br>Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different<br>Elasticsearch monitoring clusters running in the same Kubernetes cluster. |
 | *`revisionHistoryLimit`* __integer__ | RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying StatefulSets. |
 
 
@@ -1299,7 +1299,7 @@ RemoteCluster declares a remote Elasticsearch cluster connection.
 | --- | --- |
 | *`name`* __string__ | Name is the name of the remote cluster as it is set in the Elasticsearch settings.<br>The name is expected to be unique for each remote clusters. |
 | *`elasticsearchRef`* __[LocalObjectSelector](#localobjectselector)__ | ElasticsearchRef is a reference to an Elasticsearch cluster running within the same k8s cluster. |
-| *`apiKey`* __[RemoteClusterAPIKey](#remoteclusterapikey)__ | APIKey can be used to enable remote cluster access using Cross-Cluster API keys: https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-cross-cluster-api-key.html |
+| *`apiKey`* __[RemoteClusterAPIKey](#remoteclusterapikey)__ | APIKey can be used to enable remote cluster access using Cross-Cluster API keys: [Create cross-cluster API key]({{es-apis}}operation/operation-security-create-cross-cluster-api-key) |
 
 
 ### RemoteClusterAPIKey  [#remoteclusterapikey]
@@ -1318,7 +1318,7 @@ RemoteClusterAPIKey defines a remote cluster API Key.
 
 ### RemoteClusterAccess  [#remoteclusteraccess]
 
-RemoteClusterAccess models the API key specification as documented in https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-cross-cluster-api-key.html
+RemoteClusterAccess models the API key specification as documented in [Create cross-cluster API key]({{es-apis}}operation/operation-security-create-cross-cluster-api-key)
 
 :::{admonition} Appears In:
 * [RemoteClusterAPIKey](#remoteclusterapikey)
@@ -1785,13 +1785,13 @@ KibanaSpec holds the specification of a Kibana instance.
 | *`elasticsearchRef`* __[ObjectSelector](#objectselector)__ | ElasticsearchRef is a reference to an Elasticsearch cluster running in the same Kubernetes cluster. |
 | *`packageRegistryRef`* __[ObjectSelector](#objectselector)__ | PackageRegistryRef is a reference to an Elastic Package Registry running in the same Kubernetes cluster. |
 | *`enterpriseSearchRef`* __[ObjectSelector](#objectselector)__ | EnterpriseSearchRef is a reference to an EnterpriseSearch running in the same Kubernetes cluster.<br>Kibana provides the default Enterprise Search UI starting version 7.14. |
-| *`config`* __[Config](#config)__ | Config holds the Kibana configuration. See: https://www.elastic.co/guide/en/kibana/current/settings.html |
+| *`config`* __[Config](#config)__ | Config holds the Kibana configuration. See: [Kibana configuration reference](kibana://reference/configuration-reference.md) |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for Kibana. |
 | *`podTemplate`* __[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podtemplatespec-v1-core)__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Kibana pods |
 | *`revisionHistoryLimit`* __integer__ | RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying Deployment. |
 | *`secureSettings`* __[SecretSource](#secretsource) array__ | SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for Kibana. |
 | *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace.<br>Can only be used if ECK is enforcing RBAC on references. |
-| *`monitoring`* __[Monitoring](#monitoring)__ | Monitoring enables you to collect and ship log and monitoring data of this Kibana.<br>See https://www.elastic.co/guide/en/kibana/current/xpack-monitoring.html.<br>Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different<br>Elasticsearch monitoring clusters running in the same Kubernetes cluster. |
+| *`monitoring`* __[Monitoring](#monitoring)__ | Monitoring enables you to collect and ship log and monitoring data of this Kibana.<br>See [Stack monitoring](docs-content://deploy-manage/monitor/stack-monitoring.md).<br>Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different<br>Elasticsearch monitoring clusters running in the same Kubernetes cluster. |
 
 
 
@@ -1834,7 +1834,7 @@ KibanaSpec holds the specification of a Kibana instance.
 | *`image`* __string__ | Image is the Kibana Docker image to deploy. |
 | *`count`* __integer__ | Count of Kibana instances to deploy. |
 | *`elasticsearchRef`* __[ObjectSelector](#objectselector)__ | ElasticsearchRef is a reference to an Elasticsearch cluster running in the same Kubernetes cluster. |
-| *`config`* __[Config](#config)__ | Config holds the Kibana configuration. See: https://www.elastic.co/guide/en/kibana/current/settings.html |
+| *`config`* __[Config](#config)__ | Config holds the Kibana configuration. See: [Kibana configuration reference](kibana://reference/configuration-reference.md) |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for Kibana. |
 | *`podTemplate`* __[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podtemplatespec-v1-core)__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Kibana pods |
 | *`secureSettings`* __[SecretSource](#secretsource) array__ | SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for Kibana. |
@@ -2014,7 +2014,7 @@ MapsSpec holds the specification of an Elastic Maps Server instance.
 | *`image`* __string__ | Image is the Elastic Maps Server Docker image to deploy. |
 | *`count`* __integer__ | Count of Elastic Maps Server instances to deploy. |
 | *`elasticsearchRef`* __[ObjectSelector](#objectselector)__ | ElasticsearchRef is a reference to an Elasticsearch cluster running in the same Kubernetes cluster. |
-| *`config`* __[Config](#config)__ | Config holds the ElasticMapsServer configuration. See: https://www.elastic.co/guide/en/kibana/current/maps-connect-to-ems.html#elastic-maps-server-configuration |
+| *`config`* __[Config](#config)__ | Config holds the ElasticMapsServer configuration. See: [Connect to Elastic Maps Service](docs-content://explore-analyze/visualize/maps/maps-connect-to-ems.md#elastic-maps-server-configuration) |
 | *`configRef`* __[ConfigSource](#configsource)__ | ConfigRef contains a reference to an existing Kubernetes Secret holding the Elastic Maps Server configuration.<br>Configuration settings are merged and have precedence over settings specified in `config`. |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for Elastic Maps Server. |
 | *`podTemplate`* __[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podtemplatespec-v1-core)__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Elastic Maps Server pods |

--- a/docs/reference/api-reference/3_3_1.md
+++ b/docs/reference/api-reference/3_3_1.md
@@ -90,7 +90,7 @@ AgentSpec defines the desired state of the Agent
 | *`statefulSet`* __[StatefulSetSpec](#statefulsetspec)__ | StatefulSet specifies the Agent should be deployed as a StatefulSet, and allows providing its spec.<br>Cannot be used along with `daemonSet` or `deployment`. |
 | *`revisionHistoryLimit`* __integer__ | RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying DaemonSet or Deployment or StatefulSet. |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for the Agent in Fleet mode with Fleet Server enabled. |
-| *`mode`* __[AgentMode](#agentmode)__ | Mode specifies the runtime mode for the Agent. The configuration can be specified locally through<br>`config` or `configRef` (`standalone` mode), or come from Fleet during runtime (`fleet` mode). Starting with<br>version 8.13.0 Fleet-managed agents support advanced configuration via a local configuration file.<br>See https://www.elastic.co/docs/reference/fleet/advanced-kubernetes-managed-by-fleet<br>Defaults to `standalone` mode. |
+| *`mode`* __[AgentMode](#agentmode)__ | Mode specifies the runtime mode for the Agent. The configuration can be specified locally through<br>`config` or `configRef` (`standalone` mode), or come from Fleet during runtime (`fleet` mode). Starting with<br>version 8.13.0 Fleet-managed agents support advanced configuration via a local configuration file.<br>See [Advanced Elastic Agent configuration managed by Fleet](docs-content://reference/fleet/advanced-kubernetes-managed-by-fleet.md)<br>Defaults to `standalone` mode. |
 | *`fleetServerEnabled`* __boolean__ | FleetServerEnabled determines whether this Agent will launch Fleet Server. Don't set unless `mode` is set to `fleet`. |
 | *`policyID`* __string__ | PolicyID determines into which Agent Policy this Agent will be enrolled.<br>This field will become mandatory in a future release, default policies are deprecated since 8.1.0. |
 | *`kibanaRef`* __[ObjectSelector](#objectselector)__ | KibanaRef is a reference to Kibana where Fleet should be set up and this Agent should be enrolled. Don't set<br>unless `mode` is set to `fleet`. |
@@ -200,7 +200,7 @@ ApmServerSpec holds the specification of an APM Server.
 | *`version`* __string__ | Version of the APM Server. |
 | *`image`* __string__ | Image is the APM Server Docker image to deploy. |
 | *`count`* __integer__ | Count of APM Server instances to deploy. |
-| *`config`* __[Config](#config)__ | Config holds the APM Server configuration. See: https://www.elastic.co/guide/en/apm/server/current/configuring-howto-apm-server.html |
+| *`config`* __[Config](#config)__ | Config holds the APM Server configuration. See: [Configure APM Server](docs-content://solutions/observability/apm/apm-server/configure.md) |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for the APM Server resource. |
 | *`elasticsearchRef`* __[ObjectSelector](#objectselector)__ | ElasticsearchRef is a reference to the output Elasticsearch cluster running in the same Kubernetes cluster. |
 | *`kibanaRef`* __[ObjectSelector](#objectselector)__ | KibanaRef is a reference to a Kibana instance running in the same Kubernetes cluster.<br>It allows APM agent central configuration management in Kibana. |
@@ -249,7 +249,7 @@ ApmServerSpec holds the specification of an APM Server.
 | *`version`* __string__ | Version of the APM Server. |
 | *`image`* __string__ | Image is the APM Server Docker image to deploy. |
 | *`count`* __integer__ | Count of APM Server instances to deploy. |
-| *`config`* __[Config](#config)__ | Config holds the APM Server configuration. See: https://www.elastic.co/guide/en/apm/server/current/configuring-howto-apm-server.html |
+| *`config`* __[Config](#config)__ | Config holds the APM Server configuration. See: [Configure APM Server](docs-content://solutions/observability/apm/apm-server/configure.md) |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for the APM Server resource. |
 | *`elasticsearchRef`* __[ObjectSelector](#objectselector)__ | ElasticsearchRef is a reference to the output Elasticsearch cluster running in the same Kubernetes cluster. |
 | *`podTemplate`* __[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podtemplatespec-v1-core)__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the APM Server pods. |
@@ -1167,7 +1167,7 @@ ElasticsearchSpec holds the specification of an Elasticsearch cluster.
 | *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (for ex. a remote Elasticsearch cluster) in a different namespace.<br>Can only be used if ECK is enforcing RBAC on references. |
 | *`remoteClusters`* __[RemoteCluster](#remotecluster) array__ | RemoteClusters enables you to establish uni-directional connections to a remote Elasticsearch cluster. |
 | *`volumeClaimDeletePolicy`* __[VolumeClaimDeletePolicy](#volumeclaimdeletepolicy)__ | VolumeClaimDeletePolicy sets the policy for handling deletion of PersistentVolumeClaims for all NodeSets.<br>Possible values are DeleteOnScaledownOnly and DeleteOnScaledownAndClusterDeletion. Defaults to DeleteOnScaledownAndClusterDeletion. |
-| *`monitoring`* __[Monitoring](#monitoring)__ | Monitoring enables you to collect and ship log and monitoring data of this Elasticsearch cluster.<br>See https://www.elastic.co/guide/en/elasticsearch/reference/current/monitor-elasticsearch-cluster.html.<br>Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different<br>Elasticsearch monitoring clusters running in the same Kubernetes cluster. |
+| *`monitoring`* __[Monitoring](#monitoring)__ | Monitoring enables you to collect and ship log and monitoring data of this Elasticsearch cluster.<br>See [Stack monitoring](docs-content://deploy-manage/monitor/stack-monitoring.md).<br>Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different<br>Elasticsearch monitoring clusters running in the same Kubernetes cluster. |
 | *`revisionHistoryLimit`* __integer__ | RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying StatefulSets. |
 
 
@@ -1300,7 +1300,7 @@ RemoteCluster declares a remote Elasticsearch cluster connection.
 | --- | --- |
 | *`name`* __string__ | Name is the name of the remote cluster as it is set in the Elasticsearch settings.<br>The name is expected to be unique for each remote clusters. |
 | *`elasticsearchRef`* __[LocalObjectSelector](#localobjectselector)__ | ElasticsearchRef is a reference to an Elasticsearch cluster running within the same k8s cluster. |
-| *`apiKey`* __[RemoteClusterAPIKey](#remoteclusterapikey)__ | APIKey can be used to enable remote cluster access using Cross-Cluster API keys: https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-cross-cluster-api-key.html |
+| *`apiKey`* __[RemoteClusterAPIKey](#remoteclusterapikey)__ | APIKey can be used to enable remote cluster access using Cross-Cluster API keys: [Create cross-cluster API key]({{es-apis}}operation/operation-security-create-cross-cluster-api-key) |
 
 
 ### RemoteClusterAPIKey  [#remoteclusterapikey]
@@ -1319,7 +1319,7 @@ RemoteClusterAPIKey defines a remote cluster API Key.
 
 ### RemoteClusterAccess  [#remoteclusteraccess]
 
-RemoteClusterAccess models the API key specification as documented in https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-cross-cluster-api-key.html
+RemoteClusterAccess models the API key specification as documented in [Create cross-cluster API key]({{es-apis}}operation/operation-security-create-cross-cluster-api-key)
 
 :::{admonition} Appears In:
 * [RemoteClusterAPIKey](#remoteclusterapikey)
@@ -1786,13 +1786,13 @@ KibanaSpec holds the specification of a Kibana instance.
 | *`elasticsearchRef`* __[ObjectSelector](#objectselector)__ | ElasticsearchRef is a reference to an Elasticsearch cluster running in the same Kubernetes cluster. |
 | *`packageRegistryRef`* __[ObjectSelector](#objectselector)__ | PackageRegistryRef is a reference to an Elastic Package Registry running in the same Kubernetes cluster. |
 | *`enterpriseSearchRef`* __[ObjectSelector](#objectselector)__ | EnterpriseSearchRef is a reference to an EnterpriseSearch running in the same Kubernetes cluster.<br>Kibana provides the default Enterprise Search UI starting version 7.14. |
-| *`config`* __[Config](#config)__ | Config holds the Kibana configuration. See: https://www.elastic.co/guide/en/kibana/current/settings.html |
+| *`config`* __[Config](#config)__ | Config holds the Kibana configuration. See: [Kibana configuration reference](kibana://reference/configuration-reference.md) |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for Kibana. |
 | *`podTemplate`* __[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podtemplatespec-v1-core)__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Kibana pods |
 | *`revisionHistoryLimit`* __integer__ | RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying Deployment. |
 | *`secureSettings`* __[SecretSource](#secretsource) array__ | SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for Kibana. |
 | *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace.<br>Can only be used if ECK is enforcing RBAC on references. |
-| *`monitoring`* __[Monitoring](#monitoring)__ | Monitoring enables you to collect and ship log and monitoring data of this Kibana.<br>See https://www.elastic.co/guide/en/kibana/current/xpack-monitoring.html.<br>Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different<br>Elasticsearch monitoring clusters running in the same Kubernetes cluster. |
+| *`monitoring`* __[Monitoring](#monitoring)__ | Monitoring enables you to collect and ship log and monitoring data of this Kibana.<br>See [Stack monitoring](docs-content://deploy-manage/monitor/stack-monitoring.md).<br>Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different<br>Elasticsearch monitoring clusters running in the same Kubernetes cluster. |
 
 
 
@@ -1835,7 +1835,7 @@ KibanaSpec holds the specification of a Kibana instance.
 | *`image`* __string__ | Image is the Kibana Docker image to deploy. |
 | *`count`* __integer__ | Count of Kibana instances to deploy. |
 | *`elasticsearchRef`* __[ObjectSelector](#objectselector)__ | ElasticsearchRef is a reference to an Elasticsearch cluster running in the same Kubernetes cluster. |
-| *`config`* __[Config](#config)__ | Config holds the Kibana configuration. See: https://www.elastic.co/guide/en/kibana/current/settings.html |
+| *`config`* __[Config](#config)__ | Config holds the Kibana configuration. See: [Kibana configuration reference](kibana://reference/configuration-reference.md) |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for Kibana. |
 | *`podTemplate`* __[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podtemplatespec-v1-core)__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Kibana pods |
 | *`secureSettings`* __[SecretSource](#secretsource) array__ | SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for Kibana. |
@@ -2015,7 +2015,7 @@ MapsSpec holds the specification of an Elastic Maps Server instance.
 | *`image`* __string__ | Image is the Elastic Maps Server Docker image to deploy. |
 | *`count`* __integer__ | Count of Elastic Maps Server instances to deploy. |
 | *`elasticsearchRef`* __[ObjectSelector](#objectselector)__ | ElasticsearchRef is a reference to an Elasticsearch cluster running in the same Kubernetes cluster. |
-| *`config`* __[Config](#config)__ | Config holds the ElasticMapsServer configuration. See: https://www.elastic.co/guide/en/kibana/current/maps-connect-to-ems.html#elastic-maps-server-configuration |
+| *`config`* __[Config](#config)__ | Config holds the ElasticMapsServer configuration. See: [Connect to Elastic Maps Service](docs-content://explore-analyze/visualize/maps/maps-connect-to-ems.md#elastic-maps-server-configuration) |
 | *`configRef`* __[ConfigSource](#configsource)__ | ConfigRef contains a reference to an existing Kubernetes Secret holding the Elastic Maps Server configuration.<br>Configuration settings are merged and have precedence over settings specified in `config`. |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for Elastic Maps Server. |
 | *`podTemplate`* __[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podtemplatespec-v1-core)__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Elastic Maps Server pods |

--- a/docs/reference/api-reference/3_3_2.md
+++ b/docs/reference/api-reference/3_3_2.md
@@ -90,7 +90,7 @@ AgentSpec defines the desired state of the Agent
 | *`statefulSet`* __[StatefulSetSpec](#statefulsetspec)__ | StatefulSet specifies the Agent should be deployed as a StatefulSet, and allows providing its spec.<br>Cannot be used along with `daemonSet` or `deployment`. |
 | *`revisionHistoryLimit`* __integer__ | RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying DaemonSet or Deployment or StatefulSet. |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for the Agent in Fleet mode with Fleet Server enabled. |
-| *`mode`* __[AgentMode](#agentmode)__ | Mode specifies the runtime mode for the Agent. The configuration can be specified locally through<br>`config` or `configRef` (`standalone` mode), or come from Fleet during runtime (`fleet` mode). Starting with<br>version 8.13.0 Fleet-managed agents support advanced configuration via a local configuration file.<br>See https://www.elastic.co/docs/reference/fleet/advanced-kubernetes-managed-by-fleet<br>Defaults to `standalone` mode. |
+| *`mode`* __[AgentMode](#agentmode)__ | Mode specifies the runtime mode for the Agent. The configuration can be specified locally through<br>`config` or `configRef` (`standalone` mode), or come from Fleet during runtime (`fleet` mode). Starting with<br>version 8.13.0 Fleet-managed agents support advanced configuration via a local configuration file.<br>See [Advanced Elastic Agent configuration managed by Fleet](docs-content://reference/fleet/advanced-kubernetes-managed-by-fleet.md)<br>Defaults to `standalone` mode. |
 | *`fleetServerEnabled`* __boolean__ | FleetServerEnabled determines whether this Agent will launch Fleet Server. Don't set unless `mode` is set to `fleet`. |
 | *`policyID`* __string__ | PolicyID determines into which Agent Policy this Agent will be enrolled.<br>This field will become mandatory in a future release, default policies are deprecated since 8.1.0. |
 | *`kibanaRef`* __[ObjectSelector](#objectselector)__ | KibanaRef is a reference to Kibana where Fleet should be set up and this Agent should be enrolled. Don't set<br>unless `mode` is set to `fleet`. |
@@ -200,7 +200,7 @@ ApmServerSpec holds the specification of an APM Server.
 | *`version`* __string__ | Version of the APM Server. |
 | *`image`* __string__ | Image is the APM Server Docker image to deploy. |
 | *`count`* __integer__ | Count of APM Server instances to deploy. |
-| *`config`* __[Config](#config)__ | Config holds the APM Server configuration. See: https://www.elastic.co/guide/en/apm/server/current/configuring-howto-apm-server.html |
+| *`config`* __[Config](#config)__ | Config holds the APM Server configuration. See: [Configure APM Server](docs-content://solutions/observability/apm/apm-server/configure.md) |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for the APM Server resource. |
 | *`elasticsearchRef`* __[ObjectSelector](#objectselector)__ | ElasticsearchRef is a reference to the output Elasticsearch cluster running in the same Kubernetes cluster. |
 | *`kibanaRef`* __[ObjectSelector](#objectselector)__ | KibanaRef is a reference to a Kibana instance running in the same Kubernetes cluster.<br>It allows APM agent central configuration management in Kibana. |
@@ -249,7 +249,7 @@ ApmServerSpec holds the specification of an APM Server.
 | *`version`* __string__ | Version of the APM Server. |
 | *`image`* __string__ | Image is the APM Server Docker image to deploy. |
 | *`count`* __integer__ | Count of APM Server instances to deploy. |
-| *`config`* __[Config](#config)__ | Config holds the APM Server configuration. See: https://www.elastic.co/guide/en/apm/server/current/configuring-howto-apm-server.html |
+| *`config`* __[Config](#config)__ | Config holds the APM Server configuration. See: [Configure APM Server](docs-content://solutions/observability/apm/apm-server/configure.md) |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for the APM Server resource. |
 | *`elasticsearchRef`* __[ObjectSelector](#objectselector)__ | ElasticsearchRef is a reference to the output Elasticsearch cluster running in the same Kubernetes cluster. |
 | *`podTemplate`* __[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podtemplatespec-v1-core)__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the APM Server pods. |
@@ -1167,7 +1167,7 @@ ElasticsearchSpec holds the specification of an Elasticsearch cluster.
 | *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (for ex. a remote Elasticsearch cluster) in a different namespace.<br>Can only be used if ECK is enforcing RBAC on references. |
 | *`remoteClusters`* __[RemoteCluster](#remotecluster) array__ | RemoteClusters enables you to establish uni-directional connections to a remote Elasticsearch cluster. |
 | *`volumeClaimDeletePolicy`* __[VolumeClaimDeletePolicy](#volumeclaimdeletepolicy)__ | VolumeClaimDeletePolicy sets the policy for handling deletion of PersistentVolumeClaims for all NodeSets.<br>Possible values are DeleteOnScaledownOnly and DeleteOnScaledownAndClusterDeletion. Defaults to DeleteOnScaledownAndClusterDeletion. |
-| *`monitoring`* __[Monitoring](#monitoring)__ | Monitoring enables you to collect and ship log and monitoring data of this Elasticsearch cluster.<br>See https://www.elastic.co/guide/en/elasticsearch/reference/current/monitor-elasticsearch-cluster.html.<br>Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different<br>Elasticsearch monitoring clusters running in the same Kubernetes cluster. |
+| *`monitoring`* __[Monitoring](#monitoring)__ | Monitoring enables you to collect and ship log and monitoring data of this Elasticsearch cluster.<br>See [Stack monitoring](docs-content://deploy-manage/monitor/stack-monitoring.md).<br>Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different<br>Elasticsearch monitoring clusters running in the same Kubernetes cluster. |
 | *`revisionHistoryLimit`* __integer__ | RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying StatefulSets. |
 
 
@@ -1300,7 +1300,7 @@ RemoteCluster declares a remote Elasticsearch cluster connection.
 | --- | --- |
 | *`name`* __string__ | Name is the name of the remote cluster as it is set in the Elasticsearch settings.<br>The name is expected to be unique for each remote clusters. |
 | *`elasticsearchRef`* __[LocalObjectSelector](#localobjectselector)__ | ElasticsearchRef is a reference to an Elasticsearch cluster running within the same k8s cluster. |
-| *`apiKey`* __[RemoteClusterAPIKey](#remoteclusterapikey)__ | APIKey can be used to enable remote cluster access using Cross-Cluster API keys: https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-cross-cluster-api-key.html |
+| *`apiKey`* __[RemoteClusterAPIKey](#remoteclusterapikey)__ | APIKey can be used to enable remote cluster access using Cross-Cluster API keys: [Create cross-cluster API key]({{es-apis}}operation/operation-security-create-cross-cluster-api-key) |
 
 
 ### RemoteClusterAPIKey  [#remoteclusterapikey]
@@ -1319,7 +1319,7 @@ RemoteClusterAPIKey defines a remote cluster API Key.
 
 ### RemoteClusterAccess  [#remoteclusteraccess]
 
-RemoteClusterAccess models the API key specification as documented in https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-cross-cluster-api-key.html
+RemoteClusterAccess models the API key specification as documented in [Create cross-cluster API key]({{es-apis}}operation/operation-security-create-cross-cluster-api-key)
 
 :::{admonition} Appears In:
 * [RemoteClusterAPIKey](#remoteclusterapikey)
@@ -1786,13 +1786,13 @@ KibanaSpec holds the specification of a Kibana instance.
 | *`elasticsearchRef`* __[ObjectSelector](#objectselector)__ | ElasticsearchRef is a reference to an Elasticsearch cluster running in the same Kubernetes cluster. |
 | *`packageRegistryRef`* __[ObjectSelector](#objectselector)__ | PackageRegistryRef is a reference to an Elastic Package Registry running in the same Kubernetes cluster. |
 | *`enterpriseSearchRef`* __[ObjectSelector](#objectselector)__ | EnterpriseSearchRef is a reference to an EnterpriseSearch running in the same Kubernetes cluster.<br>Kibana provides the default Enterprise Search UI starting version 7.14. |
-| *`config`* __[Config](#config)__ | Config holds the Kibana configuration. See: https://www.elastic.co/guide/en/kibana/current/settings.html |
+| *`config`* __[Config](#config)__ | Config holds the Kibana configuration. See: [Kibana configuration reference](kibana://reference/configuration-reference.md) |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for Kibana. |
 | *`podTemplate`* __[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podtemplatespec-v1-core)__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Kibana pods |
 | *`revisionHistoryLimit`* __integer__ | RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying Deployment. |
 | *`secureSettings`* __[SecretSource](#secretsource) array__ | SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for Kibana. |
 | *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace.<br>Can only be used if ECK is enforcing RBAC on references. |
-| *`monitoring`* __[Monitoring](#monitoring)__ | Monitoring enables you to collect and ship log and monitoring data of this Kibana.<br>See https://www.elastic.co/guide/en/kibana/current/xpack-monitoring.html.<br>Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different<br>Elasticsearch monitoring clusters running in the same Kubernetes cluster. |
+| *`monitoring`* __[Monitoring](#monitoring)__ | Monitoring enables you to collect and ship log and monitoring data of this Kibana.<br>See [Stack monitoring](docs-content://deploy-manage/monitor/stack-monitoring.md).<br>Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different<br>Elasticsearch monitoring clusters running in the same Kubernetes cluster. |
 
 
 
@@ -1835,7 +1835,7 @@ KibanaSpec holds the specification of a Kibana instance.
 | *`image`* __string__ | Image is the Kibana Docker image to deploy. |
 | *`count`* __integer__ | Count of Kibana instances to deploy. |
 | *`elasticsearchRef`* __[ObjectSelector](#objectselector)__ | ElasticsearchRef is a reference to an Elasticsearch cluster running in the same Kubernetes cluster. |
-| *`config`* __[Config](#config)__ | Config holds the Kibana configuration. See: https://www.elastic.co/guide/en/kibana/current/settings.html |
+| *`config`* __[Config](#config)__ | Config holds the Kibana configuration. See: [Kibana configuration reference](kibana://reference/configuration-reference.md) |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for Kibana. |
 | *`podTemplate`* __[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podtemplatespec-v1-core)__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Kibana pods |
 | *`secureSettings`* __[SecretSource](#secretsource) array__ | SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for Kibana. |
@@ -2015,7 +2015,7 @@ MapsSpec holds the specification of an Elastic Maps Server instance.
 | *`image`* __string__ | Image is the Elastic Maps Server Docker image to deploy. |
 | *`count`* __integer__ | Count of Elastic Maps Server instances to deploy. |
 | *`elasticsearchRef`* __[ObjectSelector](#objectselector)__ | ElasticsearchRef is a reference to an Elasticsearch cluster running in the same Kubernetes cluster. |
-| *`config`* __[Config](#config)__ | Config holds the ElasticMapsServer configuration. See: https://www.elastic.co/guide/en/kibana/current/maps-connect-to-ems.html#elastic-maps-server-configuration |
+| *`config`* __[Config](#config)__ | Config holds the ElasticMapsServer configuration. See: [Connect to Elastic Maps Service](docs-content://explore-analyze/visualize/maps/maps-connect-to-ems.md#elastic-maps-server-configuration) |
 | *`configRef`* __[ConfigSource](#configsource)__ | ConfigRef contains a reference to an existing Kubernetes Secret holding the Elastic Maps Server configuration.<br>Configuration settings are merged and have precedence over settings specified in `config`. |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for Elastic Maps Server. |
 | *`podTemplate`* __[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podtemplatespec-v1-core)__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Elastic Maps Server pods |

--- a/docs/reference/api-reference/3_4_0.md
+++ b/docs/reference/api-reference/3_4_0.md
@@ -90,7 +90,7 @@ AgentSpec defines the desired state of the Agent
 | *`statefulSet`* __[StatefulSetSpec](#statefulsetspec)__ | StatefulSet specifies the Agent should be deployed as a StatefulSet, and allows providing its spec.<br>Cannot be used along with `daemonSet` or `deployment`. |
 | *`revisionHistoryLimit`* __integer__ | RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying DaemonSet or Deployment or StatefulSet. |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for the Agent in Fleet mode with Fleet Server enabled. |
-| *`mode`* __[AgentMode](#agentmode)__ | Mode specifies the runtime mode for the Agent. The configuration can be specified locally through<br>`config` or `configRef` (`standalone` mode), or come from Fleet during runtime (`fleet` mode). Starting with<br>version 8.13.0 Fleet-managed agents support advanced configuration via a local configuration file.<br>See https://www.elastic.co/docs/reference/fleet/advanced-kubernetes-managed-by-fleet<br>Defaults to `standalone` mode. |
+| *`mode`* __[AgentMode](#agentmode)__ | Mode specifies the runtime mode for the Agent. The configuration can be specified locally through<br>`config` or `configRef` (`standalone` mode), or come from Fleet during runtime (`fleet` mode). Starting with<br>version 8.13.0 Fleet-managed agents support advanced configuration via a local configuration file.<br>See [Advanced Elastic Agent configuration managed by Fleet](docs-content://reference/fleet/advanced-kubernetes-managed-by-fleet.md)<br>Defaults to `standalone` mode. |
 | *`fleetServerEnabled`* __boolean__ | FleetServerEnabled determines whether this Agent will launch Fleet Server. Don't set unless `mode` is set to `fleet`. |
 | *`policyID`* __string__ | PolicyID determines into which Agent Policy this Agent will be enrolled.<br>This field will become mandatory in a future release, default policies are deprecated since 8.1.0. |
 | *`kibanaRef`* __[ObjectSelector](#objectselector)__ | KibanaRef is a reference to Kibana where Fleet should be set up and this Agent should be enrolled. Don't set<br>unless `mode` is set to `fleet`. |
@@ -200,7 +200,7 @@ ApmServerSpec holds the specification of an APM Server.
 | *`version`* __string__ | Version of the APM Server. |
 | *`image`* __string__ | Image is the APM Server Docker image to deploy. |
 | *`count`* __integer__ | Count of APM Server instances to deploy. |
-| *`config`* __[Config](#config)__ | Config holds the APM Server configuration. See: https://www.elastic.co/guide/en/apm/server/current/configuring-howto-apm-server.html |
+| *`config`* __[Config](#config)__ | Config holds the APM Server configuration. See: [Configure APM Server](docs-content://solutions/observability/apm/apm-server/configure.md) |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for the APM Server resource. |
 | *`elasticsearchRef`* __[ObjectSelector](#objectselector)__ | ElasticsearchRef is a reference to the output Elasticsearch cluster running in the same Kubernetes cluster. |
 | *`kibanaRef`* __[ObjectSelector](#objectselector)__ | KibanaRef is a reference to a Kibana instance running in the same Kubernetes cluster.<br>It allows APM agent central configuration management in Kibana. |
@@ -249,7 +249,7 @@ ApmServerSpec holds the specification of an APM Server.
 | *`version`* __string__ | Version of the APM Server. |
 | *`image`* __string__ | Image is the APM Server Docker image to deploy. |
 | *`count`* __integer__ | Count of APM Server instances to deploy. |
-| *`config`* __[Config](#config)__ | Config holds the APM Server configuration. See: https://www.elastic.co/guide/en/apm/server/current/configuring-howto-apm-server.html |
+| *`config`* __[Config](#config)__ | Config holds the APM Server configuration. See: [Configure APM Server](docs-content://solutions/observability/apm/apm-server/configure.md) |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for the APM Server resource. |
 | *`elasticsearchRef`* __[ObjectSelector](#objectselector)__ | ElasticsearchRef is a reference to the output Elasticsearch cluster running in the same Kubernetes cluster. |
 | *`podTemplate`* __[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podtemplatespec-v1-core)__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the APM Server pods. |
@@ -1240,7 +1240,7 @@ ElasticsearchSpec holds the specification of an Elasticsearch cluster.
 | *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (for ex. a remote Elasticsearch cluster) in a different namespace.<br>Can only be used if ECK is enforcing RBAC on references. |
 | *`remoteClusters`* __[RemoteCluster](#remotecluster) array__ | RemoteClusters enables you to establish uni-directional connections to a remote Elasticsearch cluster. |
 | *`volumeClaimDeletePolicy`* __[VolumeClaimDeletePolicy](#volumeclaimdeletepolicy)__ | VolumeClaimDeletePolicy sets the policy for handling deletion of PersistentVolumeClaims for all NodeSets.<br>Possible values are DeleteOnScaledownOnly and DeleteOnScaledownAndClusterDeletion. Defaults to DeleteOnScaledownAndClusterDeletion. |
-| *`monitoring`* __[Monitoring](#monitoring)__ | Monitoring enables you to collect and ship log and monitoring data of this Elasticsearch cluster.<br>See https://www.elastic.co/guide/en/elasticsearch/reference/current/monitor-elasticsearch-cluster.html.<br>Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different<br>Elasticsearch monitoring clusters running in the same Kubernetes cluster. |
+| *`monitoring`* __[Monitoring](#monitoring)__ | Monitoring enables you to collect and ship log and monitoring data of this Elasticsearch cluster.<br>See [Stack monitoring](docs-content://deploy-manage/monitor/stack-monitoring.md).<br>Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different<br>Elasticsearch monitoring clusters running in the same Kubernetes cluster. |
 | *`revisionHistoryLimit`* __integer__ | RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying StatefulSets. |
 
 
@@ -1374,7 +1374,7 @@ RemoteCluster declares a remote Elasticsearch cluster connection.
 | --- | --- |
 | *`name`* __string__ | Name is the name of the remote cluster as it is set in the Elasticsearch settings.<br>The name is expected to be unique for each remote clusters. |
 | *`elasticsearchRef`* __[LocalObjectSelector](#localobjectselector)__ | ElasticsearchRef is a reference to an Elasticsearch cluster running within the same k8s cluster. |
-| *`apiKey`* __[RemoteClusterAPIKey](#remoteclusterapikey)__ | APIKey can be used to enable remote cluster access using Cross-Cluster API keys: https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-cross-cluster-api-key.html |
+| *`apiKey`* __[RemoteClusterAPIKey](#remoteclusterapikey)__ | APIKey can be used to enable remote cluster access using Cross-Cluster API keys: [Create cross-cluster API key]({{es-apis}}operation/operation-security-create-cross-cluster-api-key) |
 
 
 ### RemoteClusterAPIKey  [#remoteclusterapikey]
@@ -1393,7 +1393,7 @@ RemoteClusterAPIKey defines a remote cluster API Key.
 
 ### RemoteClusterAccess  [#remoteclusteraccess]
 
-RemoteClusterAccess models the API key specification as documented in https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-cross-cluster-api-key.html
+RemoteClusterAccess models the API key specification as documented in [Create cross-cluster API key]({{es-apis}}operation/operation-security-create-cross-cluster-api-key)
 
 :::{admonition} Appears In:
 * [RemoteClusterAPIKey](#remoteclusterapikey)
@@ -1878,13 +1878,13 @@ KibanaSpec holds the specification of a Kibana instance.
 | *`elasticsearchRef`* __[ElasticsearchSelector](#elasticsearchselector)__ | ElasticsearchRef is a reference to an Elasticsearch cluster running in the same Kubernetes cluster. |
 | *`packageRegistryRef`* __[LocalObjectSelector](#localobjectselector)__ | PackageRegistryRef is a reference to an Elastic Package Registry running in the same Kubernetes cluster. |
 | *`enterpriseSearchRef`* __[ObjectSelector](#objectselector)__ | EnterpriseSearchRef is a reference to an EnterpriseSearch running in the same Kubernetes cluster.<br>Kibana provides the default Enterprise Search UI starting version 7.14. |
-| *`config`* __[Config](#config)__ | Config holds the Kibana configuration. See: https://www.elastic.co/guide/en/kibana/current/settings.html |
+| *`config`* __[Config](#config)__ | Config holds the Kibana configuration. See: [Kibana configuration reference](kibana://reference/configuration-reference.md) |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for Kibana. |
 | *`podTemplate`* __[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podtemplatespec-v1-core)__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Kibana pods |
 | *`revisionHistoryLimit`* __integer__ | RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying Deployment. |
 | *`secureSettings`* __[SecretSource](#secretsource) array__ | SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for Kibana. |
 | *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace.<br>Can only be used if ECK is enforcing RBAC on references. |
-| *`monitoring`* __[Monitoring](#monitoring)__ | Monitoring enables you to collect and ship log and monitoring data of this Kibana.<br>See https://www.elastic.co/guide/en/kibana/current/xpack-monitoring.html.<br>Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different<br>Elasticsearch monitoring clusters running in the same Kubernetes cluster. |
+| *`monitoring`* __[Monitoring](#monitoring)__ | Monitoring enables you to collect and ship log and monitoring data of this Kibana.<br>See [Stack monitoring](docs-content://deploy-manage/monitor/stack-monitoring.md).<br>Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different<br>Elasticsearch monitoring clusters running in the same Kubernetes cluster. |
 
 
 
@@ -1927,7 +1927,7 @@ KibanaSpec holds the specification of a Kibana instance.
 | *`image`* __string__ | Image is the Kibana Docker image to deploy. |
 | *`count`* __integer__ | Count of Kibana instances to deploy. |
 | *`elasticsearchRef`* __[ObjectSelector](#objectselector)__ | ElasticsearchRef is a reference to an Elasticsearch cluster running in the same Kubernetes cluster. |
-| *`config`* __[Config](#config)__ | Config holds the Kibana configuration. See: https://www.elastic.co/guide/en/kibana/current/settings.html |
+| *`config`* __[Config](#config)__ | Config holds the Kibana configuration. See: [Kibana configuration reference](kibana://reference/configuration-reference.md) |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for Kibana. |
 | *`podTemplate`* __[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podtemplatespec-v1-core)__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Kibana pods |
 | *`secureSettings`* __[SecretSource](#secretsource) array__ | SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for Kibana. |
@@ -2107,7 +2107,7 @@ MapsSpec holds the specification of an Elastic Maps Server instance.
 | *`image`* __string__ | Image is the Elastic Maps Server Docker image to deploy. |
 | *`count`* __integer__ | Count of Elastic Maps Server instances to deploy. |
 | *`elasticsearchRef`* __[ObjectSelector](#objectselector)__ | ElasticsearchRef is a reference to an Elasticsearch cluster running in the same Kubernetes cluster. |
-| *`config`* __[Config](#config)__ | Config holds the ElasticMapsServer configuration. See: https://www.elastic.co/guide/en/kibana/current/maps-connect-to-ems.html#elastic-maps-server-configuration |
+| *`config`* __[Config](#config)__ | Config holds the ElasticMapsServer configuration. See: [Connect to Elastic Maps Service](docs-content://explore-analyze/visualize/maps/maps-connect-to-ems.md#elastic-maps-server-configuration) |
 | *`configRef`* __[ConfigSource](#configsource)__ | ConfigRef contains a reference to an existing Kubernetes Secret holding the Elastic Maps Server configuration.<br>Configuration settings are merged and have precedence over settings specified in `config`. |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for Elastic Maps Server. |
 | *`podTemplate`* __[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podtemplatespec-v1-core)__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Elastic Maps Server pods |

--- a/docs/reference/api-reference/main.md
+++ b/docs/reference/api-reference/main.md
@@ -91,7 +91,7 @@ AgentSpec defines the desired state of the Agent
 | *`statefulSet`* __[StatefulSetSpec](#statefulsetspec)__ | StatefulSet specifies the Agent should be deployed as a StatefulSet, and allows providing its spec.<br>Cannot be used along with `daemonSet` or `deployment`. |
 | *`revisionHistoryLimit`* __integer__ | RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying DaemonSet or Deployment or StatefulSet. |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for the Agent in Fleet mode with Fleet Server enabled. |
-| *`mode`* __[AgentMode](#agentmode)__ | Mode specifies the runtime mode for the Agent. The configuration can be specified locally through<br>`config` or `configRef` (`standalone` mode), or come from Fleet during runtime (`fleet` mode). Starting with<br>version 8.13.0 Fleet-managed agents support advanced configuration via a local configuration file.<br>See https://www.elastic.co/docs/reference/fleet/advanced-kubernetes-managed-by-fleet<br>Defaults to `standalone` mode. |
+| *`mode`* __[AgentMode](#agentmode)__ | Mode specifies the runtime mode for the Agent. The configuration can be specified locally through<br>`config` or `configRef` (`standalone` mode), or come from Fleet during runtime (`fleet` mode). Starting with<br>version 8.13.0 Fleet-managed agents support advanced configuration via a local configuration file.<br>See [Advanced Elastic Agent configuration managed by Fleet](docs-content://reference/fleet/advanced-kubernetes-managed-by-fleet.md)<br>Defaults to `standalone` mode. |
 | *`fleetServerEnabled`* __boolean__ | FleetServerEnabled determines whether this Agent will launch Fleet Server. Don't set unless `mode` is set to `fleet`. |
 | *`policyID`* __string__ | PolicyID determines into which Agent Policy this Agent will be enrolled.<br>This field will become mandatory in a future release, default policies are deprecated since 8.1.0. |
 | *`spaceID`* __string__ | SpaceID is the ID of the Space where the Agent Policy is defined.<br>When empty, the default Space is used. Only effective for Kibana version 9.1.0+. |
@@ -202,7 +202,7 @@ ApmServerSpec holds the specification of an APM Server.
 | *`version`* __string__ | Version of the APM Server. |
 | *`image`* __string__ | Image is the APM Server Docker image to deploy. |
 | *`count`* __integer__ | Count of APM Server instances to deploy. |
-| *`config`* __[Config](#config)__ | Config holds the APM Server configuration. See: https://www.elastic.co/docs/solutions/observability/apm/apm-server/configure |
+| *`config`* __[Config](#config)__ | Config holds the APM Server configuration. See: [Configure APM Server](docs-content://solutions/observability/apm/apm-server/configure.md) |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for the APM Server resource. |
 | *`elasticsearchRef`* __[ElasticsearchSelector](#elasticsearchselector)__ | ElasticsearchRef is a reference to the output Elasticsearch cluster running in the same Kubernetes cluster. |
 | *`kibanaRef`* __[ObjectSelector](#objectselector)__ | KibanaRef is a reference to a Kibana instance running in the same Kubernetes cluster.<br>It allows APM agent central configuration management in Kibana. |
@@ -252,7 +252,7 @@ ApmServerSpec holds the specification of an APM Server.
 | *`version`* __string__ | Version of the APM Server. |
 | *`image`* __string__ | Image is the APM Server Docker image to deploy. |
 | *`count`* __integer__ | Count of APM Server instances to deploy. |
-| *`config`* __[Config](#config)__ | Config holds the APM Server configuration. See: https://www.elastic.co/docs/solutions/observability/apm/apm-server/configure |
+| *`config`* __[Config](#config)__ | Config holds the APM Server configuration. See: [Configure APM Server](docs-content://solutions/observability/apm/apm-server/configure.md) |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for the APM Server resource. |
 | *`elasticsearchRef`* __[ObjectSelector](#objectselector)__ | ElasticsearchRef is a reference to the output Elasticsearch cluster running in the same Kubernetes cluster. |
 | *`podTemplate`* __[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podtemplatespec-v1-core)__ | PodTemplate provides customization options (labels, annotations, affinity rules, resource requests, and so on) for the APM Server pods. |
@@ -1297,7 +1297,7 @@ ElasticsearchSpec holds the specification of an Elasticsearch cluster.
 | *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (for ex. a remote Elasticsearch cluster) in a different namespace.<br>Can only be used if ECK is enforcing RBAC on references. |
 | *`remoteClusters`* __[RemoteCluster](#remotecluster) array__ | RemoteClusters enables you to establish uni-directional connections to a remote Elasticsearch cluster. |
 | *`volumeClaimDeletePolicy`* __[VolumeClaimDeletePolicy](#volumeclaimdeletepolicy)__ | VolumeClaimDeletePolicy sets the policy for handling deletion of PersistentVolumeClaims for all NodeSets.<br>Possible values are DeleteOnScaledownOnly and DeleteOnScaledownAndClusterDeletion. Defaults to DeleteOnScaledownAndClusterDeletion. |
-| *`monitoring`* __[Monitoring](#monitoring)__ | Monitoring enables you to collect and ship log and monitoring data of this Elasticsearch cluster.<br>See https://www.elastic.co/docs/deploy-manage/monitor/stack-monitoring.<br>Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different<br>Elasticsearch monitoring clusters running in the same Kubernetes cluster. |
+| *`monitoring`* __[Monitoring](#monitoring)__ | Monitoring enables you to collect and ship log and monitoring data of this Elasticsearch cluster.<br>See [Stack monitoring](docs-content://deploy-manage/monitor/stack-monitoring.md).<br>Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different<br>Elasticsearch monitoring clusters running in the same Kubernetes cluster. |
 | *`revisionHistoryLimit`* __integer__ | RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying StatefulSets. |
 
 
@@ -1432,7 +1432,7 @@ RemoteCluster declares a remote Elasticsearch cluster connection.
 | --- | --- |
 | *`name`* __string__ | Name is the name of the remote cluster as it is set in the Elasticsearch settings.<br>The name is expected to be unique for each remote clusters. |
 | *`elasticsearchRef`* __[LocalObjectSelector](#localobjectselector)__ | ElasticsearchRef is a reference to an Elasticsearch cluster running within the same k8s cluster. |
-| *`apiKey`* __[RemoteClusterAPIKey](#remoteclusterapikey)__ | APIKey can be used to enable remote cluster access using Cross-Cluster API keys: https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-cross-cluster-api-key |
+| *`apiKey`* __[RemoteClusterAPIKey](#remoteclusterapikey)__ | APIKey can be used to enable remote cluster access using Cross-Cluster API keys: [Create cross-cluster API key]({{es-apis}}operation/operation-security-create-cross-cluster-api-key) |
 
 
 ### RemoteClusterAPIKey  [#remoteclusterapikey]
@@ -1451,7 +1451,7 @@ RemoteClusterAPIKey defines a remote cluster API Key.
 
 ### RemoteClusterAccess  [#remoteclusteraccess]
 
-RemoteClusterAccess models the API key specification as documented in https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-cross-cluster-api-key
+RemoteClusterAccess models the API key specification as documented in [Create cross-cluster API key]({{es-apis}}operation/operation-security-create-cross-cluster-api-key)
 
 :::{admonition} Appears In:
 * [RemoteClusterAPIKey](#remoteclusterapikey)
@@ -1937,14 +1937,14 @@ KibanaSpec holds the specification of a Kibana instance.
 | *`elasticsearchRef`* __[ElasticsearchSelector](#elasticsearchselector)__ | ElasticsearchRef is a reference to an Elasticsearch cluster running in the same Kubernetes cluster. |
 | *`packageRegistryRef`* __[LocalObjectSelector](#localobjectselector)__ | PackageRegistryRef is a reference to an Elastic Package Registry running in the same Kubernetes cluster. |
 | *`enterpriseSearchRef`* __[ObjectSelector](#objectselector)__ | EnterpriseSearchRef is a reference to an EnterpriseSearch running in the same Kubernetes cluster.<br>Kibana provides the default Enterprise Search UI starting version 7.14. |
-| *`config`* __[Config](#config)__ | Config holds the Kibana configuration. See: https://www.elastic.co/docs/reference/kibana/configuration-reference |
+| *`config`* __[Config](#config)__ | Config holds the Kibana configuration. See: [Kibana configuration reference](kibana://reference/configuration-reference.md) |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for Kibana. |
 | *`resources`* __[Resources](#resources)__ | Resources provides a shorthand to set CPU and Memory resources on the Kibana container. When set, these<br>values override any CPU or memory resource settings specified in the PodTemplate for the primary Kibana<br>container. To set resources on other containers, use the PodTemplate. |
 | *`podTemplate`* __[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podtemplatespec-v1-core)__ | PodTemplate provides customization options (labels, annotations, affinity rules, resource requests, and so on) for the Kibana pods |
 | *`revisionHistoryLimit`* __integer__ | RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying Deployment. |
 | *`secureSettings`* __[SecretSource](#secretsource) array__ | SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for Kibana. |
 | *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace.<br>Can only be used if ECK is enforcing RBAC on references. |
-| *`monitoring`* __[Monitoring](#monitoring)__ | Monitoring enables you to collect and ship log and monitoring data of this Kibana.<br>See https://www.elastic.co/docs/deploy-manage/monitor/stack-monitoring.<br>Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different<br>Elasticsearch monitoring clusters running in the same Kubernetes cluster. |
+| *`monitoring`* __[Monitoring](#monitoring)__ | Monitoring enables you to collect and ship log and monitoring data of this Kibana.<br>See [Stack monitoring](docs-content://deploy-manage/monitor/stack-monitoring.md).<br>Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different<br>Elasticsearch monitoring clusters running in the same Kubernetes cluster. |
 
 
 
@@ -1987,7 +1987,7 @@ KibanaSpec holds the specification of a Kibana instance.
 | *`image`* __string__ | Image is the Kibana Docker image to deploy. |
 | *`count`* __integer__ | Count of Kibana instances to deploy. |
 | *`elasticsearchRef`* __[ObjectSelector](#objectselector)__ | ElasticsearchRef is a reference to an Elasticsearch cluster running in the same Kubernetes cluster. |
-| *`config`* __[Config](#config)__ | Config holds the Kibana configuration. See: https://www.elastic.co/docs/reference/kibana/configuration-reference |
+| *`config`* __[Config](#config)__ | Config holds the Kibana configuration. See: [Kibana configuration reference](kibana://reference/configuration-reference.md) |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for Kibana. |
 | *`podTemplate`* __[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podtemplatespec-v1-core)__ | PodTemplate provides customization options (labels, annotations, affinity rules, resource requests, and so on) for the Kibana pods |
 | *`secureSettings`* __[SecretSource](#secretsource) array__ | SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for Kibana. |
@@ -2168,7 +2168,7 @@ MapsSpec holds the specification of an Elastic Maps Server instance.
 | *`image`* __string__ | Image is the Elastic Maps Server Docker image to deploy. |
 | *`count`* __integer__ | Count of Elastic Maps Server instances to deploy. |
 | *`elasticsearchRef`* __[ElasticsearchSelector](#elasticsearchselector)__ | ElasticsearchRef is a reference to an Elasticsearch cluster running in the same Kubernetes cluster. |
-| *`config`* __[Config](#config)__ | Config holds the ElasticMapsServer configuration. See: https://www.elastic.co/docs/explore-analyze/visualize/maps/maps-connect-to-ems#elastic-maps-server-configuration |
+| *`config`* __[Config](#config)__ | Config holds the ElasticMapsServer configuration. See: [Connect to Elastic Maps Service](docs-content://explore-analyze/visualize/maps/maps-connect-to-ems.md#elastic-maps-server-configuration) |
 | *`configRef`* __[ConfigSource](#configsource)__ | ConfigRef contains a reference to an existing Kubernetes Secret holding the Elastic Maps Server configuration.<br>Configuration settings are merged and have precedence over settings specified in `config`. |
 | *`http`* __[HTTPConfig](#httpconfig)__ | HTTP holds the HTTP layer configuration for Elastic Maps Server. |
 | *`resources`* __[Resources](#resources)__ | Resources provides a shorthand to set CPU and Memory resources on the Elastic Maps Server container. When set,<br>these values override any CPU or memory resource settings specified in the PodTemplate for the primary Elastic<br>Maps Server container. To set resources on other containers, use the PodTemplate. |

--- a/hack/api-docs/build.sh
+++ b/hack/api-docs/build.sh
@@ -37,19 +37,44 @@ build_docs() {
     # Remove dots from the version string for compatibility with the doc web site.
     local outFile="${version//./_}.md"
 
+    local SCRATCH_TEMPLATES="${SCRATCH_DIR}/templates"
+    local OUT_PATH="${DOCS_DIR}/reference/api-reference/${outFile}"
+
     (
         echo "Installing crd-ref-docs $REFDOCS_VER to $BIN_DIR"
         mkdir -p "$BIN_DIR"
         GOBIN=$BIN_DIR go install "${REFDOCS_REPO}@${REFDOCS_VER}"
+
+        echo "Staging templates and injecting URL mapping"
+        mkdir -p "${SCRATCH_TEMPLATES}"
+        cp -R "${SCRIPT_DIR}/templates/." "${SCRATCH_TEMPLATES}/"
+        MAPPING_PATH="${SCRIPT_DIR}/url-mapping.json" \
+        TEMPLATES_DIR="${SCRATCH_TEMPLATES}" \
+        python3 - <<'PYEOF'
+import json, os, pathlib
+m = json.load(open(os.environ["MAPPING_PATH"]))
+q = lambda s: s.replace("\\", "\\\\").replace('"', '\\"')
+pipe = "".join(' | replace "%s" "[%s](%s)"' % (q(u), q(e["text"]), q(e["link"])) for u, e in m["mappings"].items())
+for fname, expr, tail in [("type_members.tpl", "$field.Doc", ' | replace "\\n" "<br>"'), ("type.tpl", "$type.Doc", ""), ("gv_details.tpl", "$gv.Doc", "")]:
+    p = pathlib.Path(os.environ["TEMPLATES_DIR"]) / fname
+    src, old = p.read_text(), "{{ "+expr+tail+" }}"
+    if old not in src: raise SystemExit(f"pattern not found in {fname}: {old!r}")
+    p.write_text(src.replace(old, "{{ "+expr+pipe+tail+" }}"))
+PYEOF
 
         echo "Generating API reference documentation for version: ${version}, output file: ${outFile}"
         "${BIN_DIR}"/crd-ref-docs --source-path="${REPO_ROOT}"/pkg/apis \
             --config="${SCRIPT_DIR}"/config.yaml \
             --renderer=markdown \
             --template-value=eckVersion="${version}" \
-            --templates-dir="${SCRIPT_DIR}"/templates \
-            --output-path="${DOCS_DIR}"/reference/api-reference/"${outFile}"
+            --templates-dir="${SCRATCH_TEMPLATES}" \
+            --output-path="${OUT_PATH}"
     )
+
+    if grep -nE 'https://www\.elastic\.co/docs/' "${OUT_PATH}" >/dev/null; then
+        echo "WARNING: unmapped elastic.co/docs URL(s) in ${OUT_PATH} (add to url-mapping.json):" >&2
+        grep -nE 'https://www\.elastic\.co/docs/' "${OUT_PATH}" >&2
+    fi
 }
 
 trap cleanup EXIT

--- a/hack/api-docs/build.sh
+++ b/hack/api-docs/build.sh
@@ -13,17 +13,18 @@ set -euo pipefail
 SCRATCH_DIR="${SCRATCH_DIR:-$(mktemp -d -t crd-ref-docs-XXXXX)}"
 CLEANUP="${CLEANUP:-true}"
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# Load the version script to get the current version of the project.
-# shellcheck disable=SC1091
-source "${SCRIPT_DIR}"/../version.sh
-
 cleanup() {
     if [[ $CLEANUP == "true" ]]; then
         echo "Removing $SCRATCH_DIR"
         rm -rf "$SCRATCH_DIR" || echo "Failed to remove $SCRATCH_DIR"
     fi
 }
+trap cleanup EXIT
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Load the version script to get the current version of the project.
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}"/../version.sh
 
 build_docs() {
     local REPO_ROOT="${SCRIPT_DIR}/../.."
@@ -37,45 +38,39 @@ build_docs() {
     # Remove dots from the version string for compatibility with the doc web site.
     local outFile="${version//./_}.md"
 
-    local SCRATCH_TEMPLATES="${SCRATCH_DIR}/templates"
     local OUT_PATH="${DOCS_DIR}/reference/api-reference/${outFile}"
 
-    (
+    if [[ -x "${BIN_DIR}/crd-ref-docs" ]]; then
+        echo "Reusing crd-ref-docs at $BIN_DIR"
+    else
         echo "Installing crd-ref-docs $REFDOCS_VER to $BIN_DIR"
         mkdir -p "$BIN_DIR"
         GOBIN=$BIN_DIR go install "${REFDOCS_REPO}@${REFDOCS_VER}"
+    fi
 
-        echo "Staging templates and injecting URL mapping"
-        mkdir -p "${SCRATCH_TEMPLATES}"
-        cp -R "${SCRIPT_DIR}/templates/." "${SCRATCH_TEMPLATES}/"
-        MAPPING_PATH="${SCRIPT_DIR}/url-mapping.json" \
-        TEMPLATES_DIR="${SCRATCH_TEMPLATES}" \
-        python3 - <<'PYEOF'
+    echo "Generating API reference documentation for version: ${version}, output file: ${outFile}"
+    "${BIN_DIR}"/crd-ref-docs --source-path="${REPO_ROOT}"/pkg/apis \
+        --config="${SCRIPT_DIR}"/config.yaml \
+        --renderer=markdown \
+        --template-value=eckVersion="${version}" \
+        --templates-dir="${SCRIPT_DIR}"/templates \
+        --output-path="${OUT_PATH}"
+
+    echo "Rewriting URLs from url-mapping.json"
+    MAPPING_PATH="${SCRIPT_DIR}/url-mapping.json" OUT_PATH="${OUT_PATH}" python3 - <<'PYEOF'
 import json, os, pathlib
+p = pathlib.Path(os.environ["OUT_PATH"])
 m = json.load(open(os.environ["MAPPING_PATH"]))
-q = lambda s: s.replace("\\", "\\\\").replace('"', '\\"')
-pipe = "".join(' | replace "%s" "[%s](%s)"' % (q(u), q(e["text"]), q(e["link"])) for u, e in m["mappings"].items())
-for fname, expr, tail in [("type_members.tpl", "$field.Doc", ' | replace "\\n" "<br>"'), ("type.tpl", "$type.Doc", ""), ("gv_details.tpl", "$gv.Doc", "")]:
-    p = pathlib.Path(os.environ["TEMPLATES_DIR"]) / fname
-    src, old = p.read_text(), "{{ "+expr+tail+" }}"
-    if old not in src: raise SystemExit(f"pattern not found in {fname}: {old!r}")
-    p.write_text(src.replace(old, "{{ "+expr+pipe+tail+" }}"))
+src = p.read_text()
+for url, e in m["mappings"].items():
+    src = src.replace(url, f'[{e["text"]}]({e["link"]})')
+p.write_text(src)
 PYEOF
 
-        echo "Generating API reference documentation for version: ${version}, output file: ${outFile}"
-        "${BIN_DIR}"/crd-ref-docs --source-path="${REPO_ROOT}"/pkg/apis \
-            --config="${SCRIPT_DIR}"/config.yaml \
-            --renderer=markdown \
-            --template-value=eckVersion="${version}" \
-            --templates-dir="${SCRATCH_TEMPLATES}" \
-            --output-path="${OUT_PATH}"
-    )
-
-    if grep -nE 'https://www\.elastic\.co/docs/' "${OUT_PATH}" >/dev/null; then
-        echo "WARNING: unmapped elastic.co/docs URL(s) in ${OUT_PATH} (add to url-mapping.json):" >&2
-        grep -nE 'https://www\.elastic\.co/docs/' "${OUT_PATH}" >&2
+    if unmapped=$(grep -nE 'https://www\.elastic\.co/docs/' "${OUT_PATH}"); then
+        { echo "WARNING: unmapped elastic.co/docs URL(s) in ${OUT_PATH} (add to url-mapping.json):"
+          echo "$unmapped"; } >&2
     fi
 }
 
-trap cleanup EXIT
 build_docs

--- a/hack/api-docs/url-mapping.json
+++ b/hack/api-docs/url-mapping.json
@@ -1,15 +1,14 @@
 {
-  "_description": "Canonical mappings from legacy elastic.co/guide URLs to elastic.co/docs equivalents, as used in pkg/apis/**/*.go doc comments that flow through to the published API reference (docs/reference/api-reference/main.md) and CRD descriptions. Established by https://github.com/elastic/cloud-on-k8s/pull/9441. When you update a link in API source comments, prefer reusing or extending these targets so the published reference stays consistent.",
+  "_description": "elastic.co/docs URLs to docs-builder cross-repo links.",
   "mappings": {
-    "https://www.elastic.co/guide/en/apm/server/current/configuring-howto-apm-server.html": "https://www.elastic.co/docs/solutions/observability/apm/apm-server/configure",
-    "https://www.elastic.co/guide/en/kibana/current/settings.html": "https://www.elastic.co/docs/reference/kibana/configuration-reference",
-    "https://www.elastic.co/guide/en/kibana/current/xpack-monitoring.html": "https://www.elastic.co/docs/deploy-manage/monitor/stack-monitoring",
-    "https://www.elastic.co/guide/en/kibana/current/maps-connect-to-ems.html#elastic-maps-server-configuration": "https://www.elastic.co/docs/explore-analyze/visualize/maps/maps-connect-to-ems#elastic-maps-server-configuration",
-    "https://www.elastic.co/guide/en/elasticsearch/reference/current/monitor-elasticsearch-cluster.html": "https://www.elastic.co/docs/deploy-manage/monitor/stack-monitoring",
-    "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-cross-cluster-api-key.html": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-cross-cluster-api-key",
-    "https://www.elastic.co/guide/en/elasticsearch/reference/current/defining-roles.html#roles-management-file": "https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/defining-roles#roles-management-file",
-    "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-settings.html#password-hashing-algorithms": "https://www.elastic.co/docs/reference/elasticsearch/configuration-reference/security-settings#password-hashing-algorithms",
-    "https://www.elastic.co/guide/en/elasticsearch/reference/7.5/file-realm.html#file-realm-configuration": "https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/file-based#file-realm-configuration",
-    "https://www.elastic.co/guide/en/elasticsearch/reference/current/advanced-configuration.html#readiness-tcp-port": "https://www.elastic.co/docs/reference/elasticsearch/configuration-reference/networking-settings#tcp-readiness-port"
+    "https://www.elastic.co/docs/solutions/observability/apm/apm-server/configure": "docs-content://solutions/observability/apm/apm-server/configure.md",
+    "https://www.elastic.co/docs/reference/kibana/configuration-reference": "kibana://reference/configuration-reference.md",
+    "https://www.elastic.co/docs/deploy-manage/monitor/stack-monitoring": "docs-content://deploy-manage/monitor/stack-monitoring.md",
+    "https://www.elastic.co/docs/explore-analyze/visualize/maps/maps-connect-to-ems#elastic-maps-server-configuration": "docs-content://explore-analyze/visualize/maps/maps-connect-to-ems.md#elastic-maps-server-configuration",
+    "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-cross-cluster-api-key": "{{es-apis}}operation/operation-security-create-cross-cluster-api-key",
+    "https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/defining-roles#roles-management-file": "docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/defining-roles.md#roles-management-file",
+    "https://www.elastic.co/docs/reference/elasticsearch/configuration-reference/security-settings#password-hashing-algorithms": "elasticsearch://reference/elasticsearch/configuration-reference/security-settings.md#password-hashing-algorithms",
+    "https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/file-based#file-realm-configuration": "docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/file-based.md#file-realm-configuration",
+    "https://www.elastic.co/docs/reference/elasticsearch/configuration-reference/networking-settings#tcp-readiness-port": "elasticsearch://reference/elasticsearch/configuration-reference/networking-settings.md#tcp-readiness-port"
   }
 }

--- a/hack/api-docs/url-mapping.json
+++ b/hack/api-docs/url-mapping.json
@@ -1,0 +1,15 @@
+{
+  "_description": "Canonical mappings from legacy elastic.co/guide URLs to elastic.co/docs equivalents, as used in pkg/apis/**/*.go doc comments that flow through to the published API reference (docs/reference/api-reference/main.md) and CRD descriptions. Established by https://github.com/elastic/cloud-on-k8s/pull/9441. When you update a link in API source comments, prefer reusing or extending these targets so the published reference stays consistent.",
+  "mappings": {
+    "https://www.elastic.co/guide/en/apm/server/current/configuring-howto-apm-server.html": "https://www.elastic.co/docs/solutions/observability/apm/apm-server/configure",
+    "https://www.elastic.co/guide/en/kibana/current/settings.html": "https://www.elastic.co/docs/reference/kibana/configuration-reference",
+    "https://www.elastic.co/guide/en/kibana/current/xpack-monitoring.html": "https://www.elastic.co/docs/deploy-manage/monitor/stack-monitoring",
+    "https://www.elastic.co/guide/en/kibana/current/maps-connect-to-ems.html#elastic-maps-server-configuration": "https://www.elastic.co/docs/explore-analyze/visualize/maps/maps-connect-to-ems#elastic-maps-server-configuration",
+    "https://www.elastic.co/guide/en/elasticsearch/reference/current/monitor-elasticsearch-cluster.html": "https://www.elastic.co/docs/deploy-manage/monitor/stack-monitoring",
+    "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-cross-cluster-api-key.html": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-cross-cluster-api-key",
+    "https://www.elastic.co/guide/en/elasticsearch/reference/current/defining-roles.html#roles-management-file": "https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/defining-roles#roles-management-file",
+    "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-settings.html#password-hashing-algorithms": "https://www.elastic.co/docs/reference/elasticsearch/configuration-reference/security-settings#password-hashing-algorithms",
+    "https://www.elastic.co/guide/en/elasticsearch/reference/7.5/file-realm.html#file-realm-configuration": "https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/file-based#file-realm-configuration",
+    "https://www.elastic.co/guide/en/elasticsearch/reference/current/advanced-configuration.html#readiness-tcp-port": "https://www.elastic.co/docs/reference/elasticsearch/configuration-reference/networking-settings#tcp-readiness-port"
+  }
+}

--- a/hack/api-docs/url-mapping.json
+++ b/hack/api-docs/url-mapping.json
@@ -1,14 +1,45 @@
 {
   "_description": "elastic.co/docs URLs to docs-builder cross-repo links.",
   "mappings": {
-    "https://www.elastic.co/docs/solutions/observability/apm/apm-server/configure": "docs-content://solutions/observability/apm/apm-server/configure.md",
-    "https://www.elastic.co/docs/reference/kibana/configuration-reference": "kibana://reference/configuration-reference.md",
-    "https://www.elastic.co/docs/deploy-manage/monitor/stack-monitoring": "docs-content://deploy-manage/monitor/stack-monitoring.md",
-    "https://www.elastic.co/docs/explore-analyze/visualize/maps/maps-connect-to-ems#elastic-maps-server-configuration": "docs-content://explore-analyze/visualize/maps/maps-connect-to-ems.md#elastic-maps-server-configuration",
-    "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-cross-cluster-api-key": "{{es-apis}}operation/operation-security-create-cross-cluster-api-key",
-    "https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/defining-roles#roles-management-file": "docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/defining-roles.md#roles-management-file",
-    "https://www.elastic.co/docs/reference/elasticsearch/configuration-reference/security-settings#password-hashing-algorithms": "elasticsearch://reference/elasticsearch/configuration-reference/security-settings.md#password-hashing-algorithms",
-    "https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/file-based#file-realm-configuration": "docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/file-based.md#file-realm-configuration",
-    "https://www.elastic.co/docs/reference/elasticsearch/configuration-reference/networking-settings#tcp-readiness-port": "elasticsearch://reference/elasticsearch/configuration-reference/networking-settings.md#tcp-readiness-port"
+    "https://www.elastic.co/docs/solutions/observability/apm/apm-server/configure": {
+      "link": "docs-content://solutions/observability/apm/apm-server/configure.md",
+      "text": "Configure APM Server"
+    },
+    "https://www.elastic.co/docs/reference/kibana/configuration-reference": {
+      "link": "kibana://reference/configuration-reference.md",
+      "text": "Kibana configuration reference"
+    },
+    "https://www.elastic.co/docs/deploy-manage/monitor/stack-monitoring": {
+      "link": "docs-content://deploy-manage/monitor/stack-monitoring.md",
+      "text": "Stack monitoring"
+    },
+    "https://www.elastic.co/docs/explore-analyze/visualize/maps/maps-connect-to-ems#elastic-maps-server-configuration": {
+      "link": "docs-content://explore-analyze/visualize/maps/maps-connect-to-ems.md#elastic-maps-server-configuration",
+      "text": "Connect to Elastic Maps Service"
+    },
+    "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-cross-cluster-api-key": {
+      "link": "{{es-apis}}operation/operation-security-create-cross-cluster-api-key",
+      "text": "Create cross-cluster API key"
+    },
+    "https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/defining-roles#roles-management-file": {
+      "link": "docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/defining-roles.md#roles-management-file",
+      "text": "File-based role management"
+    },
+    "https://www.elastic.co/docs/reference/elasticsearch/configuration-reference/security-settings#password-hashing-algorithms": {
+      "link": "elasticsearch://reference/elasticsearch/configuration-reference/security-settings.md#password-hashing-algorithms",
+      "text": "Password hashing algorithms"
+    },
+    "https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/file-based#file-realm-configuration": {
+      "link": "docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/file-based.md#file-realm-configuration",
+      "text": "Configure a file realm"
+    },
+    "https://www.elastic.co/docs/reference/elasticsearch/configuration-reference/networking-settings#tcp-readiness-port": {
+      "link": "elasticsearch://reference/elasticsearch/configuration-reference/networking-settings.md#tcp-readiness-port",
+      "text": "TCP readiness port"
+    },
+    "https://www.elastic.co/docs/reference/fleet/advanced-kubernetes-managed-by-fleet": {
+      "link": "docs-content://reference/fleet/advanced-kubernetes-managed-by-fleet.md",
+      "text": "Advanced Elastic Agent configuration managed by Fleet"
+    }
   }
 }

--- a/hack/api-docs/url-mapping.json
+++ b/hack/api-docs/url-mapping.json
@@ -1,5 +1,5 @@
 {
-  "_description": "elastic.co/docs URLs to docs-builder cross-repo links.",
+  "_description": "mapping elastic.co/docs URLs to docs-builder cross-repo links to allow validation",
   "mappings": {
     "https://www.elastic.co/docs/solutions/observability/apm/apm-server/configure": {
       "link": "docs-content://solutions/observability/apm/apm-server/configure.md",


### PR DESCRIPTION
To leverage docs link validation, mapping all links introduced in godoc comments to docs-builder style xlinks with link text. We warn on "plain" docs links so this will also make any docs build output cleaner.

Wired it into hack/api-docs/build.sh so url-mapping.json is applied to the rendered markdown after crd-ref-docs runs, and warns on any unmapped URL

Regenerated main.md and applied link changes to docs that were generated for previous cloud-on-k8s releases
