### PR TITLE
Bump eck-diagnostics to 1.11.0 and add --keep-secret-data

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,6 +17,15 @@
       ],
       "datasourceTemplate": "docker",
       "versioningTemplate": "loose"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^test/e2e/Dockerfile$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\n]+)\\nENV \\w+=(?<currentValue>[^\\n]+)"
+      ]
     }
   ],
   "ignorePaths": [

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -6,7 +6,8 @@ ARG ARCH
 
 WORKDIR /go/src/github.com/elastic/cloud-on-k8s
 
-ENV ECK_DIAG_VERSION=1.10.0
+# renovate: datasource=github-releases depName=elastic/eck-diagnostics
+ENV ECK_DIAG_VERSION=1.11.0
 # Download and extract the correct eck-diagnostics binary based on the image architecture
 # ARCH is passed from drivah.toml.sh (amd64 or arm64)
 # Map to eck-diagnostics naming: x86_64 for amd64, arm64 for arm64

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -870,7 +870,7 @@ func (h *helper) runECKDiagnostics() {
 	operatorNS := h.testContext.Operator.Namespace
 	// include the default namespace to have diagnostics on the local disk provisioner used in some environments
 	otherNS := append([]string{h.testContext.E2ENamespace, "default"}, h.testContext.Operator.ManagedNamespaces...)
-	cmd := exec.Command("eck-diagnostics", "-o", operatorNS, "-r", strings.Join(otherNS, ","), "--run-agent-diagnostics") //nolint:noctx
+	cmd := exec.Command("eck-diagnostics", "-o", operatorNS, "-r", strings.Join(otherNS, ","), "--run-agent-diagnostics", "--keep-secret-data") //nolint:noctx
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {

--- a/test/e2e/test/diagnostics.go
+++ b/test/e2e/test/diagnostics.go
@@ -62,5 +62,6 @@ func maybeRunECKDiagnostics(ctx context.Context, testName string, step Step) {
 		"-o", testCtx.Operator.Namespace,
 		"-r", strings.Join(otherNS, ","),
 		"--run-agent-diagnostics",
+		"--keep-secret-data",
 	)
 }


### PR DESCRIPTION
### Changes

- Bump `ECK_DIAG_VERSION` from `1.10.0` to `1.11.0` in `test/e2e/Dockerfile`
- Add a Renovate inline comment on the `ECK_DIAG_VERSION` env var and a matching `customManagers` regex entry in `.github/renovate.json` so future eck-diagnostics releases are auto-bumped via GitHub releases
- Pass `--keep-secret-data` to both eck-diagnostics invocations so that Kubernetes secret values are included in diagnostic archives, enabling reproduction of e2e test failures that rely on secret contents