### PR TITLE
Test that restart shutdowns for not-yet-rejoined nodes are preserved

### DIFF
--- a/pkg/controller/elasticsearch/driver/stateful/driver_test.go
+++ b/pkg/controller/elasticsearch/driver/stateful/driver_test.go
@@ -239,8 +239,8 @@ func TestDriver_hasPendingSpecChanges(t *testing.T) {
 
 type fakeESShutdownClient struct {
 	esclient.Client
-	restartedNodeIDs       []string
-	terminatedNodeIDs      []string
+	restartedNodeIDs  []string
+	terminatedNodeIDs []string
 	// notYetJoinedRestartNodeIDs have a completed Restart shutdown record but are NOT yet members of the
 	// cluster — they model nodes that finished their restart shutdown but haven't rejoined yet. They are
 	// returned by GetShutdown but excluded from GetNodes, so OnlyNodesInCluster filters them out.

--- a/pkg/controller/elasticsearch/driver/stateful/driver_test.go
+++ b/pkg/controller/elasticsearch/driver/stateful/driver_test.go
@@ -241,7 +241,11 @@ type fakeESShutdownClient struct {
 	esclient.Client
 	restartedNodeIDs       []string
 	terminatedNodeIDs      []string
-	shutdownDeletedNodeIDs map[string]struct{}
+	// notYetJoinedRestartNodeIDs have a completed Restart shutdown record but are NOT yet members of the
+	// cluster — they model nodes that finished their restart shutdown but haven't rejoined yet. They are
+	// returned by GetShutdown but excluded from GetNodes, so OnlyNodesInCluster filters them out.
+	notYetJoinedRestartNodeIDs []string
+	shutdownDeletedNodeIDs     map[string]struct{}
 }
 
 func (f *fakeESShutdownClient) GetNodes(_ context.Context) (esclient.Nodes, error) {
@@ -258,8 +262,11 @@ func (f *fakeESShutdownClient) GetNodes(_ context.Context) (esclient.Nodes, erro
 }
 
 func (f *fakeESShutdownClient) GetShutdown(_ context.Context, _ *string) (esclient.ShutdownResponse, error) {
-	shutdownNodes := make([]esclient.NodeShutdown, 0, len(f.restartedNodeIDs)+len(f.terminatedNodeIDs))
+	shutdownNodes := make([]esclient.NodeShutdown, 0, len(f.restartedNodeIDs)+len(f.terminatedNodeIDs)+len(f.notYetJoinedRestartNodeIDs))
 	for _, nodeID := range f.restartedNodeIDs {
+		shutdownNodes = append(shutdownNodes, esclient.NodeShutdown{NodeID: nodeID, Type: string(esclient.Restart), Status: esclient.ShutdownComplete})
+	}
+	for _, nodeID := range f.notYetJoinedRestartNodeIDs {
 		shutdownNodes = append(shutdownNodes, esclient.NodeShutdown{NodeID: nodeID, Type: string(esclient.Restart), Status: esclient.ShutdownComplete})
 	}
 	for _, nodeID := range f.terminatedNodeIDs {
@@ -327,18 +334,19 @@ func TestDriver_reconcileCriticalStepsWhilePaused(t *testing.T) {
 	matchingStatefulSets := expectedResources.StatefulSets()
 
 	tests := []struct {
-		name                 string
-		k8sObjects           []crclient.Object // pre-existing StatefulSets beyond scriptsConfigMap
-		resolvedConfig       nodespec.ResolvedConfig
-		failK8sClient        bool
-		restartedNodeIDs     []string
-		terminatedNodeIDs    []string
-		wantErr              bool
-		wantRequeue          bool
-		wantCondStatus       corev1.ConditionStatus
-		wantCondMsgSubstr    string
-		wantEvents           []events.Event
-		wantClearedShutdowns []string
+		name                       string
+		k8sObjects                 []crclient.Object // pre-existing StatefulSets beyond scriptsConfigMap
+		resolvedConfig             nodespec.ResolvedConfig
+		failK8sClient              bool
+		restartedNodeIDs           []string
+		terminatedNodeIDs          []string
+		notYetJoinedRestartNodeIDs []string
+		wantErr                    bool
+		wantRequeue                bool
+		wantCondStatus             corev1.ConditionStatus
+		wantCondMsgSubstr          string
+		wantEvents                 []events.Event
+		wantClearedShutdowns       []string
 	}{
 		{
 			name:           "actual StatefulSets match expected: no pending changes",
@@ -376,13 +384,14 @@ func TestDriver_reconcileCriticalStepsWhilePaused(t *testing.T) {
 			},
 		},
 		{
-			name:                 "restarted pods that have not yet joined trigger a requeue",
-			resolvedConfig:       resolvedConfig,
-			restartedNodeIDs:     nil,
-			terminatedNodeIDs:    []string{"node-to-terminated"},
-			wantClearedShutdowns: nil,
-			wantCondStatus:       corev1.ConditionTrue,
-			wantCondMsgSubstr:    "spec changes are pending and will be applied on resume",
+			// Verifies OnlyNodesInCluster gating: a completed Restart shutdown record whose node
+			// has not yet rejoined the cluster must NOT be cleared.
+			name:                       "restart shutdowns for nodes that have not yet rejoined are preserved",
+			resolvedConfig:             resolvedConfig,
+			notYetJoinedRestartNodeIDs: []string{"node-still-rejoining"},
+			wantClearedShutdowns:       nil,
+			wantCondStatus:             corev1.ConditionTrue,
+			wantCondMsgSubstr:          "spec changes are pending and will be applied on resume",
 			wantEvents: []events.Event{
 				{
 					EventType: corev1.EventTypeWarning,
@@ -418,8 +427,9 @@ func TestDriver_reconcileCriticalStepsWhilePaused(t *testing.T) {
 			}
 
 			shutdownClient := &fakeESShutdownClient{
-				restartedNodeIDs:  tt.restartedNodeIDs,
-				terminatedNodeIDs: tt.terminatedNodeIDs,
+				restartedNodeIDs:           tt.restartedNodeIDs,
+				terminatedNodeIDs:          tt.terminatedNodeIDs,
+				notYetJoinedRestartNodeIDs: tt.notYetJoinedRestartNodeIDs,
 			}
 			sharedState.ESClient = shutdownClient
 


### PR DESCRIPTION
## Summary

Follow-up to a [review comment on #9398](https://github.com/elastic/cloud-on-k8s/pull/9398#discussion_r3287046817). The "restarted pods that have not yet joined trigger a requeue" case in `TestDriver_reconcileCriticalStepsWhilePaused` didn't match its name: with `restartedNodeIDs = nil` and an empty `k8sObjects`, neither the `ssetIsSteady` requeue path nor any restart-shutdown clearing actually ran. The requeue came from the empty-vs-expected spec diff in `hasPendingSpecChanges`, so the case was effectively a duplicate of "no actual StatefulSets: pending changes detected" with an inert `terminatedNodeIDs` field (the `Remove`-type shutdown it produced was always filtered out by the `Restart`-typed `Clear` call's `ShutdownComplete.Applies` predicate).

This PR rewrites the case to actually exercise what its name implies. `fakeESShutdownClient` gets a new `notYetJoinedRestartNodeIDs` field: IDs that appear in `GetShutdown` as `Restart` / `ShutdownComplete` but are deliberately excluded from `GetNodes`, modeling a node that finished its restart shutdown but hasn't rejoined the cluster yet. The new case proves the `OnlyNodesInCluster` gating in `nodeShutdown.Clear` — without that predicate, the shutdown record would be deleted and `wantClearedShutdowns: nil` would fail.

## Test plan

- [x] `go test ./pkg/controller/elasticsearch/driver/stateful/ -run TestDriver_reconcileCriticalStepsWhilePaused -v` passes
- [x] Mutation check: temporarily drop `nodeShutdown.OnlyNodesInCluster` from the `Clear` call in `pkg/controller/elasticsearch/driver/stateful/driver.go` — the new case should fail with `wantClearedShutdowns: nil` violated

🤖 Generated with [Claude Code](https://claude.com/claude-code)