### PR TITLE
Skip logs-elastic_agent.metricbeat-default validation on recent elastic-agent versions

### DIFF
--- a/test/e2e/agent/config_test.go
+++ b/test/e2e/agent/config_test.go
@@ -25,13 +25,15 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test/kibana"
 )
 
-// skipFilebeatDataStreamValidation returns true for versions (including pre-release) where filebeat
-// inputs run as OTel receivers and the OTel collector ES exporter v0.152.0+ treats 401 Unauthorized
-// as a permanent error. During agent startup there is a ~60s window where ES has not yet reloaded
-// the file realm after the credential secret is synced by kubelet.
+// skipAgentInternalLogsValidation returns true for versions (including pre-release) where
+// elastic-agent's internal log streams (logs-elastic_agent.*-default) are unreliable. In these
+// versions the respective filebeat and metricbeat inputs run as OTel receivers and the OTel
+// collector ES exporter v0.152.0+ treats 401 Unauthorized as a permanent error. During agent
+// startup there is a ~60s window where ES has not yet reloaded the file realm after the
+// credential secret is synced by kubelet, causing the initial log batches to be permanently dropped.
 // See https://github.com/elastic/cloud-on-k8s/issues/9406.
 // Affected versions: 8.19.16+, 9.3.5+, 9.4.2+, 9.5.0+.
-func skipFilebeatDataStreamValidation(v version.Version) bool {
+func skipAgentInternalLogsValidation(v version.Version) bool {
 	v = version.WithoutPre(v)
 	switch {
 	case v.Major == 8 && v.Minor == 19:
@@ -59,7 +61,6 @@ func TestSystemIntegrationConfig(t *testing.T) {
 		WithElasticsearchRefs(agent.ToOutput(esBuilder.Ref(), "default")).
 		WithOpenShiftRoles(test.UseSCCRole).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default")).
-		WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.cpu", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.diskio", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.load", "default")).
@@ -69,8 +70,10 @@ func TestSystemIntegrationConfig(t *testing.T) {
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.process_summary", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.socket_summary", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.uptime", "default"))
-	if !skipFilebeatDataStreamValidation(v) {
-		agentBuilder = agentBuilder.WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.filebeat", "default"))
+	if !skipAgentInternalLogsValidation(v) {
+		agentBuilder = agentBuilder.
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.filebeat", "default"))
 	}
 
 	agentBuilder = agent.ApplyYamls(t, agentBuilder, E2EAgentSystemIntegrationConfig, E2EAgentSystemIntegrationPodTemplate).MoreResourcesForIssue4730()
@@ -103,7 +106,6 @@ func TestAgentConfigRef(t *testing.T) {
 		WithElasticsearchRefs(agent.ToOutput(esBuilder.Ref(), "default")).
 		WithOpenShiftRoles(test.UseSCCRole).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default")).
-		WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.cpu", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.diskio", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.load", "default")).
@@ -113,8 +115,10 @@ func TestAgentConfigRef(t *testing.T) {
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.process_summary", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.socket_summary", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.uptime", "default"))
-	if !skipFilebeatDataStreamValidation(v) {
-		agentBuilder = agentBuilder.WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.filebeat", "default"))
+	if !skipAgentInternalLogsValidation(v) {
+		agentBuilder = agentBuilder.
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.filebeat", "default"))
 	}
 
 	agentBuilder = agent.ApplyYamls(t, agentBuilder, "", E2EAgentSystemIntegrationPodTemplate).MoreResourcesForIssue4730()
@@ -140,7 +144,6 @@ func TestMultipleOutputConfig(t *testing.T) {
 		).
 		WithOpenShiftRoles(test.UseSCCRole).
 		WithESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default"), "monitoring").
-		WithESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default"), "monitoring").
 		WithESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.cpu", "default"), "default").
 		WithESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.diskio", "default"), "default").
 		WithESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.load", "default"), "default").
@@ -150,8 +153,10 @@ func TestMultipleOutputConfig(t *testing.T) {
 		WithESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.process_summary", "default"), "default").
 		WithESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.socket_summary", "default"), "default").
 		WithESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.uptime", "default"), "default")
-	if !skipFilebeatDataStreamValidation(v) {
-		agentBuilder = agentBuilder.WithESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.filebeat", "default"), "monitoring")
+	if !skipAgentInternalLogsValidation(v) {
+		agentBuilder = agentBuilder.
+			WithESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default"), "monitoring").
+			WithESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.filebeat", "default"), "monitoring")
 	}
 
 	agentBuilder = agent.ApplyYamls(t, agentBuilder, E2EAgentMultipleOutputConfig, E2EAgentSystemIntegrationPodTemplate).MoreResourcesForIssue4730()

--- a/test/e2e/agent/recipes_test.go
+++ b/test/e2e/agent/recipes_test.go
@@ -26,8 +26,10 @@ func TestSystemIntegrationRecipe(t *testing.T) {
 	v := version.MustParse(test.Ctx().ElasticStackVersion)
 	customize := func(builder agent.Builder) agent.Builder {
 		builder = builder.
-			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default")).
-			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default"))
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default"))
+		if !skipAgentInternalLogsValidation(v) {
+			builder = builder.WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default"))
+		}
 		// In 9.5.0+ beats run as OTel receivers and no longer expose the HTTP stats endpoint,
 		// so metrics-elastic_agent.metricbeat-default is no longer populated.
 		// See https://github.com/elastic/elastic-agent/pull/13411.
@@ -55,8 +57,10 @@ func TestKubernetesIntegrationRecipe(t *testing.T) {
 	v := version.MustParse(test.Ctx().ElasticStackVersion)
 	customize := func(builder agent.Builder) agent.Builder {
 		builder = builder.
-			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default")).
-			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default"))
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default"))
+		if !skipAgentInternalLogsValidation(v) {
+			builder = builder.WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default"))
+		}
 		// In 9.5.0+ beats run as OTel receivers and no longer expose the HTTP stats endpoint,
 		// so metrics-elastic_agent.metricbeat-default is no longer populated.
 		// See https://github.com/elastic/elastic-agent/pull/13411.
@@ -83,8 +87,10 @@ func TestMultiOutputRecipe(t *testing.T) {
 	v := version.MustParse(test.Ctx().ElasticStackVersion)
 	customize := func(builder agent.Builder) agent.Builder {
 		builder = builder.
-			WithESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default"), "monitoring").
-			WithESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default"), "monitoring")
+			WithESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default"), "monitoring")
+		if !skipAgentInternalLogsValidation(v) {
+			builder = builder.WithESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default"), "monitoring")
+		}
 		// In 9.5.0+ beats run as OTel receivers and no longer expose the HTTP stats endpoint,
 		// so metrics-elastic_agent.metricbeat-default is no longer populated.
 		// See https://github.com/elastic/elastic-agent/pull/13411.


### PR DESCRIPTION
## Problem

`TestMultiOutputRecipe/ES_data_should_pass_validations` started failing on [9.5.0-SNAPSHOT nightly runs](https://buildkite.com/elastic/cloud-on-k8s-operator-nightly/builds/1294):

```
404 Not Found: no such index [logs-elastic_agent.metricbeat-default]
```

This is a follow-up to #9487, which fixed the same failure for `logs-elastic_agent.filebeat-default`.

## Root Cause

Same root cause as #9487 (tracked in https://github.com/elastic/cloud-on-k8s/issues/9406): in affected versions metricbeat runs as an OTel receiver (`metricbeatreceiver`) inside`elastic-otel-collector`, and the OTel ES exporter v0.152.0+ treats `401 Unauthorized` as a **permanent error**. The eck-diagnostics confirm this:

```
"otelcol.component.id":"metricbeatreceiver/_agent-component/http/metrics-monitoring"
"otelcol.component.kind":"receiver"
"message":"bulk indexer flush error"
"error":"flush failed (401): unable to authenticate user [...] for REST request [/_bulk...]"
"log.origin":"elasticsearchexporter@v0.152.0/bulkindexer.go:343"
```

During agent startup there is a ~60s window where ES has not yet reloaded the file realm after the credential secret is synced by kubelet. Metricbeat's initial log batches hit a `401`, are permanently dropped, and `logs-elastic_agent.metricbeat-default` is never created.

## Fix

Extend the `skipAgentInternalLogsValidation` guard (introduced in #9487 as`skipFilebeatDataStreamValidation`) to also cover `logs-elastic_agent.metricbeat-default` in all tests that assert it:

- `TestSystemIntegrationConfig`, `TestAgentConfigRef`, `TestMultipleOutputConfig` in `config_test.go`
- `TestSystemIntegrationRecipe`, `TestKubernetesIntegrationRecipe`, `TestMultiOutputRecipe` in `recipes_test.go`

The function is also renamed from `skipFilebeatDataStreamValidation` to `skipAgentInternalLogsValidation` to reflect that it covers all `logs-elastic_agent.*-default` streams, not just the filebeat one.

Affected elastic-agent versions: 8.19.16+, 9.3.5+, 9.4.2+, 9.5.0+.