### PR TITLE
[3.4.1] e2e: skip logs-elastic_agent-default validation on affected versions (#9511)

### DIFF
--- a/test/e2e/agent/config_test.go
+++ b/test/e2e/agent/config_test.go
@@ -60,7 +60,6 @@ func TestSystemIntegrationConfig(t *testing.T) {
 	agentBuilder := agent.NewBuilder(name).
 		WithElasticsearchRefs(agent.ToOutput(esBuilder.Ref(), "default")).
 		WithOpenShiftRoles(test.UseSCCRole).
-		WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.cpu", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.diskio", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.load", "default")).
@@ -72,6 +71,7 @@ func TestSystemIntegrationConfig(t *testing.T) {
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.uptime", "default"))
 	if !skipAgentInternalLogsValidation(v) {
 		agentBuilder = agentBuilder.
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.filebeat", "default"))
 	}
@@ -105,7 +105,6 @@ func TestAgentConfigRef(t *testing.T) {
 		WithObjects(secret).
 		WithElasticsearchRefs(agent.ToOutput(esBuilder.Ref(), "default")).
 		WithOpenShiftRoles(test.UseSCCRole).
-		WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.cpu", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.diskio", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.load", "default")).
@@ -117,6 +116,7 @@ func TestAgentConfigRef(t *testing.T) {
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.uptime", "default"))
 	if !skipAgentInternalLogsValidation(v) {
 		agentBuilder = agentBuilder.
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.filebeat", "default"))
 	}
@@ -143,7 +143,6 @@ func TestMultipleOutputConfig(t *testing.T) {
 			agent.ToOutput(esBuilder2.Ref(), "monitoring"),
 		).
 		WithOpenShiftRoles(test.UseSCCRole).
-		WithESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default"), "monitoring").
 		WithESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.cpu", "default"), "default").
 		WithESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.diskio", "default"), "default").
 		WithESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.load", "default"), "default").
@@ -155,6 +154,7 @@ func TestMultipleOutputConfig(t *testing.T) {
 		WithESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.uptime", "default"), "default")
 	if !skipAgentInternalLogsValidation(v) {
 		agentBuilder = agentBuilder.
+			WithESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default"), "monitoring").
 			WithESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default"), "monitoring").
 			WithESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.filebeat", "default"), "monitoring")
 	}

--- a/test/e2e/agent/recipes_test.go
+++ b/test/e2e/agent/recipes_test.go
@@ -25,10 +25,10 @@ import (
 func TestSystemIntegrationRecipe(t *testing.T) {
 	v := version.MustParse(test.Ctx().ElasticStackVersion)
 	customize := func(builder agent.Builder) agent.Builder {
-		builder = builder.
-			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default"))
 		if !skipAgentInternalLogsValidation(v) {
-			builder = builder.WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default"))
+			builder = builder.
+				WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default")).
+				WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default"))
 		}
 		// In 9.5.0+ beats run as OTel receivers and no longer expose the HTTP stats endpoint,
 		// so metrics-elastic_agent.metricbeat-default is no longer populated.
@@ -56,10 +56,10 @@ func TestSystemIntegrationRecipe(t *testing.T) {
 func TestKubernetesIntegrationRecipe(t *testing.T) {
 	v := version.MustParse(test.Ctx().ElasticStackVersion)
 	customize := func(builder agent.Builder) agent.Builder {
-		builder = builder.
-			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default"))
 		if !skipAgentInternalLogsValidation(v) {
-			builder = builder.WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default"))
+			builder = builder.
+				WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default")).
+				WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default"))
 		}
 		// In 9.5.0+ beats run as OTel receivers and no longer expose the HTTP stats endpoint,
 		// so metrics-elastic_agent.metricbeat-default is no longer populated.
@@ -86,10 +86,10 @@ func TestKubernetesIntegrationRecipe(t *testing.T) {
 func TestMultiOutputRecipe(t *testing.T) {
 	v := version.MustParse(test.Ctx().ElasticStackVersion)
 	customize := func(builder agent.Builder) agent.Builder {
-		builder = builder.
-			WithESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default"), "monitoring")
 		if !skipAgentInternalLogsValidation(v) {
-			builder = builder.WithESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default"), "monitoring")
+			builder = builder.
+				WithESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default"), "monitoring").
+				WithESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default"), "monitoring")
 		}
 		// In 9.5.0+ beats run as OTel receivers and no longer expose the HTTP stats endpoint,
 		// so metrics-elastic_agent.metricbeat-default is no longer populated.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.4`:
 - [e2e: skip logs-elastic_agent-default validation on affected versions (#9511)](https://github.com/elastic/cloud-on-k8s/pull/9511)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)