### PR TITLE
e2e: skip metrics-elastic_agent.elastic_agent validation for APM on affected 8.x versions

### DIFF
--- a/test/e2e/agent/config_test.go
+++ b/test/e2e/agent/config_test.go
@@ -47,6 +47,16 @@ func skipAgentInternalLogsValidation(v version.Version) bool {
 	}
 }
 
+// skipAPMServerElasticAgentMetricsValidation returns true for 8.x versions < 8.19.0 where APM
+// server's CollectMonitoring emits flat dotted metric names (e.g. "fetch.es") that land in
+// metrics-elastic_agent.elastic_agent-default. Because that data stream uses TSDB with synthetic
+// source, querying it after those documents are ingested returns a 500 "Duplicate field 'fetch'".
+// See https://github.com/elastic/apm-server/issues/13625, fixed in 8.19.0.
+func skipAPMServerElasticAgentMetricsValidation(v version.Version) bool {
+	v = version.WithoutPre(v)
+	return v.Major == 8 && v.LT(version.From(8, 19, 0))
+}
+
 func TestSystemIntegrationConfig(t *testing.T) {
 	name := "test-agent-system-int"
 

--- a/test/e2e/agent/recipes_test.go
+++ b/test/e2e/agent/recipes_test.go
@@ -240,9 +240,15 @@ func TestFleetCustomLogsIntegrationRecipe(t *testing.T) {
 }
 
 func TestFleetAPMIntegrationRecipe(t *testing.T) {
+	v := version.MustParse(test.Ctx().ElasticStackVersion)
 	customize := func(builder agent.Builder) agent.Builder {
 		if !builder.Agent.Spec.FleetServerEnabled {
 			return builder
+		}
+		if skipAPMServerElasticAgentMetricsValidation(v) {
+			return builder.WithFleetAgentDataStreamsValidationFiltered(func(dsType, dataset string) bool {
+				return dsType != agent.MetricsType || dataset != "elastic_agent.elastic_agent"
+			})
 		}
 		return builder.WithFleetAgentDataStreamsValidation()
 	}

--- a/test/e2e/test/agent/builder.go
+++ b/test/e2e/test/agent/builder.go
@@ -244,23 +244,34 @@ func (b Builder) WithESValidation(validation ValidationFunc, outputName string) 
 }
 
 func (b Builder) WithFleetAgentDataStreamsValidation() Builder {
+	return b.WithFleetAgentDataStreamsValidationFiltered(nil)
+}
+
+// WithFleetAgentDataStreamsValidationFiltered adds data stream validations for elastic-agent
+// internal streams. When filter is non-nil it is called for each (type, dataset) pair and only
+// streams for which it returns true are validated. When nil, all streams are validated.
+func (b Builder) WithFleetAgentDataStreamsValidationFiltered(filter func(dsType, dataset string) bool) Builder {
 	v := version.MustParse(test.Ctx().ElasticStackVersion)
-	b = b.
-		WithDefaultESValidation(HasWorkingDataStream(LogsType, "elastic_agent", "default")).
-		WithDefaultESValidation(HasWorkingDataStream(LogsType, "elastic_agent.filebeat", "default")).
-		WithDefaultESValidation(HasWorkingDataStream(LogsType, "elastic_agent.fleet_server", "default")).
-		WithDefaultESValidation(HasWorkingDataStream(LogsType, "elastic_agent.metricbeat", "default")).
-		WithDefaultESValidation(HasWorkingDataStream(MetricsType, "elastic_agent.elastic_agent", "default")).
-		WithDefaultESValidation(HasWorkingDataStream(MetricsType, "elastic_agent.fleet_server", "default"))
+	maybeAdd := func(dsType, dataset string) {
+		if filter == nil || filter(dsType, dataset) {
+			b = b.WithDefaultESValidation(HasWorkingDataStream(dsType, dataset, "default"))
+		}
+	}
+	maybeAdd(LogsType, "elastic_agent")
+	maybeAdd(LogsType, "elastic_agent.filebeat")
+	maybeAdd(LogsType, "elastic_agent.fleet_server")
+	maybeAdd(LogsType, "elastic_agent.metricbeat")
+	maybeAdd(MetricsType, "elastic_agent.elastic_agent")
+	maybeAdd(MetricsType, "elastic_agent.fleet_server")
 	// In 9.5.0+ beats run as OTel receivers and no longer expose the HTTP stats endpoint,
 	// so beat/metrics-monitoring is not created and metrics-elastic_agent.metricbeat-default
 	// is no longer populated. See https://github.com/elastic/elastic-agent/pull/13411.
 	if v.LT(version.MinFor(9, 5, 0)) {
-		b = b.WithDefaultESValidation(HasWorkingDataStream(MetricsType, "elastic_agent.metricbeat", "default"))
+		maybeAdd(MetricsType, "elastic_agent.metricbeat")
 	}
 	// https://github.com/elastic/cloud-on-k8s/issues/7389
 	if v.LT(version.MinFor(8, 12, 0)) {
-		b = b.WithDefaultESValidation(HasWorkingDataStream(MetricsType, "elastic_agent.filebeat", "default"))
+		maybeAdd(MetricsType, "elastic_agent.filebeat")
 	}
 	return b
 }


### PR DESCRIPTION
## Problem

`TestFleetAPMIntegrationRecipe` was intermittently fail on stack versions < 8.19.0 with a 500 error from Elasticsearch when validating the `metrics-elastic_agent.elastic_agent-default` data stream: `"Duplicate field 'fetch'"`. [BK link](https://buildkite.com/elastic/cloud-on-k8s-operator/builds/15058)

## Root cause

APM server < 8.19.0 has a bug ([elastic/apm-server#13625](https://github.com/elastic/apm-server/issues/13625)) in `CollectMonitoring`, introduced with the Elasticsearch agentcfg fetcher in 8.7.0. It calls `monitoring.ReportInt(V, "fetch.es", ...)` which goes through the flat-snapshot visitor and produces literal dotted-string keys in the monitoring output (e.g. `"fetch.es": 0`, `"fetch.size": 1`) rather than nested JSON objects.

These metrics are collected by elastic-agent's `http-metrics-monitoring` metricbeat component and ingested into `metrics-elastic_agent.elastic_agent-default`. That data stream uses TSDB with synthetic source (enabled since elastic-agent integration package 1.11.0 for Kibana >= 8.9.0). When Elasticsearch reconstructs `_source` at query time it attempts to expand the dotted keys into nested objects while a sibling field with the same root name exists, triggering the duplicate field error.

My theory is that the failure is timing-dependent: it surfaces only when elastic-agent completes at least one monitoring poll cycle and ingests APM metrics before the test's data stream validation runs, which explains why it does not appear consistently across all affected versions in CI runs.

The bug was fixed in APM server 8.19.0.

## Changes

**`test/e2e/test/agent/builder.go`** — `WithFleetAgentDataStreamsValidation()` now delegates to a new `WithFleetAgentDataStreamsValidationFiltered(filter func(dsType, dataset string) bool)`. When the filter is nil all streams are validated (unchanged behaviour). When non-nil only streams for which it returns true are added. A `(type, dataset)` pair is used rather than dataset name alone because some datasets (e.g. `elastic_agent.fleet_server`) appear under both logs and metrics types.

**`test/e2e/agent/config_test.go`** — adds `skipAPMServerElasticAgentMetricsValidation` which returns true for `8.x < 8.19.0`.

**`test/e2e/agent/recipes_test.go`** — `TestFleetAPMIntegrationRecipe` uses the filtered variant for affected versions, excluding `(MetricsType, "elastic_agent.elastic_agent")` while continuing to validate all other internal elastic-agent data streams. 8.19.0+ and 9.x validate the full set unchanged.