### PR TITLE
e2e: assert Elasticsearch association is Established before Agent data validation

### DIFF
--- a/test/e2e/test/agent/steps.go
+++ b/test/e2e/test/agent/steps.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	agentv1alpha1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/agent/v1alpha1"
+	commonv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/pointer"
@@ -138,13 +139,35 @@ func (b Builder) CreationTestSteps(k *test.K8sClient) test.StepList {
 func (b Builder) CheckK8sTestSteps(k *test.K8sClient) test.StepList {
 	return test.StepList{
 		{
+			Name: "Agent Elasticsearch associations should be established",
+			Test: test.Eventually(func() error {
+				var agent agentv1alpha1.Agent
+				if err := k.Client.Get(context.Background(), k8s.ExtractNamespacedName(&b.Agent), &agent); err != nil {
+					return err
+				}
+				expected := len(b.Agent.Spec.ElasticsearchRefs)
+				got := len(agent.Status.ElasticsearchAssociationsStatus)
+				if expected != got {
+					return fmt.Errorf("expected %d ES association(s) in status, got %d", expected, got)
+				}
+				for ref, s := range agent.Status.ElasticsearchAssociationsStatus {
+					if s != commonv1.AssociationEstablished {
+						return fmt.Errorf("ES association %s is %q, expected %q", ref, s, commonv1.AssociationEstablished)
+					}
+				}
+				return nil
+			}),
+			Skip: func() bool {
+				return len(b.Agent.Spec.ElasticsearchRefs) == 0
+			},
+		},
+		{
 			Name: "Agent status should be updated",
 			Test: test.Eventually(func() error {
 				var agent agentv1alpha1.Agent
 				if err := k.Client.Get(context.Background(), k8s.ExtractNamespacedName(&b.Agent), &agent); err != nil {
 					return err
 				}
-				// don't check association statuses that may vary across tests
 				agent.Status.ElasticsearchAssociationsStatus = nil
 				agent.Status.KibanaAssociationStatus = ""
 				agent.Status.FleetServerAssociationStatus = ""


### PR DESCRIPTION

## Problem

The Agent e2e tests (`TestSystemIntegrationConfig`, `TestAgentConfigRef`, `TestMultipleOutputConfig`, etc.) verify that an Elastic Agent can write data to Elasticsearch by polling for healthy data streams. However, they never explicitly assert that the credential handshake between the Agent and Elasticsearch completed successfully.

### The gap

`CheckK8sTestSteps` for the Agent **zeroed out** `ElasticsearchAssociationsStatus` before comparing the expected status, meaning the test never verified that the association reached `Established`:

```go
// don't check association statuses that may vary across tests
agent.Status.ElasticsearchAssociationsStatus = nil
```

The data-stream validations in `CheckStackTestSteps` implicitly covered this via `test.Eventually` retries, but a credential failure would only manifest as a timeout rather than a clear assertion error.

Compare with the Logstash e2e steps, which already check:

```go
for a, s := range logstash.Status.ElasticsearchAssociationsStatus {
    if s != v1.AssociationEstablished {
        return fmt.Errorf("elasticsearch association %s has status %s ", a, s)
    }
}
```

## Fix

Add a dedicated `"Agent Elasticsearch associations should be established"` step in `CheckK8sTestSteps` (skipped when no ES refs are declared) that:

- Asserts the number of association entries in status matches the number of
  declared `ElasticsearchRefs`.
- Asserts every entry has status `Established`.

This makes a credential setup failure fail fast with a clear message instead of timing out on data-stream polling.