### PR TITLE
e2e: fix stack monitoring checks trivially passing with 0 pods

### DIFF
--- a/test/e2e/test/beat/builder.go
+++ b/test/e2e/test/beat/builder.go
@@ -406,3 +406,7 @@ func (b Builder) GetLogsCluster() *types.NamespacedName {
 	logsCluster := b.Beat.Spec.Monitoring.Logs.ElasticsearchRefs[0].NamespacedName()
 	return &logsCluster
 }
+
+func (b Builder) ListOptions() []k8sclient.ListOption {
+	return test.BeatPodListOptions(b.Beat.Namespace, b.Beat.Name, b.Beat.Spec.Type)
+}

--- a/test/e2e/test/checks/monitoring.go
+++ b/test/e2e/test/checks/monitoring.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/types"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	esv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/version"
@@ -29,6 +30,7 @@ type Monitored interface {
 	GetMetricsIndexPattern() string
 	GetLogsCluster() *types.NamespacedName
 	GetMetricsCluster() *types.NamespacedName
+	ListOptions() []k8sclient.ListOption
 }
 
 func MonitoredSteps(monitored Monitored, k8sClient *test.K8sClient) test.StepList {
@@ -54,21 +56,17 @@ type stackMonitoringChecks struct {
 
 func (c stackMonitoringChecks) Steps() test.StepList {
 	return test.StepList{
-		c.CheckBeatSidecarsInElasticsearch(),
+		c.CheckBeatSidecars(),
 		c.CheckMonitoringMetricsIndex(),
 		c.CheckFilebeatIndex(),
 	}
 }
 
-func (c stackMonitoringChecks) CheckBeatSidecarsInElasticsearch() test.Step {
+func (c stackMonitoringChecks) CheckBeatSidecars() test.Step {
 	return test.Step{
 		Name: "Check that beat sidecars are running",
 		Test: test.Eventually(func() error {
-			pods, err := c.k8sClient.GetPods(
-				test.ESPodListOptions(
-					c.monitored.Namespace(),
-					c.monitored.Name())...,
-			)
+			pods, err := c.k8sClient.GetPods(c.monitored.ListOptions()...)
 			if err != nil {
 				return err
 			}

--- a/test/e2e/test/checks/monitoring.go
+++ b/test/e2e/test/checks/monitoring.go
@@ -72,6 +72,9 @@ func (c stackMonitoringChecks) CheckBeatSidecarsInElasticsearch() test.Step {
 			if err != nil {
 				return err
 			}
+			if len(pods) == 0 {
+				return fmt.Errorf("no pods found for %s/%s", c.monitored.Namespace(), c.monitored.Name())
+			}
 			for _, pod := range pods {
 				if len(pod.Spec.Containers) != 3 {
 					return fmt.Errorf("expected %d containers, got %d", 3, len(pod.Spec.Containers))
@@ -116,7 +119,7 @@ func (c stackMonitoringChecks) CheckFilebeatIndex() test.Step {
 	return test.Step{
 		Name: "Check that documents are indexed in one filebeat-* index",
 		Test: test.Eventually(func() error {
-			if c.monitored.GetMetricsCluster() == nil {
+			if c.monitored.GetLogsCluster() == nil {
 				return nil
 			}
 			esLogsRef := *c.monitored.GetLogsCluster()

--- a/test/e2e/test/elasticsearch/builder.go
+++ b/test/e2e/test/elasticsearch/builder.go
@@ -596,6 +596,10 @@ func (b Builder) GetMetricsCluster() *types.NamespacedName {
 	return &metricsCluster
 }
 
+func (b Builder) ListOptions() []client.ListOption {
+	return test.ESPodListOptions(b.Elasticsearch.Namespace, b.Elasticsearch.Name)
+}
+
 // TolerateMutationChecksFailures relaxes the continuous health check performed during a mutation by accepting a given number of failures.
 // When a new index is created at the same time as the mutation, the shutdown node API currently does not prevent shutting down a node
 // which has a new uninitialized replica, resulting in a cluster with red health status for a few seconds while the node comes back.


### PR DESCRIPTION
## Problem
`TestExternalESStackMonitoring/PVCs_should_eventually_be_removed` was failing intermittently in nightly CI with "1 pvcs still present" after a 15-minute timeout ([BK link](https://buildkite.com/elastic/cloud-on-k8s-operator-nightly/builds/1318)).

## Root cause
`TestExternalESStackMonitoring` adds `spec.monitoring` to the monitored cluster via a live `k.Client.Update` during the check phase - the `monitored` builder is never updated. As a result, when `MonitoredSteps(&monitored, k)` runs, `GetMetricsCluster()` reads from the builder (which has no monitoring refs) and returns `nil`, causing `CheckMonitoringMetricsIndex` and `CheckFilebeatIndex` to immediately return nil without checking anything.

The only remaining gate was `CheckBeatSidecarsInElasticsearch`, which iterates over pods and checks each has 3 containers and is Ready. Adding `spec.monitoring` triggers a rolling upgrade on the 1-node cluster. During the upgrade the old pod is deleted before the new one is created, leaving a brief 0-pod window. Because the check iterated over an empty slice it trivially returned nil:
```go
for _, pod := range pods {  // empty - loop body never executes
    ...
}
return nil  // passes regardless
```
`test.Eventually` polled during this window, all check steps passed, and the test started cleanup - deleting the ES resource **mid-rolling-upgrade**.

At that point ECK reconciliations were returning early at the `expectationsSatisfied` gate (StatefulSet `observedGeneration` not yet caught up), so `reconcilePVCOwnerRefs` was never reached. The PVC had no owner reference, K8s GC had nothing to follow, the `kubernetes.io/pvc-protection` finalizer kept the PVC alive, and the deletion step timed out.

## Fixes

**`CheckBeatSidecars`** (renamed from `CheckBeatSidecarsInElasticsearch`): add a guard so `test.Eventually` retries through the 0-pod window instead of treating it as success:
```go
if len(pods) == 0 {
    return fmt.Errorf("no pods found for %s/%s", c.monitored.Namespace(), c.monitored.Name())
}
```

**`CheckBeatSidecars` — wrong pod list options**: the check was hardcoded to use `ESPodListOptions` regardless of the resource type, so for Kibana, Logstash, and Beat resources it would always find 0 pods and trivially pass (before the guard above) or permanently fail (after). Fixed by adding `ListOptions() []k8sclient.ListOption` to the `Monitored` interface and implementing it on the ES, Kibana (`ListOptions` already existed), Logstash (`ListOptions` already existed), and Beat builders. The check now uses `c.monitored.ListOptions()`.

**`CheckFilebeatIndex`**: fix a latent nil guard bug - the check was guarding on `GetMetricsCluster() == nil` but then dereferencing `GetLogsCluster()`. These are set together in practice, but the guard should match what it dereferences:
```go
// before
if c.monitored.GetMetricsCluster() == nil {
// after
if c.monitored.GetLogsCluster() == nil {
```