### PR TITLE
e2e: skip logs-elastic_agent-default validation on affected versions

### DIFF
--- a/test/e2e/agent/config_test.go
+++ b/test/e2e/agent/config_test.go
@@ -60,7 +60,6 @@ func TestSystemIntegrationConfig(t *testing.T) {
 	agentBuilder := agent.NewBuilder(name).
 		WithElasticsearchRefs(agent.ToOutput(esBuilder.Ref(), "default")).
 		WithOpenShiftRoles(test.UseSCCRole).
-		WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.cpu", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.diskio", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.load", "default")).
@@ -72,6 +71,7 @@ func TestSystemIntegrationConfig(t *testing.T) {
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.uptime", "default"))
 	if !skipAgentInternalLogsValidation(v) {
 		agentBuilder = agentBuilder.
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.filebeat", "default"))
 	}
@@ -105,7 +105,6 @@ func TestAgentConfigRef(t *testing.T) {
 		WithObjects(secret).
 		WithElasticsearchRefs(agent.ToOutput(esBuilder.Ref(), "default")).
 		WithOpenShiftRoles(test.UseSCCRole).
-		WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.cpu", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.diskio", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.load", "default")).
@@ -117,6 +116,7 @@ func TestAgentConfigRef(t *testing.T) {
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.uptime", "default"))
 	if !skipAgentInternalLogsValidation(v) {
 		agentBuilder = agentBuilder.
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.filebeat", "default"))
 	}
@@ -143,7 +143,6 @@ func TestMultipleOutputConfig(t *testing.T) {
 			agent.ToOutput(esBuilder2.Ref(), "monitoring"),
 		).
 		WithOpenShiftRoles(test.UseSCCRole).
-		WithESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default"), "monitoring").
 		WithESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.cpu", "default"), "default").
 		WithESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.diskio", "default"), "default").
 		WithESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.load", "default"), "default").
@@ -155,6 +154,7 @@ func TestMultipleOutputConfig(t *testing.T) {
 		WithESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.uptime", "default"), "default")
 	if !skipAgentInternalLogsValidation(v) {
 		agentBuilder = agentBuilder.
+			WithESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default"), "monitoring").
 			WithESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default"), "monitoring").
 			WithESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.filebeat", "default"), "monitoring")
 	}

--- a/test/e2e/agent/recipes_test.go
+++ b/test/e2e/agent/recipes_test.go
@@ -25,10 +25,10 @@ import (
 func TestSystemIntegrationRecipe(t *testing.T) {
 	v := version.MustParse(test.Ctx().ElasticStackVersion)
 	customize := func(builder agent.Builder) agent.Builder {
-		builder = builder.
-			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default"))
 		if !skipAgentInternalLogsValidation(v) {
-			builder = builder.WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default"))
+			builder = builder.
+				WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default")).
+				WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default"))
 		}
 		// In 9.5.0+ beats run as OTel receivers and no longer expose the HTTP stats endpoint,
 		// so metrics-elastic_agent.metricbeat-default is no longer populated.
@@ -56,10 +56,10 @@ func TestSystemIntegrationRecipe(t *testing.T) {
 func TestKubernetesIntegrationRecipe(t *testing.T) {
 	v := version.MustParse(test.Ctx().ElasticStackVersion)
 	customize := func(builder agent.Builder) agent.Builder {
-		builder = builder.
-			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default"))
 		if !skipAgentInternalLogsValidation(v) {
-			builder = builder.WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default"))
+			builder = builder.
+				WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default")).
+				WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default"))
 		}
 		// In 9.5.0+ beats run as OTel receivers and no longer expose the HTTP stats endpoint,
 		// so metrics-elastic_agent.metricbeat-default is no longer populated.
@@ -86,10 +86,10 @@ func TestKubernetesIntegrationRecipe(t *testing.T) {
 func TestMultiOutputRecipe(t *testing.T) {
 	v := version.MustParse(test.Ctx().ElasticStackVersion)
 	customize := func(builder agent.Builder) agent.Builder {
-		builder = builder.
-			WithESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default"), "monitoring")
 		if !skipAgentInternalLogsValidation(v) {
-			builder = builder.WithESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default"), "monitoring")
+			builder = builder.
+				WithESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default"), "monitoring").
+				WithESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default"), "monitoring")
 		}
 		// In 9.5.0+ beats run as OTel receivers and no longer expose the HTTP stats endpoint,
 		// so metrics-elastic_agent.metricbeat-default is no longer populated.


### PR DESCRIPTION
## Problem

`TestKubernetesIntegrationRecipe/ES_data_should_pass_validations` started failing on 9.3.5 nightly runs with `404 Not Found: no such index [logs-elastic_agent-default]` [BK link](https://buildkite.com/elastic/cloud-on-k8s-operator/builds/15047).

This is a follow-up to #9487 and the `elastic_agent.metricbeat` fix. The base `logs-elastic_agent-default` stream was always affected by the same root cause but was masked — `logs-elastic_agent.filebeat-default` appeared first in the validation order and caused the test to fail before reaching the base stream check. Once `.filebeat` and `.metricbeat` were guarded, the failure was exposed.

## Root Cause

Same root cause as #9487 (tracked in https://github.com/elastic/cloud-on-k8s/issues/9406), but a different internal receiver: `logs-elastic_agent-default` is populated by `elasticmonitoringreceiver` (`internal/edot/receivers/elasticmonitoring`), not by filebeat or metricbeat.

The eck-diagnostics confirm all three failure stages from `elasticsearchexporter@v0.152.0`:

```
"otelcol.component.id":"elasticmonitoringreceiver/_agent-component/internal-telemetry-monitoring"
"message":"bulk indexer flush error"
"error":"flush failed (401): unable to authenticate user [...] for REST request [/_bulk...]"
"log.origin":"elasticsearchexporter@v0.152.0/bulkindexer.go:343"

"message":"Exporting failed. Dropping data."
"error":"Permanent error: flush failed (401): ..."

"message":"Component state changed filestream-monitoring (HEALTHY->DEGRADED): Recoverable: Elasticsearch request failed: 401 Unauthorized"
```

During agent startup there is a ~60s window where ES has not yet reloaded the file realm after the credential secret is synced by kubelet. The initial batches from `elasticmonitoringreceiver` hit a `401`, are permanently dropped, and `logs-elastic_agent-default` is never created.

## Fix

Extend the `skipAgentInternalLogsValidation` guard to also cover `logs-elastic_agent-default` in all six tests across `config_test.go` and `recipes_test.go`. All `logs-elastic_agent*` streams (`elastic_agent`, `elastic_agent.metricbeat`, `elastic_agent.filebeat`) are now fully guarded.

Affected versions: 8.19.16+, 9.3.5+, 9.4.2+, 9.5.0+.
