### PR TITLE
e2e: retry GKE Kyverno policy application on webhook not ready

### DIFF
--- a/hack/deployer/runner/gke.go
+++ b/hack/deployer/runner/gke.go
@@ -17,6 +17,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/hack/deployer/exec"
 	"github.com/elastic/cloud-on-k8s/v3/hack/deployer/runner/bucket"
 	"github.com/elastic/cloud-on-k8s/v3/hack/deployer/runner/kyverno"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/retry"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/vault"
 )
 
@@ -171,7 +172,11 @@ func (d *GKEDriver) Execute() error {
 				return err
 			}
 			// apply extra policies to prevent use of unlabeled storage classes which might escape garbage collection in CI
-			if err := apply(kyverno.GKEPolicies); err != nil {
+			if err := retry.UntilSuccess(
+				func() error { return apply(kyverno.GKEPolicies) },
+				2*time.Minute,
+				5*time.Second,
+			); err != nil {
 				return err
 			}
 		}

--- a/hack/deployer/runner/gke.go
+++ b/hack/deployer/runner/gke.go
@@ -171,7 +171,9 @@ func (d *GKEDriver) Execute() error {
 			if err := kyverno.Install(); err != nil {
 				return err
 			}
-			// apply extra policies to prevent use of unlabeled storage classes which might escape garbage collection in CI
+			// apply extra policies to prevent use of unlabeled storage classes which might escape garbage collection in CI.
+			// Retry because `rollout status` (used in kyverno.Install) only guarantees the pods are available,
+			// not that the webhook server is ready to accept connections yet.
 			if err := retry.UntilSuccess(
 				func() error { return apply(kyverno.GKEPolicies) },
 				2*time.Minute,


### PR DESCRIPTION

## Problem

When setting up a GKE cluster with `EnforceSecurityPolicies` enabled, the deployer installs Kyverno and then immediately applies the GKE-specific storage class policies. The installation sequence already waits for all Kyverno deployments to complete their rollout, but this is not sufficient: `rollout status` reports success as soon as the pods are available, but the Kyverno webhook server may not yet be accepting connections.

The result is a transient failure on the first `kubectl apply` call after installation ([BK link](https://buildkite.com/elastic/cloud-on-k8s-operator-nightly/builds/1320)):

```
Error from server (InternalError): error when creating "STDIN": Internal error occurred:
  failed calling webhook "mutate-policy.kyverno.svc": failed to call webhook:
  Post "https://kyverno-svc.kyverno.svc:443/policymutate?timeout=10s": No agent available
```

## Fix

Wrap the `apply(kyverno.GKEPolicies)` call in `runner/gke.go` with `retry.UntilSuccess` (2 min timeout, 5 s interval) - the same pattern already used for the base policy installation inside `kyverno.Install()`.