### PR TITLE
e2e: revert stack version 8.7.2 to 8.7.1

### DIFF
--- a/.buildkite/e2e/release-branch-matrix.yaml
+++ b/.buildkite/e2e/release-branch-matrix.yaml
@@ -9,7 +9,8 @@
     - E2E_STACK_VERSION: "8.4.3"
     - E2E_STACK_VERSION: "8.5.3"
     - E2E_STACK_VERSION: "8.6.2"
-    - E2E_STACK_VERSION: "8.7.2"
+    # do not update to 8.7.2 the elasticsearch container image doesn't exist
+    - E2E_STACK_VERSION: "8.7.1"
     - E2E_STACK_VERSION: "8.8.2"
     - E2E_STACK_VERSION: "8.9.2"
     - E2E_STACK_VERSION: "8.10.4"


### PR DESCRIPTION
Revert E2E_STACK_VERSION 8.7.2 to 8.7.1 as an elasticsearch image for 8.7.2 isn't published