### PR TITLE
[3.4] e2e: skip metrics-elastic_agent.elastic_agent validation for APM on affected 8.x versions (#9517)

### DIFF
--- a/test/e2e/agent/config_test.go
+++ b/test/e2e/agent/config_test.go
@@ -47,6 +47,16 @@ func skipAgentInternalLogsValidation(v version.Version) bool {
 	}
 }
 
+// skipAPMServerElasticAgentMetricsValidation returns true for 8.x versions < 8.19.0 where APM
+// server's CollectMonitoring emits flat dotted metric names (e.g. "fetch.es") that land in
+// metrics-elastic_agent.elastic_agent-default. Because that data stream uses TSDB with synthetic
+// source, querying it after those documents are ingested returns a 500 "Duplicate field 'fetch'".
+// See https://github.com/elastic/apm-server/issues/13625, fixed in 8.19.0.
+func skipAPMServerElasticAgentMetricsValidation(v version.Version) bool {
+	v = version.WithoutPre(v)
+	return v.Major == 8 && v.LT(version.From(8, 19, 0))
+}
+
 func TestSystemIntegrationConfig(t *testing.T) {
 	name := "test-agent-system-int"
 

--- a/test/e2e/agent/recipes_test.go
+++ b/test/e2e/agent/recipes_test.go
@@ -240,9 +240,15 @@ func TestFleetCustomLogsIntegrationRecipe(t *testing.T) {
 }
 
 func TestFleetAPMIntegrationRecipe(t *testing.T) {
+	v := version.MustParse(test.Ctx().ElasticStackVersion)
 	customize := func(builder agent.Builder) agent.Builder {
 		if !builder.Agent.Spec.FleetServerEnabled {
 			return builder
+		}
+		if skipAPMServerElasticAgentMetricsValidation(v) {
+			return builder.WithFleetAgentDataStreamsValidationFiltered(func(dsType, dataset string) bool {
+				return dsType != agent.MetricsType || dataset != "elastic_agent.elastic_agent"
+			})
 		}
 		return builder.WithFleetAgentDataStreamsValidation()
 	}

--- a/test/e2e/test/agent/builder.go
+++ b/test/e2e/test/agent/builder.go
@@ -222,23 +222,34 @@ func (b Builder) WithESValidation(validation ValidationFunc, outputName string) 
 }
 
 func (b Builder) WithFleetAgentDataStreamsValidation() Builder {
+	return b.WithFleetAgentDataStreamsValidationFiltered(nil)
+}
+
+// WithFleetAgentDataStreamsValidationFiltered adds data stream validations for elastic-agent
+// internal streams. When filter is non-nil it is called for each (type, dataset) pair and only
+// streams for which it returns true are validated. When nil, all streams are validated.
+func (b Builder) WithFleetAgentDataStreamsValidationFiltered(filter func(dsType, dataset string) bool) Builder {
 	v := version.MustParse(test.Ctx().ElasticStackVersion)
-	b = b.
-		WithDefaultESValidation(HasWorkingDataStream(LogsType, "elastic_agent", "default")).
-		WithDefaultESValidation(HasWorkingDataStream(LogsType, "elastic_agent.filebeat", "default")).
-		WithDefaultESValidation(HasWorkingDataStream(LogsType, "elastic_agent.fleet_server", "default")).
-		WithDefaultESValidation(HasWorkingDataStream(LogsType, "elastic_agent.metricbeat", "default")).
-		WithDefaultESValidation(HasWorkingDataStream(MetricsType, "elastic_agent.elastic_agent", "default")).
-		WithDefaultESValidation(HasWorkingDataStream(MetricsType, "elastic_agent.fleet_server", "default"))
+	maybeAdd := func(dsType, dataset string) {
+		if filter == nil || filter(dsType, dataset) {
+			b = b.WithDefaultESValidation(HasWorkingDataStream(dsType, dataset, "default"))
+		}
+	}
+	maybeAdd(LogsType, "elastic_agent")
+	maybeAdd(LogsType, "elastic_agent.filebeat")
+	maybeAdd(LogsType, "elastic_agent.fleet_server")
+	maybeAdd(LogsType, "elastic_agent.metricbeat")
+	maybeAdd(MetricsType, "elastic_agent.elastic_agent")
+	maybeAdd(MetricsType, "elastic_agent.fleet_server")
 	// In 9.5.0+ beats run as OTel receivers and no longer expose the HTTP stats endpoint,
 	// so beat/metrics-monitoring is not created and metrics-elastic_agent.metricbeat-default
 	// is no longer populated. See https://github.com/elastic/elastic-agent/pull/13411.
 	if v.LT(version.MinFor(9, 5, 0)) {
-		b = b.WithDefaultESValidation(HasWorkingDataStream(MetricsType, "elastic_agent.metricbeat", "default"))
+		maybeAdd(MetricsType, "elastic_agent.metricbeat")
 	}
 	// https://github.com/elastic/cloud-on-k8s/issues/7389
 	if v.LT(version.MinFor(8, 12, 0)) {
-		b = b.WithDefaultESValidation(HasWorkingDataStream(MetricsType, "elastic_agent.filebeat", "default"))
+		maybeAdd(MetricsType, "elastic_agent.filebeat")
 	}
 	return b
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.4`:
 - [e2e: skip metrics-elastic_agent.elastic_agent validation for APM on affected 8.x versions (#9517)](https://github.com/elastic/cloud-on-k8s/pull/9517)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)