### PR TITLE
e2e: fix Agent pause-orchestration test on OCP clusters

### DIFF
--- a/test/e2e/test/agent/builder.go
+++ b/test/e2e/test/agent/builder.go
@@ -497,19 +497,29 @@ func (b Builder) Ref() commonv1.ObjectSelector {
 func (b Builder) RuntimeObjects() []k8sclient.Object {
 	// OpenShift does not only require running as root, the privileged field must also be
 	// set to true in order to write in a hostPath volume.
-	if test.Ctx().OcpCluster {
-		podSecurityContext := b.getPodSecurityContext()
-		if podSecurityContext != nil && podSecurityContext.RunAsUser != nil {
-			if *podSecurityContext.RunAsUser == 0 {
-				// Only update the container's SecurityContext if the Pod runs as root.
-				b = b.WithContainerSecurityContext(corev1.SecurityContext{
-					Privileged: new(true),
-					RunAsUser:  new(int64(0)),
-				})
-			}
-		}
-	}
+	// Deep-copy before applying OCP modifications so the original builder is not mutated
+	// through the shared DaemonSetSpec pointer — phase builders (created via DeepCopy before
+	// RuntimeObjects runs) would otherwise miss the modification in UpgradeTestSteps.
+	b = b.withOCPSecurityContext()
 	return append(b.AdditionalObjects, &b.Agent)
+}
+
+// withOCPSecurityContext returns a deep copy of the builder with the OCP-required privileged
+// container security context applied when the pod runs as root on an OCP cluster.
+// The original builder is never modified.
+func (b Builder) withOCPSecurityContext() Builder {
+	if !test.Ctx().OcpCluster {
+		return b
+	}
+	podSecurityContext := b.getPodSecurityContext()
+	if podSecurityContext == nil || podSecurityContext.RunAsUser == nil || *podSecurityContext.RunAsUser != 0 {
+		return b
+	}
+	bCopy := *b.DeepCopy()
+	return bCopy.WithContainerSecurityContext(corev1.SecurityContext{
+		Privileged: new(true),
+		RunAsUser:  new(int64(0)),
+	})
 }
 
 func (b Builder) getPodSecurityContext() *corev1.PodSecurityContext {

--- a/test/e2e/test/agent/builder.go
+++ b/test/e2e/test/agent/builder.go
@@ -504,9 +504,10 @@ func (b Builder) RuntimeObjects() []k8sclient.Object {
 	return append(b.AdditionalObjects, &b.Agent)
 }
 
-// withOCPSecurityContext returns a deep copy of the builder with the OCP-required privileged
+// withOCPSecurityContext returns a copy of the builder with the OCP-required privileged
 // container security context applied when the pod runs as root on an OCP cluster.
-// The original builder is never modified.
+// Only b.Agent is deep-copied to break the shared *DaemonSetSpec pointer; all other
+// builder fields (including AdditionalObjects) are preserved via the value receiver copy.
 func (b Builder) withOCPSecurityContext() Builder {
 	if !test.Ctx().OcpCluster {
 		return b
@@ -515,8 +516,16 @@ func (b Builder) withOCPSecurityContext() Builder {
 	if podSecurityContext == nil || podSecurityContext.RunAsUser == nil || *podSecurityContext.RunAsUser != 0 {
 		return b
 	}
-	bCopy := *b.DeepCopy()
-	return bCopy.WithContainerSecurityContext(corev1.SecurityContext{
+	b.Agent = *b.Agent.DeepCopy()
+	switch {
+	case b.Agent.Spec.DaemonSet != nil:
+		b.PodTemplate = &b.Agent.Spec.DaemonSet.PodTemplate
+	case b.Agent.Spec.Deployment != nil:
+		b.PodTemplate = &b.Agent.Spec.Deployment.PodTemplate
+	case b.Agent.Spec.StatefulSet != nil:
+		b.PodTemplate = &b.Agent.Spec.StatefulSet.PodTemplate
+	}
+	return b.WithContainerSecurityContext(corev1.SecurityContext{
 		Privileged: new(true),
 		RunAsUser:  new(int64(0)),
 	})

--- a/test/e2e/test/agent/steps.go
+++ b/test/e2e/test/agent/steps.go
@@ -274,7 +274,9 @@ func (b Builder) UpgradeTestSteps(k *test.K8sClient) test.StepList {
 					agent.Annotations = make(map[string]string)
 				}
 				maps.Copy(agent.Annotations, b.Agent.Annotations)
-				agent.Spec = b.Agent.Spec
+				// Apply the same OCP-specific security context that RuntimeObjects() applies on
+				// creation so the spec stays consistent and no spurious pending changes are detected.
+				agent.Spec = b.withOCPSecurityContext().Agent.Spec
 				if err := k.Client.Update(context.Background(), &agent); err != nil {
 					return err
 				}


### PR DESCRIPTION
### Problem
`RuntimeObjects()` applied `Privileged:true` via a shared pointer, mutating the original builder as a side effect. Phase builders (deep-copied earlier) missed this, so `UpgradeTestSteps()` silently stripped the field — causing a real spec change the operator correctly flagged as pending.

This currently breaks CI. 

### Fix
Extract `withOCPSecurityContext()` and use it in both `RuntimeObjects()` and `UpgradeTestSteps()` for consistency.

<!--
Thank you for your interest in contributing to Elastic Cloud on Kubernetes!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/cloud-on-k8s/tree/main/CONTRIBUTING.md)?
- If you submit code, is your pull request against main? We recommend pull requests against main. We will backport them as needed.
