### PR TITLE
[3.4] e2e: fix flaky association event regex in APM and Kibana e2e tests (#9516)

### DIFF
--- a/test/e2e/apm/association_test.go
+++ b/test/e2e/apm/association_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test/kibana"
 )
 
-var associationEventRegex = regexp.MustCompile(`Association status changed from \[(.+?)] to \[(.+?)]`)
+var associationEventRegex = regexp.MustCompile(`Association status changed from \[(.*?)] to \[(.*?)]`)
 
 // TestCrossNSAssociation tests associating Elasticsearch and an APM Server running in different namespaces.
 func TestCrossNSAssociation(t *testing.T) {

--- a/test/e2e/kb/association_test.go
+++ b/test/e2e/kb/association_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test/kibana"
 )
 
-var associationEventRegex = regexp.MustCompile(`Association status changed from \[(.+?)] to \[(.+?)]`)
+var associationEventRegex = regexp.MustCompile(`Association status changed from \[(.*?)] to \[(.*?)]`)
 
 // TestCrossNSAssociation tests associating Elasticsearch and Kibana running in different namespaces.
 func TestCrossNSAssociation(t *testing.T) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.4`:
 - [e2e: fix flaky association event regex in APM and Kibana e2e tests (#9516)](https://github.com/elastic/cloud-on-k8s/pull/9516)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)