### PR TITLE
Bump stack patch versions, OCP to 4.22, and k8s to 1.36

### DIFF
--- a/.buildkite/e2e/nightly-main-matrix.yaml
+++ b/.buildkite/e2e/nightly-main-matrix.yaml
@@ -3,10 +3,10 @@
   fixed:
     E2E_PROVIDER: gke
   mixed:
-    - E2E_STACK_VERSION: "8.19.15"
+    - E2E_STACK_VERSION: "8.19.16"
     - E2E_STACK_VERSION: "9.2.8"
-    - E2E_STACK_VERSION: "9.3.4"
-    # current stack version 9.4.0 is tested in all other tests no need to test it again
+    - E2E_STACK_VERSION: "9.3.5"
+    # current stack version 9.4.2 is tested in all other tests no need to test it again
     - E2E_STACK_VERSION: "8.19.16-SNAPSHOT"
     - E2E_STACK_VERSION: "9.5.0-SNAPSHOT"
 
@@ -15,7 +15,7 @@
     E2E_PROVIDER: ocp
   mixed:
     ## Test the current stack version.
-    - E2E_STACK_VERSION: "9.4.0"
+    - E2E_STACK_VERSION: "9.4.2"
     ## Also test the next stack version to detect any change in the images that might not be compatible with the CRI-O runtime.
     - E2E_STACK_VERSION: "9.5.0-SNAPSHOT"
 

--- a/.buildkite/e2e/nightly-main-matrix.yaml
+++ b/.buildkite/e2e/nightly-main-matrix.yaml
@@ -29,8 +29,8 @@
     - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f
     # The latest version of kind/k8s needs to be listed twice at the end of this list
     # as it's tested in both ipv4 and ipv6 mode.
-    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.36.1@sha256:21c46cf61fd45873f89e6a1bfcba4b7904dffa84c2bec88aeeca9a0409af4725
-    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.36.1@sha256:21c46cf61fd45873f89e6a1bfcba4b7904dffa84c2bec88aeeca9a0409af4725
+    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5
+    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5
       DEPLOYER_KIND_IP_FAMILY: ipv6
 
 - label: gke

--- a/.buildkite/e2e/release-branch-matrix.yaml
+++ b/.buildkite/e2e/release-branch-matrix.yaml
@@ -40,8 +40,8 @@
     - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f
     # The latest version of kind/k8s needs to be listed twice at the end of this list
     # as it's tested in both ipv4 and ipv6 mode.
-    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.36.1@sha256:21c46cf61fd45873f89e6a1bfcba4b7904dffa84c2bec88aeeca9a0409af4725
-    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.36.1@sha256:21c46cf61fd45873f89e6a1bfcba4b7904dffa84c2bec88aeeca9a0409af4725
+    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5
+    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5
       DEPLOYER_KIND_IP_FAMILY: ipv6
 
 - label: k3d

--- a/.buildkite/e2e/release-branch-matrix.yaml
+++ b/.buildkite/e2e/release-branch-matrix.yaml
@@ -21,12 +21,12 @@
     - E2E_STACK_VERSION: "8.16.6"
     - E2E_STACK_VERSION: "8.17.10"
     - E2E_STACK_VERSION: "8.18.8"
-    - E2E_STACK_VERSION: "8.19.15"
+    - E2E_STACK_VERSION: "8.19.16"
     - E2E_STACK_VERSION: "9.0.8"
     - E2E_STACK_VERSION: "9.1.10"
     - E2E_STACK_VERSION: "9.2.8"
-    - E2E_STACK_VERSION: "9.3.4"
-    # current stack version 9.4.0 is tested in all other tests no need to test it again
+    - E2E_STACK_VERSION: "9.3.5"
+    # current stack version 9.4.2 is tested in all other tests no need to test it again
     - E2E_STACK_VERSION: "8.19.16-SNAPSHOT"
     - E2E_STACK_VERSION: "9.5.0-SNAPSHOT"
 
@@ -69,7 +69,7 @@
     - DEPLOYER_CLIENT_VERSION: "4.21.7"
       E2E_STACK_VERSION: "9.2.8"
     - DEPLOYER_CLIENT_VERSION: "4.21.7"
-      E2E_STACK_VERSION: "9.3.4"
+      E2E_STACK_VERSION: "9.3.5"
 
 - label: eks-arm
   fixed:

--- a/.buildkite/e2e/release-branch-matrix.yaml
+++ b/.buildkite/e2e/release-branch-matrix.yaml
@@ -66,9 +66,9 @@
   fixed:
     E2E_PROVIDER: ocp
   mixed:
-    - DEPLOYER_CLIENT_VERSION: "4.21.7"
+    - DEPLOYER_CLIENT_VERSION: "4.22.0"
       E2E_STACK_VERSION: "9.2.8"
-    - DEPLOYER_CLIENT_VERSION: "4.21.7"
+    - DEPLOYER_CLIENT_VERSION: "4.22.0"
       E2E_STACK_VERSION: "9.3.5"
 
 - label: eks-arm

--- a/Makefile
+++ b/Makefile
@@ -463,7 +463,7 @@ drivah-build-e2e:
 
 # -- run
 
-E2E_STACK_VERSION          ?= 9.4.0
+E2E_STACK_VERSION          ?= 9.4.2
 # regexp to filter tests to run
 export TESTS_MATCH         ?= ^Test
 export E2E_JSON            ?= false

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Current features:
 Supported versions:
 
 * Kubernetes 1.32-1.36
-* OpenShift 4.16-4.21
+* OpenShift 4.16-4.22
 * Elasticsearch, Kibana, APM Server: 8+, 9+
 * Enterprise Search: 8+
 * Beats: 8+, 9+

--- a/config/e2e/monitoring.yaml
+++ b/config/e2e/monitoring.yaml
@@ -5,7 +5,7 @@ metadata:
   name: e2e-agent
   namespace: {{ .E2ENamespace }}
 spec:
-  version: 9.4.0
+  version: 9.4.2
   elasticsearchRefs:
     - secretName: eck-{{ .TestRun }}
   daemonSet:

--- a/config/recipes/apm-server-jaeger/apm-server-jaeger.yaml
+++ b/config/recipes/apm-server-jaeger/apm-server-jaeger.yaml
@@ -4,7 +4,7 @@ metadata:
   name: apm-server-quickstart
   namespace: default
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   config:
     name: elastic-apm

--- a/config/recipes/associations-rbac/apm_es_kibana_rbac.yaml
+++ b/config/recipes/associations-rbac/apm_es_kibana_rbac.yaml
@@ -84,7 +84,7 @@ metadata:
   name: elasticsearch-sample
   namespace: elasticsearch-ns
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
     - name: default
       count: 1
@@ -97,7 +97,7 @@ metadata:
   name: kibana-sample
   namespace: kibana-ns
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   config:
     xpack.fleet.packages:
@@ -115,7 +115,7 @@ metadata:
   name: apm-apm-sample
   namespace: apmserver-ns
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: "elasticsearch-sample"

--- a/config/recipes/autopilot/elasticsearch.yaml
+++ b/config/recipes/autopilot/elasticsearch.yaml
@@ -21,7 +21,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
   - name: default
     count: 1

--- a/config/recipes/autopilot/fleet-kubernetes-integration.yaml
+++ b/config/recipes/autopilot/fleet-kubernetes-integration.yaml
@@ -20,7 +20,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
   - name: default
     count: 1
@@ -41,7 +41,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -103,7 +103,7 @@ kind: Agent
 metadata:
   name: fleet-server
 spec:
-  version: 9.4.0
+  version: 9.4.2
   kibanaRef:
     name: kibana
   elasticsearchRefs:
@@ -145,7 +145,7 @@ kind: Agent
 metadata: 
   name: elastic-agent
 spec:
-  version: 9.4.0
+  version: 9.4.2
   kibanaRef:
     name: kibana
   fleetServerRef: 

--- a/config/recipes/autopilot/kubernetes-integration.yaml
+++ b/config/recipes/autopilot/kubernetes-integration.yaml
@@ -4,7 +4,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -25,7 +25,7 @@ kind: Agent
 metadata:
   name: elastic-agent
 spec:
-  version: 9.4.0
+  version: 9.4.2
   elasticsearchRefs:
   - name: elasticsearch
   resources:

--- a/config/recipes/autopilot/metricbeat_hosts.yaml
+++ b/config/recipes/autopilot/metricbeat_hosts.yaml
@@ -4,7 +4,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -26,7 +26,7 @@ metadata:
   name: metricbeat
 spec:
   type: metricbeat
-  version: 9.4.0
+  version: 9.4.2
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:

--- a/config/recipes/autoscaling/elasticsearch.yaml
+++ b/config/recipes/autoscaling/elasticsearch.yaml
@@ -51,7 +51,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
     - name: master
       count: 3

--- a/config/recipes/beats/auditbeat_hosts.yaml
+++ b/config/recipes/beats/auditbeat_hosts.yaml
@@ -4,7 +4,7 @@ metadata:
   name: auditbeat
 spec:
   type: auditbeat
-  version: 9.4.0
+  version: 9.4.2
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -118,7 +118,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
   - name: default
     count: 3
@@ -130,7 +130,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/filebeat_autodiscover.yaml
+++ b/config/recipes/beats/filebeat_autodiscover.yaml
@@ -4,7 +4,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 9.4.0
+  version: 9.4.2
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -122,7 +122,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
   - name: default
     count: 3
@@ -134,7 +134,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/filebeat_autodiscover_by_metadata.yaml
+++ b/config/recipes/beats/filebeat_autodiscover_by_metadata.yaml
@@ -4,7 +4,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 9.4.0
+  version: 9.4.2
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -118,7 +118,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
   - name: default
     count: 3
@@ -130,7 +130,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/filebeat_no_autodiscover.yaml
+++ b/config/recipes/beats/filebeat_no_autodiscover.yaml
@@ -4,7 +4,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 9.4.0
+  version: 9.4.2
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -60,7 +60,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
   - name: default
     count: 3
@@ -72,7 +72,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/heartbeat_es_kb_health.yaml
+++ b/config/recipes/beats/heartbeat_es_kb_health.yaml
@@ -4,7 +4,7 @@ metadata:
   name: heartbeat
 spec:
   type: heartbeat
-  version: 9.4.0
+  version: 9.4.2
   elasticsearchRef:
     name: elasticsearch
   config:
@@ -27,7 +27,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
   - name: default
     count: 3
@@ -39,7 +39,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/metricbeat_hosts.yaml
+++ b/config/recipes/beats/metricbeat_hosts.yaml
@@ -4,7 +4,7 @@ metadata:
   name: metricbeat
 spec:
   type: metricbeat
-  version: 9.4.0
+  version: 9.4.2
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -182,7 +182,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
   - name: default
     count: 3
@@ -194,7 +194,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/openshift_monitoring.yaml
+++ b/config/recipes/beats/openshift_monitoring.yaml
@@ -4,7 +4,7 @@ metadata:
   name: metricbeat
 spec:
   type: metricbeat
-  version: 9.4.0
+  version: 9.4.2
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -229,7 +229,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 9.4.0
+  version: 9.4.2
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -332,7 +332,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
   - name: default
     count: 3
@@ -344,7 +344,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/packetbeat_dns_http.yaml
+++ b/config/recipes/beats/packetbeat_dns_http.yaml
@@ -4,7 +4,7 @@ metadata:
   name: packetbeat
 spec:
   type: packetbeat
-  version: 9.4.0
+  version: 9.4.2
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -44,7 +44,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
   - name: default
     count: 3
@@ -56,7 +56,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/stack_monitoring.yaml
+++ b/config/recipes/beats/stack_monitoring.yaml
@@ -6,7 +6,7 @@ metadata:
   name: metricbeat
 spec:
   type: metricbeat
-  version: 9.4.0
+  version: 9.4.2
   elasticsearchRef:
     name: elasticsearch-monitoring
   config:
@@ -140,7 +140,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 9.4.0
+  version: 9.4.2
   elasticsearchRef:
     name: elasticsearch-monitoring
   kibanaRef:
@@ -260,7 +260,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
   - name: default
     count: 3
@@ -276,7 +276,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -293,7 +293,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-monitoring
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
   - name: default
     count: 3
@@ -305,7 +305,7 @@ kind: Kibana
 metadata:
   name: kibana-monitoring
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: elasticsearch-monitoring

--- a/config/recipes/elastic-agent/fleet-apm-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-apm-integration.yaml
@@ -3,7 +3,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -61,7 +61,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
   - name: default
     count: 3
@@ -73,7 +73,7 @@ kind: Agent
 metadata:
   name: fleet-server
 spec:
-  version: 9.4.0
+  version: 9.4.2
   kibanaRef:
     name: kibana
   elasticsearchRefs:
@@ -95,7 +95,7 @@ kind: Agent
 metadata: 
   name: elastic-agent
 spec:
-  version: 9.4.0
+  version: 9.4.2
   kibanaRef:
     name: kibana
   fleetServerRef: 

--- a/config/recipes/elastic-agent/fleet-custom-logs-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-custom-logs-integration.yaml
@@ -3,7 +3,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -70,7 +70,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
   - name: default
     count: 3
@@ -82,7 +82,7 @@ kind: Agent
 metadata:
   name: fleet-server
 spec:
-  version: 9.4.0
+  version: 9.4.2
   kibanaRef:
     name: kibana
   elasticsearchRefs:
@@ -104,7 +104,7 @@ kind: Agent
 metadata: 
   name: elastic-agent
 spec:
-  version: 9.4.0
+  version: 9.4.2
   kibanaRef:
     name: kibana
   fleetServerRef: 

--- a/config/recipes/elastic-agent/fleet-ingress-setup.yaml
+++ b/config/recipes/elastic-agent/fleet-ingress-setup.yaml
@@ -3,7 +3,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -57,7 +57,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
   - name: default-3
     count: 3
@@ -134,7 +134,7 @@ kind: Agent
 metadata:
   name: fleet-server
 spec:
-  version: 9.4.0
+  version: 9.4.2
   http:
     # Configuring the same certificates used for the ingress here has the effect that 
     # the CA certificate that is expected in ca.crt inside this secret is propagated to the agents
@@ -177,7 +177,7 @@ spec:
     providers.kubernetes:
       add_resource_metadata:
         deployment: true
-  version: 9.4.0
+  version: 9.4.2
   kibanaRef:
     name: kibana
   fleetServerRef:

--- a/config/recipes/elastic-agent/fleet-kubernetes-integration-nonroot.yaml
+++ b/config/recipes/elastic-agent/fleet-kubernetes-integration-nonroot.yaml
@@ -71,7 +71,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -129,7 +129,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
   - name: default
     count: 3
@@ -141,7 +141,7 @@ kind: Agent
 metadata:
   name: fleet-server
 spec:
-  version: 9.4.0
+  version: 9.4.2
   kibanaRef:
     name: kibana
   elasticsearchRefs:
@@ -161,7 +161,7 @@ kind: Agent
 metadata: 
   name: elastic-agent
 spec:
-  version: 9.4.0
+  version: 9.4.2
   kibanaRef:
     name: kibana
   fleetServerRef: 

--- a/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
@@ -3,7 +3,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -54,7 +54,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
   - name: default
     count: 3
@@ -66,7 +66,7 @@ kind: Agent
 metadata:
   name: fleet-server
 spec:
-  version: 9.4.0
+  version: 9.4.2
   kibanaRef:
     name: kibana
   elasticsearchRefs:
@@ -88,7 +88,7 @@ kind: Agent
 metadata: 
   name: elastic-agent
 spec:
-  version: 9.4.0
+  version: 9.4.2
   kibanaRef:
     name: kibana
   fleetServerRef: 

--- a/config/recipes/elastic-agent/ksm-sharding.yaml
+++ b/config/recipes/elastic-agent/ksm-sharding.yaml
@@ -3,7 +3,7 @@ kind: Agent
 metadata:
   name: elastic-agent
 spec:
-  version: 9.4.0
+  version: 9.4.2
   elasticsearchRefs:
   - name: elasticsearch
   statefulSet:
@@ -457,7 +457,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
   - name: default
     count: 3
@@ -469,7 +469,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/elastic-agent/kubernetes-integration.yaml
+++ b/config/recipes/elastic-agent/kubernetes-integration.yaml
@@ -3,7 +3,7 @@ kind: Agent
 metadata:
   name: elastic-agent
 spec:
-  version: 9.4.0
+  version: 9.4.2
   elasticsearchRefs:
   - name: elasticsearch
   daemonSet:
@@ -222,7 +222,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
   - name: default
     count: 3
@@ -234,7 +234,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/elastic-agent/multi-output.yaml
+++ b/config/recipes/elastic-agent/multi-output.yaml
@@ -3,7 +3,7 @@ kind: Agent
 metadata:
   name: elastic-agent
 spec:
-  version: 9.4.0
+  version: 9.4.2
   elasticsearchRefs:
   - outputName: default
     name: elasticsearch
@@ -196,7 +196,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
   - name: default
     count: 3
@@ -208,7 +208,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -218,7 +218,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-mon
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
   - name: default
     count: 3
@@ -230,7 +230,7 @@ kind: Kibana
 metadata:
   name: kibana-mon
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: elasticsearch-mon

--- a/config/recipes/elastic-agent/system-integration.yaml
+++ b/config/recipes/elastic-agent/system-integration.yaml
@@ -3,7 +3,7 @@ kind: Agent
 metadata:
   name: elastic-agent
 spec:
-  version: 9.4.0
+  version: 9.4.2
   elasticsearchRefs:
   - name: elasticsearch
   daemonSet:
@@ -31,7 +31,7 @@ spec:
       meta:
         package:
           name: system
-          version: 9.4.0
+          version: 9.4.2
       data_stream:
         namespace: default
       streams:
@@ -136,7 +136,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
   - name: default
     count: 3
@@ -148,7 +148,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/gclb/01-elastic-stack.yaml
+++ b/config/recipes/gclb/01-elastic-stack.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 9.4.0
+  version: 9.4.2
   http:
     service:
       metadata:
@@ -45,7 +45,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   http:
     service:

--- a/config/recipes/gclb/99-kibana-path.yaml
+++ b/config/recipes/gclb/99-kibana-path.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: thor
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   config:
     # Make Kibana aware of the fact that it is behind a proxy

--- a/config/recipes/istio-gateway/03-elasticsearch-kibana.yaml
+++ b/config/recipes/istio-gateway/03-elasticsearch-kibana.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: ekmnt
 spec:
-  version: 9.4.0
+  version: 9.4.2
   http:
     tls:
       selfSignedCertificate:
@@ -82,7 +82,7 @@ metadata:
   labels:
     app: ekmnt
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   http:
     tls:

--- a/config/recipes/logstash/logstash-eck.yaml
+++ b/config/recipes/logstash/logstash-eck.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
     - name: default
       count: 3
@@ -17,7 +17,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -28,7 +28,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 9.4.0
+  version: 9.4.2
   config:
     filebeat.inputs:
       - type: filestream
@@ -68,7 +68,7 @@ metadata:
   name: logstash
 spec:
   count: 1
-  version: 9.4.0
+  version: 9.4.2
   elasticsearchRefs:
     - clusterName: eck
       name: elasticsearch

--- a/config/recipes/logstash/logstash-es-role.yaml
+++ b/config/recipes/logstash/logstash-es-role.yaml
@@ -15,7 +15,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.4.0
+  version: 9.4.2
   auth:
     roles:
       - secretName: my-roles-secret
@@ -31,7 +31,7 @@ metadata:
   name: logstash
 spec:
   count: 1
-  version: 9.4.0
+  version: 9.4.2
   elasticsearchRefs:
     - name: elasticsearch
       clusterName: eck

--- a/config/recipes/logstash/logstash-monitored.yaml
+++ b/config/recipes/logstash/logstash-monitored.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
     - name: default
       count: 3
@@ -17,7 +17,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -28,7 +28,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 9.4.0
+  version: 9.4.2
   config:
     filebeat.inputs:
       - type: filestream
@@ -68,7 +68,7 @@ metadata:
   name: logstash
 spec:
   count: 1
-  version: 9.4.0
+  version: 9.4.2
   elasticsearchRefs:
     - clusterName: eck
       name: elasticsearch
@@ -117,7 +117,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-monitoring
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
     - name: default
       count: 3
@@ -129,7 +129,7 @@ kind: Kibana
 metadata:
   name: kibana-monitoring
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: elasticsearch-monitoring

--- a/config/recipes/logstash/logstash-multi.yaml
+++ b/config/recipes/logstash/logstash-multi.yaml
@@ -12,7 +12,7 @@ metadata:
   name: qa
   namespace: qa
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
     - name: default
       count: 3
@@ -25,7 +25,7 @@ kind: Elasticsearch
 metadata:
   name: production
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
     - name: default
       count: 3
@@ -39,7 +39,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 9.4.0
+  version: 9.4.2
   config:
     filebeat.inputs:
       - type: filestream
@@ -79,7 +79,7 @@ metadata:
   name: logstash
 spec:
   count: 1
-  version: 9.4.0
+  version: 9.4.2
   elasticsearchRefs:
   - clusterName: prod-es
     name: production

--- a/config/recipes/logstash/logstash-pipeline-as-secret.yaml
+++ b/config/recipes/logstash/logstash-pipeline-as-secret.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
     - name: default
       count: 3
@@ -17,7 +17,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -28,7 +28,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 9.4.0
+  version: 9.4.2
   config:
     filebeat.inputs:
       - type: filestream
@@ -68,7 +68,7 @@ metadata:
   name: logstash
 spec:
   count: 1
-  version: 9.4.0
+  version: 9.4.2
   elasticsearchRefs:
     - clusterName: eck
       name: elasticsearch

--- a/config/recipes/logstash/logstash-pipeline-as-volume.yaml
+++ b/config/recipes/logstash/logstash-pipeline-as-volume.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
     - name: default
       count: 3
@@ -17,7 +17,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -28,7 +28,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 9.4.0
+  version: 9.4.2
   config:
     filebeat.inputs:
       - type: filestream
@@ -68,7 +68,7 @@ metadata:
   name: logstash
 spec:
   count: 1
-  version: 9.4.0
+  version: 9.4.2
   elasticsearchRefs:
     - clusterName: eck
       name: elasticsearch

--- a/config/recipes/logstash/logstash-volumes.yaml
+++ b/config/recipes/logstash/logstash-volumes.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
     - name: default
       count: 3
@@ -18,7 +18,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 9.4.0
+  version: 9.4.2
   config:
     filebeat.inputs:
       - type: filestream
@@ -58,7 +58,7 @@ metadata:
   name: logstash
 spec:
   count: 1
-  version: 9.4.0
+  version: 9.4.2
   elasticsearchRefs:
     - clusterName: eck
       name: elasticsearch

--- a/config/recipes/maps/01-ems.yaml
+++ b/config/recipes/maps/01-ems.yaml
@@ -3,5 +3,5 @@ kind: ElasticMapsServer
 metadata:
   name: ems-sample
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1

--- a/config/recipes/maps/02-es-kb.yaml
+++ b/config/recipes/maps/02-es-kb.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
     - name: default
       count: 3
@@ -27,7 +27,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   config:
     # Configure this to a domain you control

--- a/config/recipes/mtls/managed/fleet.yaml
+++ b/config/recipes/mtls/managed/fleet.yaml
@@ -12,7 +12,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.4.0
+  version: 9.4.2
   http:
     tls:
       client:
@@ -28,7 +28,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -84,7 +84,7 @@ kind: Agent
 metadata:
   name: fleet-server
 spec:
-  version: 9.4.0
+  version: 9.4.2
   http:
     tls:
       client:
@@ -105,7 +105,7 @@ kind: Agent
 metadata:
   name: elastic-agent
 spec:
-  version: 9.4.0
+  version: 9.4.2
   kibanaRef:
     name: kibana
   fleetServerRef:

--- a/config/recipes/mtls/managed/standalone-agent.yaml
+++ b/config/recipes/mtls/managed/standalone-agent.yaml
@@ -12,7 +12,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.4.0
+  version: 9.4.2
   http:
     tls:
       client:
@@ -28,7 +28,7 @@ kind: Agent
 metadata:
   name: elastic-agent
 spec:
-  version: 9.4.0
+  version: 9.4.2
   elasticsearchRefs:
     - outputName: default
       name: elasticsearch

--- a/config/recipes/mtls/manual/beats.yaml
+++ b/config/recipes/mtls/manual/beats.yaml
@@ -122,7 +122,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.4.0
+  version: 9.4.2
   http:
     tls:
       certificate:
@@ -142,7 +142,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -165,7 +165,7 @@ metadata:
   name: metricbeat
 spec:
   type: metricbeat
-  version: 9.4.0
+  version: 9.4.2
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:

--- a/config/recipes/mtls/manual/fleet.yaml
+++ b/config/recipes/mtls/manual/fleet.yaml
@@ -149,7 +149,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.4.0
+  version: 9.4.2
   http:
     tls:
       certificate:
@@ -169,7 +169,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -242,7 +242,7 @@ kind: Agent
 metadata:
   name: fleet-server
 spec:
-  version: 9.4.0
+  version: 9.4.2
   kibanaRef:
     name: kibana
   elasticsearchRefs:
@@ -302,7 +302,7 @@ kind: Agent
 metadata:
   name: elastic-agent
 spec:
-  version: 9.4.0
+  version: 9.4.2
   kibanaRef:
     name: kibana
   fleetServerRef:

--- a/config/recipes/mtls/manual/standalone-agent.yaml
+++ b/config/recipes/mtls/manual/standalone-agent.yaml
@@ -122,7 +122,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.4.0
+  version: 9.4.2
   http:
     tls:
       certificate:
@@ -142,7 +142,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -164,7 +164,7 @@ kind: Agent
 metadata:
   name: elastic-agent
 spec:
-  version: 9.4.0
+  version: 9.4.2
   elasticsearchRefs:
   - name: elasticsearch
   config:
@@ -192,7 +192,7 @@ spec:
       meta:
         package:
           name: system
-          version: 9.4.0
+          version: 9.4.2
       data_stream:
         namespace: default
       streams:

--- a/config/recipes/packageregistry/epr-eck.yaml
+++ b/config/recipes/packageregistry/epr-eck.yaml
@@ -4,7 +4,7 @@ kind: PackageRegistry
 metadata:
   name: registry
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
 ---
 apiVersion: kibana.k8s.elastic.co/v1
@@ -12,7 +12,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -48,7 +48,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
   - name: default
     count: 1
@@ -60,7 +60,7 @@ kind: Agent
 metadata:
   name: fleet-server
 spec:
-  version: 9.4.0
+  version: 9.4.2
   kibanaRef:
     name: kibana
   elasticsearchRefs:

--- a/config/recipes/packageregistry/epr-extra-ca.yaml
+++ b/config/recipes/packageregistry/epr-extra-ca.yaml
@@ -4,7 +4,7 @@ kind: PackageRegistry
 metadata:
   name: registry
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
 ---
 apiVersion: kibana.k8s.elastic.co/v1
@@ -12,7 +12,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -72,7 +72,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
   - name: default
     count: 1
@@ -84,7 +84,7 @@ kind: Agent
 metadata:
   name: fleet-server
 spec:
-  version: 9.4.0
+  version: 9.4.2
   kibanaRef:
     name: kibana
   elasticsearchRefs:

--- a/config/recipes/packageregistry/epr-volumes.yaml
+++ b/config/recipes/packageregistry/epr-volumes.yaml
@@ -4,7 +4,7 @@ kind: PackageRegistry
 metadata:
   name: registry
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   config:
     package_paths:
@@ -26,7 +26,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -62,7 +62,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
   - name: default
     count: 1
@@ -74,7 +74,7 @@ kind: Agent
 metadata:
   name: fleet-server
 spec:
-  version: 9.4.0
+  version: 9.4.2
   kibanaRef:
     name: kibana
   elasticsearchRefs:

--- a/config/recipes/remoteclusters/elasticsearch.yaml
+++ b/config/recipes/remoteclusters/elasticsearch.yaml
@@ -9,7 +9,7 @@ metadata:
   name: cluster1
   namespace: ns1
 spec:
-  version: 9.4.0
+  version: 9.4.2
   remoteClusters:
     - name: to-ns2-cluster2
       elasticsearchRef:
@@ -38,7 +38,7 @@ spec:
 #      spec:
 #        # expose this cluster Service with a LoadBalancer
 #        type: LoadBalancer
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: "cluster1"
@@ -54,7 +54,7 @@ metadata:
   name: cluster2
   namespace: ns2
 spec:
-  version: 9.4.0
+  version: 9.4.2
   ## Required for this cluster to be accessed using remote cluster API keys.
   remoteClusterServer:
     enabled: true
@@ -75,7 +75,7 @@ spec:
 #      spec:
 #        # expose this cluster Service with a LoadBalancer
 #        type: LoadBalancer
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: "cluster2"

--- a/config/recipes/traefik/02-elastic-stack.yaml
+++ b/config/recipes/traefik/02-elastic-stack.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
   - name: master
     count: 1
@@ -41,7 +41,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   config:
     xpack.fleet.packages:
@@ -57,7 +57,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: hulk

--- a/config/samples/apm/apm_es_kibana.yaml
+++ b/config/samples/apm/apm_es_kibana.yaml
@@ -5,7 +5,7 @@ kind: Elasticsearch
 metadata:
   name: es-apm-sample
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
   - name: default
     count: 3
@@ -19,7 +19,7 @@ kind: Kibana
 metadata:
   name: kb-apm-sample
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: "es-apm-sample"
@@ -33,7 +33,7 @@ kind: ApmServer
 metadata:
   name: apm-apm-sample
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: "es-apm-sample"

--- a/config/samples/elasticsearch/elasticsearch-stateless.yaml
+++ b/config/samples/elasticsearch/elasticsearch-stateless.yaml
@@ -14,7 +14,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-stateless-sample
 spec:
-  version: 9.4.0
+  version: 9.4.2
   mode: stateless
   objectStore:
     type: s3

--- a/config/samples/elasticsearch/elasticsearch.yaml
+++ b/config/samples/elasticsearch/elasticsearch.yaml
@@ -5,7 +5,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
   - name: default
     # Uncomment zoneAwareness to spread this NodeSet across zones.

--- a/config/samples/kibana/kibana_es.yaml
+++ b/config/samples/kibana/kibana_es.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
   - name: default
     count: 1
@@ -18,7 +18,7 @@ kind: Kibana
 metadata:
   name: kibana-sample
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 1
   elasticsearchRef:
     name: "elasticsearch-sample"

--- a/config/samples/logstash/logstash.yaml
+++ b/config/samples/logstash/logstash.yaml
@@ -3,7 +3,7 @@ kind: Logstash
 metadata:
   name: logstash-sample
 spec:
-  version: 9.4.0
+  version: 9.4.2
   count: 3
   config:
     log.level: info

--- a/config/samples/logstash/logstash_es.yaml
+++ b/config/samples/logstash/logstash_es.yaml
@@ -3,7 +3,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
     - name: default
       count: 2
@@ -16,7 +16,7 @@ metadata:
   name: logstash-sample
 spec:
   count: 1
-  version: 9.4.0
+  version: 9.4.2
   elasticsearchRefs:
     - clusterName: production
       name: elasticsearch-sample

--- a/config/samples/logstash/logstash_pv.yaml
+++ b/config/samples/logstash/logstash_pv.yaml
@@ -4,7 +4,7 @@ metadata:
   name: d
 spec:
   count: 1
-  version: 9.4.0
+  version: 9.4.2
   config:
     queue.type: persisted
   pipelines:

--- a/config/samples/logstash/logstash_stackmonitor.yaml
+++ b/config/samples/logstash/logstash_stackmonitor.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: monitoring
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
     - name: default
       count: 3
@@ -17,7 +17,7 @@ metadata:
   name: logstash-sample
 spec:
   count: 1
-  version: 9.4.0
+  version: 9.4.2
   config:
     log.level: info
     api.http.host: "0.0.0.0"
@@ -55,7 +55,7 @@ kind: Kibana
 metadata:
   name: kibana-sample
 spec:
-  version: 9.4.0
+  version: 9.4.2
   elasticsearchRef:
     name: monitoring
   count: 1

--- a/config/samples/logstash/logstash_svc.yaml
+++ b/config/samples/logstash/logstash_svc.yaml
@@ -3,7 +3,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: 9.4.0
+  version: 9.4.2
   nodeSets:
     - name: default
       count: 3
@@ -16,7 +16,7 @@ metadata:
   name: logstash-sample
 spec:
   count: 2
-  version: 9.4.0
+  version: 9.4.2
   config:
     log.level: info
     api.http.host: "0.0.0.0"

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -103,7 +103,7 @@ plans:
 - id: ocp-ci
   operation: create
   clusterName: ci
-  clientVersion: 4.21.7
+  clientVersion: 4.22.0
   provider: ocp
   machineType: e2-standard-8
   serviceAccount: true
@@ -114,7 +114,7 @@ plans:
 - id: ocp-dev
   operation: create
   clusterName: dev
-  clientVersion: 4.21.7
+  clientVersion: 4.22.0
   provider: ocp
   machineType: e2-standard-8
   serviceAccount: true

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -171,7 +171,7 @@ plans:
   diskSetup: kubectl apply -k hack/deployer/config/local-disks-kind
   kind:
     nodeCount: 3
-    nodeImage: kindest/node:v1.36.1@sha256:21c46cf61fd45873f89e6a1bfcba4b7904dffa84c2bec88aeeca9a0409af4725
+    nodeImage: kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5
     ipFamily: ipv4
 - id: kind-ci
   operation: create
@@ -183,7 +183,7 @@ plans:
   diskSetup: kubectl apply -k hack/deployer/config/local-disks-kind
   kind:
     nodeCount: 3
-    nodeImage: kindest/node:v1.36.1@sha256:21c46cf61fd45873f89e6a1bfcba4b7904dffa84c2bec88aeeca9a0409af4725
+    nodeImage: kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5
     ipFamily: ipv4
 - id: k3d-dev
   operation: create

--- a/hack/operatorhub/templates/csv.tpl
+++ b/hack/operatorhub/templates/csv.tpl
@@ -287,9 +287,9 @@ spec:
     Supported versions:
 
 
-    * Kubernetes 1.31-1.35
+    * Kubernetes 1.31-1.36
 
-    * OpenShift 4.16-4.21
+    * OpenShift 4.16-4.22
 
     * Google Kubernetes Engine (GKE), Azure Kubernetes Service (AKS), and Amazon Elastic Kubernetes Service (EKS)
 


### PR DESCRIPTION
 ### Stack versions

  Bump latest patch versions across all CI matrices, sample/recipe configs, and the default `E2E_STACK_VERSION`:

  | Series | Before | After |
  |--------|--------|-------|
  | 8.19.x | 8.19.15 | 8.19.16 |
  | 9.3.x | 9.3.4 | 9.3.5 |
  | 9.4.x (default) | 9.4.0 | 9.4.2 |

  ### OpenShift 4.22

  - Bump OCP deployer client from `4.21.7` → `4.22.0` in `plans.yml` (default for nightly) and `release-branch-matrix.yaml`
  - Update supported version range to `4.16–4.22` in README and OperatorHub CSV template

  ### Kubernetes 1.36

  - Add `kindest/node:v1.36.1` (update image digest) to both CI Kind matrices; 1.35 drops to a single run, 1.36 gets the ipv4+ipv6 double entry as the new latest
  - k8s 1.31 is retained — still under EKS extended support
  - Update supported range to `1.31–1.36` in README and OperatorHub CSV template