### PR TITLE
e2e: fix flaky association event regex in APM and Kibana e2e tests

### DIFF
--- a/test/e2e/apm/association_test.go
+++ b/test/e2e/apm/association_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test/kibana"
 )
 
-var associationEventRegex = regexp.MustCompile(`Association status changed from \[(.+?)] to \[(.+?)]`)
+var associationEventRegex = regexp.MustCompile(`Association status changed from \[(.*?)] to \[(.*?)]`)
 
 // TestCrossNSAssociation tests associating Elasticsearch and an APM Server running in different namespaces.
 func TestCrossNSAssociation(t *testing.T) {

--- a/test/e2e/kb/association_test.go
+++ b/test/e2e/kb/association_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test/kibana"
 )
 
-var associationEventRegex = regexp.MustCompile(`Association status changed from \[(.+?)] to \[(.+?)]`)
+var associationEventRegex = regexp.MustCompile(`Association status changed from \[(.*?)] to \[(.*?)]`)
 
 // TestCrossNSAssociation tests associating Elasticsearch and Kibana running in different namespaces.
 func TestCrossNSAssociation(t *testing.T) {


### PR DESCRIPTION
## Problem

`TestAPMAssociationWhenReferencedESDisappears` and the equivalent Kibana test
intermittently fail with:

```
expected events did not fire: assocEstablished=false assocLost=true noBackend=true
```

The tests watch for three Kubernetes events on the resource under test:

| Flag | Event expected |
|---|---|
| `assocEstablished` | status transition **to** `[Established]` |
| `assocLost` | status transition **from** `[Established]` |
| `noBackend` | `AssociationError` warning |

The failure is intermittent because it depends on a race between ES becoming
ready and the first operator reconcile of the APM/Kibana resource:

- **Common case (passing):** ES is not yet ready when the operator first
  reconciles, so the association goes `[] → [Pending/Failed] → [Established]`.
  The second transition has a non-empty "from" state, the regex matches, and
  `assocEstablished` is set.

- **Failing case:** ES is already healthy by the time the operator runs its
  first reconcile. The association jumps directly `[] → [Established]`,
  skipping any intermediate state. The "from" brackets are empty (`[]`).

## Root cause

Both test files defined the regex as:

```go
var associationEventRegex = regexp.MustCompile(`Association status changed from \[(.+?)] to \[(.+?)]`)
```

`(.+?)` requires **one or more** characters between the brackets. The initial
association status is an empty Go map, which serialises as `[]` (zero
characters). So `FindStringSubmatch` returns `nil` for the
`[] → [Established]` event, `assocEstablished` is never set, and the test
times out after 15 minutes.

The `[Established] → [Failed]` event (triggered by the namespace change)
always matched because both capture groups are non-empty, which is why
`assocLost=true` while `assocEstablished=false`.

## Fix

Change `(.+?)` to `(.*?)` (zero-or-more) in both files:

```go
var associationEventRegex = regexp.MustCompile(`Association status changed from \[(.*?)] to \[(.*?)]`)
```

With `(.*?)`, `[]` matches as an empty string `""`. The downstream comparisons
are unaffected: `"" == establishedString` correctly evaluates to `false`, so no
false positives are introduced for any other transition.

## Files changed

- `test/e2e/apm/association_test.go`
- `test/e2e/kb/association_test.go`