### PR TITLE
Treat API server 504 timeout as transient network error

### DIFF
--- a/test/e2e/test/elasticsearch/http_client.go
+++ b/test/e2e/test/elasticsearch/http_client.go
@@ -53,7 +53,8 @@ func NewElasticsearchClient(es esv1.Elasticsearch, k *test.K8sClient) (client.Cl
 		case *k8serrors.StatusError:
 			// Transient API server errors (500, 503, 504, 429) are infrastructure-level
 			// failures, treat them the same as network errors.
-			if k8serrors.IsInternalError(err) || k8serrors.IsServerTimeout(err) || k8serrors.IsServiceUnavailable(err) || k8serrors.IsTooManyRequests(err) {
+			if k8serrors.IsInternalError(err) || k8serrors.IsServerTimeout(err) || k8serrors.IsServiceUnavailable(err) ||
+				k8serrors.IsTooManyRequests(err) || k8serrors.IsTimeout(err) {
 				return nil, &potentialNetworkError{err: err}
 			}
 			return nil, err


### PR DESCRIPTION
## Problem

The nightly CI run on 2026-06-10 showed a spurious test failure in `TestMutationResizeMemoryDown`:

```
Error: Should be empty, but was [the server was unable to return a response in the time allotted,
       but may still be processing the request (get secrets test-mutation-resize-mem-down-vq54-es-elastic-user)]
```

The error originates in `NewElasticsearchClient` when fetching the elastic user password secret. The Kubernetes API server returned an HTTP 504 "timeout" response - distinct from a server-side processing timeout (`ServerTimeout`) - which was not classified as a transient infrastructure failure. This caused the test watcher to treat it as a hard error rather than retrying.

## Fix

Add `k8serrors.IsTimeout(err)` to the set of transient `*k8serrors.StatusError` conditions that are wrapped in `potentialNetworkError` in `test/e2e/test/elasticsearch/http_client.go`.

The existing comment already describes the intent: transient API server errors (5xx, 429) should be treated the same as network errors so that callers can retry. `IsTimeout` covers HTTP 504 Gateway Timeout responses from the API server, which belong in this same category alongside `IsInternalError` (500), `IsServerTimeout` (503 with Retry-After), `IsServiceUnavailable` (503), and `IsTooManyRequests` (429).