### PR TITLE
Test k8s 1.36 with Kind and drop 1.31 support

### DIFF
--- a/.buildkite/e2e/nightly-main-matrix.yaml
+++ b/.buildkite/e2e/nightly-main-matrix.yaml
@@ -23,14 +23,14 @@
   fixed:
     E2E_PROVIDER: kind
   mixed:
-    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.31.14@sha256:6f86cf509dbb42767b6e79debc3f2c32e4ee01386f0489b3b2be24b0a55aac2b
     - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.32.11@sha256:5fc52d52a7b9574015299724bd68f183702956aa4a2116ae75a63cb574b35af8
     - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.33.7@sha256:d26ef333bdb2cbe9862a0f7c3803ecc7b4303d8cea8e814b481b09949d353040
     - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.34.3@sha256:08497ee19eace7b4b5348db5c6a1591d7752b164530a36f855cb0f2bdcbadd48
+    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f
     # The latest version of kind/k8s needs to be listed twice at the end of this list
     # as it's tested in both ipv4 and ipv6 mode.
-    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f
-    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f
+    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.36.1@sha256:21c46cf61fd45873f89e6a1bfcba4b7904dffa84c2bec88aeeca9a0409af4725
+    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.36.1@sha256:21c46cf61fd45873f89e6a1bfcba4b7904dffa84c2bec88aeeca9a0409af4725
       DEPLOYER_KIND_IP_FAMILY: ipv6
 
 - label: gke

--- a/.buildkite/e2e/release-branch-matrix.yaml
+++ b/.buildkite/e2e/release-branch-matrix.yaml
@@ -34,14 +34,14 @@
   fixed:
     E2E_PROVIDER: kind
   mixed:
-    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.31.14@sha256:6f86cf509dbb42767b6e79debc3f2c32e4ee01386f0489b3b2be24b0a55aac2b
     - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.32.11@sha256:5fc52d52a7b9574015299724bd68f183702956aa4a2116ae75a63cb574b35af8
     - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.33.7@sha256:d26ef333bdb2cbe9862a0f7c3803ecc7b4303d8cea8e814b481b09949d353040
     - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.34.3@sha256:08497ee19eace7b4b5348db5c6a1591d7752b164530a36f855cb0f2bdcbadd48
+    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f
     # The latest version of kind/k8s needs to be listed twice at the end of this list
     # as it's tested in both ipv4 and ipv6 mode.
-    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f
-    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f
+    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.36.1@sha256:21c46cf61fd45873f89e6a1bfcba4b7904dffa84c2bec88aeeca9a0409af4725
+    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.36.1@sha256:21c46cf61fd45873f89e6a1bfcba4b7904dffa84c2bec88aeeca9a0409af4725
       DEPLOYER_KIND_IP_FAMILY: ipv6
 
 - label: k3d

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Current features:
 
 Supported versions:
 
-* Kubernetes 1.31-1.35
+* Kubernetes 1.32-1.36
 * OpenShift 4.16-4.21
 * Elasticsearch, Kibana, APM Server: 8+, 9+
 * Enterprise Search: 8+

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -166,24 +166,24 @@ plans:
   clusterName: eck
   clientVersion: 0.31.0
   provider: kind
-  kubernetesVersion: 1.35.0
+  kubernetesVersion: 1.36.1
   enforceSecurityPolicies: true
   diskSetup: kubectl apply -k hack/deployer/config/local-disks-kind
   kind:
     nodeCount: 3
-    nodeImage: kindest/node:v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f
+    nodeImage: kindest/node:v1.36.1@sha256:21c46cf61fd45873f89e6a1bfcba4b7904dffa84c2bec88aeeca9a0409af4725
     ipFamily: ipv4
 - id: kind-ci
   operation: create
   clusterName: kind-ci
   clientVersion: 0.31.0
   provider: kind
-  kubernetesVersion: 1.35.0
+  kubernetesVersion: 1.36.1
   enforceSecurityPolicies: true
   diskSetup: kubectl apply -k hack/deployer/config/local-disks-kind
   kind:
     nodeCount: 3
-    nodeImage: kindest/node:v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f
+    nodeImage: kindest/node:v1.36.1@sha256:21c46cf61fd45873f89e6a1bfcba4b7904dffa84c2bec88aeeca9a0409af4725
     ipFamily: ipv4
 - id: k3d-dev
   operation: create


### PR DESCRIPTION
## Summary

- Add `kindest/node:v1.36.1` to the Kind E2E test matrix (nightly and release-branch), tested in both IPv4 and IPv6 mode
- Drop `kindest/node:v1.31.14` from the matrix (supported range moves from 1.31–1.35 to 1.32–1.36)
- Update `kind-dev` and `kind-ci` deployer plans to use v1.36.1
- Update README supported Kubernetes version range to 1.32–1.36

## Test plan

- [ ] Trigger Kind E2E tests (IPv4 and IPv6) by commenting on this PR:
  ```
  buildkite test this -f p=kind -m DEPLOYER_KIND_IP_FAMILY=ipv4,DEPLOYER_KIND_IP_FAMILY=ipv6
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)