### PR TITLE
Skip logs-elastic_agent.filebeat-default validation on elastic-agent backport versions

### DIFF
--- a/test/e2e/agent/config_test.go
+++ b/test/e2e/agent/config_test.go
@@ -25,6 +25,26 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test/kibana"
 )
 
+// skipFilebeatDataStreamValidation returns true for versions (including pre-release) where filebeat
+// inputs run as OTel receivers and the OTel collector ES exporter v0.152.0+ treats 401 Unauthorized
+// as a permanent error. During agent startup there is a ~60s window where ES has not yet reloaded
+// the file realm after the credential secret is synced by kubelet.
+// See https://github.com/elastic/cloud-on-k8s/issues/9406.
+// Affected versions: 8.19.16+, 9.3.5+, 9.4.2+, 9.5.0+.
+func skipFilebeatDataStreamValidation(v version.Version) bool {
+	v = version.WithoutPre(v)
+	switch {
+	case v.Major == 8 && v.Minor == 19:
+		return v.GTE(version.From(8, 19, 16))
+	case v.Major == 9 && v.Minor == 3:
+		return v.GTE(version.From(9, 3, 5))
+	case v.Major == 9 && v.Minor == 4:
+		return v.GTE(version.From(9, 4, 2))
+	default:
+		return v.GTE(version.From(9, 5, 0))
+	}
+}
+
 func TestSystemIntegrationConfig(t *testing.T) {
 	name := "test-agent-system-int"
 
@@ -49,11 +69,7 @@ func TestSystemIntegrationConfig(t *testing.T) {
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.process_summary", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.socket_summary", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.uptime", "default"))
-	// In 9.5.0+ filebeat inputs run as OTel receivers and the ES exporter in OTel collector
-	// v0.152.0+ treats 401 Unauthorized as a permanent error. During agent startup there is
-	// a ~60s window where ES has not yet reloaded the file realm after the credential secret
-	// is synced by kubelet. See https://github.com/elastic/cloud-on-k8s/issues/9406.
-	if v.LT(version.MinFor(9, 5, 0)) {
+	if !skipFilebeatDataStreamValidation(v) {
 		agentBuilder = agentBuilder.WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.filebeat", "default"))
 	}
 
@@ -97,11 +113,7 @@ func TestAgentConfigRef(t *testing.T) {
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.process_summary", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.socket_summary", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.uptime", "default"))
-	// In 9.5.0+ filebeat inputs run as OTel receivers and the ES exporter in OTel collector
-	// v0.152.0+ treats 401 Unauthorized as a permanent error. During agent startup there is
-	// a ~60s window where ES has not yet reloaded the file realm after the credential secret
-	// is synced by kubelet. See https://github.com/elastic/cloud-on-k8s/issues/9406.
-	if v.LT(version.MinFor(9, 5, 0)) {
+	if !skipFilebeatDataStreamValidation(v) {
 		agentBuilder = agentBuilder.WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.filebeat", "default"))
 	}
 
@@ -138,11 +150,7 @@ func TestMultipleOutputConfig(t *testing.T) {
 		WithESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.process_summary", "default"), "default").
 		WithESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.socket_summary", "default"), "default").
 		WithESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.uptime", "default"), "default")
-	// In 9.5.0+ filebeat inputs run as OTel receivers and the ES exporter in OTel collector
-	// v0.152.0+ treats 401 Unauthorized as a permanent error. During agent startup there is
-	// a ~60s window where ES has not yet reloaded the file realm after the credential secret
-	// is synced by kubelet. See https://github.com/elastic/cloud-on-k8s/issues/9406.
-	if v.LT(version.MinFor(9, 5, 0)) {
+	if !skipFilebeatDataStreamValidation(v) {
 		agentBuilder = agentBuilder.WithESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.filebeat", "default"), "monitoring")
 	}
 


### PR DESCRIPTION
## Summary

Follow-up to #9462, which guarded the `logs-elastic_agent.filebeat-default` data stream validation behind `< 9.5.0`. The same OTel collector v0.152.0 bump that caused the original failure on 9.5.0+ has since been backported to three release branches:

| Branch | Backport commit | First affected version |
|--------|----------------|------------------------|
| 9.4    | elastic/elastic-agent@70d895a | 9.4.2 |
| 9.3    | elastic/elastic-agent@dcae50e | 9.3.5 |
| 8.19   | elastic/elastic-agent@0f61309 | 8.19.16 |

Without this fix the same three tests would start failing on nightly runs against
those stack versions:

- `TestAgentConfigRef`
- `TestSystemIntegrationConfig`
- `TestMultipleOutputConfig`

Relates #9406

## Root Cause

See #9462 for the full analysis. In short:

1. Filebeat inputs run as OTel receivers (elastic/elastic-agent#13991).
2. OTel collector ES exporter v0.152.0 treats `401 Unauthorized` as a **permanent error**, dropping batches instead of retrying (opentelemetry-collector-contrib#47926).

During agent startup there is a ~60s window where Elasticsearch has not yet reloaded the file realm after the credential secret is synced by kubelet. Filebeat's first log batches receive a `401`, are permanently dropped, and the file cursor advances — so the`logs-elastic_agent.filebeat-default` index is never populated.