### PR TITLE
fix TESTS_MATCH default value breaking YAML after #9462

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -465,7 +465,7 @@ drivah-build-e2e:
 
 E2E_STACK_VERSION          ?= 9.4.0
 # regexp to filter tests to run
-export TESTS_MATCH         ?= "^Test"
+export TESTS_MATCH         ?= ^Test
 export E2E_JSON            ?= false
 TEST_TIMEOUT               ?= 15m
 E2E_SKIP_CLEANUP           ?= false


### PR DESCRIPTION
## Problem

  #9462 wrapped `--test-regex=$(TESTS_MATCH)` in single quotes to prevent `|` from being interpreted as a shell pipe operator. However, the default value `"^Test"` contained embedded double quotes that the original unquoted recipe
  silently stripped via shell interpretation. With single quotes those `"` are passed literally to the binary, which embeds them in the `e2e_job.yaml` template and produces invalid YAML:

```
  "-run", ""^Test""
                 ^^ unescaped quote inside a double-quoted YAML string
```

  Result:

  error: error parsing e2e_job.yaml: error converting YAML to JSON: yaml: line 30: did not find expected ',' or ']'

  ## Fix

  Remove the embedded double quotes from the default value:

  ```makefile
  # before
  export TESTS_MATCH ?= "^Test"
  # after
  export TESTS_MATCH ?= ^Test
  ```