### PR TITLE
Fix Kyverno webhook "No agent available" error

### DIFF
--- a/hack/deployer/runner/kyverno/kyverno.go
+++ b/hack/deployer/runner/kyverno/kyverno.go
@@ -51,9 +51,16 @@ func Install(globalKubectlOptions ...string) error {
 	log.Println("Installing Kyverno policies")
 	if err := retry.UntilSuccess(
 		func() error { return apply(k, dir, policiesManifest, "policies.yaml") },
+		2*time.Minute,
 		5*time.Second,
-		1*time.Second,
 	); err != nil {
+		return err
+	}
+
+	// Applying policies can briefly disrupt the admission controller; wait for it to be ready again
+	// before returning so that subsequent kubectl commands don't hit "No agent available".
+	log.Println("Waiting for Kyverno to be ready after policy installation...")
+	if err := k.NewCommand(waitForKyvernoDeployments).Run(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
BK: https://buildkite.com/elastic/cloud-on-k8s-operator-nightly/builds/1308#019ed264-c71c-4aea-95d8-3df3d7ca1f6d

Applying ClusterPolicy resources can briefly disrupt the Kyverno admission controller, leaving a window where the mutating webhook returns "No agent available" for any subsequent kubectl command.

Two changes:
  - Add a second rollout status wait after policy installation so Install() only returns once Kyverno is healthy again.
  - Widen the policy-apply retry window from 5 s to 2 min so the initial apply can survive the webhook not yet accepting connections right after rollout.
