### PR TITLE
fix: logstash ignoring `set-default-security-context` operator flag

### DIFF
--- a/pkg/controller/logstash/pod.go
+++ b/pkg/controller/logstash/pod.go
@@ -122,8 +122,11 @@ func buildPodTemplate(params Params, configHash hash.Hash32) (corev1.PodTemplate
 		WithVolumes(volumes...).
 		WithVolumeMounts(volumeMounts...).
 		WithInitContainers(initConfigContainer(params)).
-		WithInitContainerDefaults().
-		WithPodSecurityContext(DefaultSecurityContext)
+		WithInitContainerDefaults()
+
+	if params.OperatorParams.SetDefaultSecurityContext {
+		builder = builder.WithPodSecurityContext(DefaultSecurityContext)
+	}
 
 	builder, err = stackmon.WithMonitoring(params.Context, params.Client, builder, params.Logstash, params.APIServerConfig, params.Meta)
 	if err != nil {

--- a/pkg/controller/logstash/pod_test.go
+++ b/pkg/controller/logstash/pod_test.go
@@ -21,6 +21,7 @@ import (
 	commonv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/common/v1"
 	logstashv1alpha1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/logstash/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/container"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/operator"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/pod"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/logstash/configs"
@@ -42,10 +43,11 @@ func TestNewPodTemplateSpec(t *testing.T) {
 	}
 
 	tests := []struct {
-		name            string
-		logstash        logstashv1alpha1.Logstash
-		apiServerConfig configs.APIServer
-		assertions      func(pod corev1.PodTemplateSpec)
+		name                      string
+		logstash                  logstashv1alpha1.Logstash
+		apiServerConfig           configs.APIServer
+		setDefaultSecurityContext bool
+		assertions                func(pod corev1.PodTemplateSpec)
 	}{
 		{
 			name: "defaults",
@@ -302,6 +304,30 @@ func TestNewPodTemplateSpec(t *testing.T) {
 			},
 		},
 		{
+			name: "with SetDefaultSecurityContext=true, seccomp profile is set",
+			logstash: logstashv1alpha1.Logstash{ObjectMeta: meta, Spec: logstashv1alpha1.LogstashSpec{
+				Version: "8.6.1",
+			}},
+			apiServerConfig:           GetDefaultAPIServer(),
+			setDefaultSecurityContext: true,
+			assertions: func(pod corev1.PodTemplateSpec) {
+				require.NotNil(t, pod.Spec.SecurityContext)
+				require.NotNil(t, pod.Spec.SecurityContext.SeccompProfile)
+				assert.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, pod.Spec.SecurityContext.SeccompProfile.Type)
+			},
+		},
+		{
+			name: "with SetDefaultSecurityContext=false, seccomp profile is not set",
+			logstash: logstashv1alpha1.Logstash{ObjectMeta: meta, Spec: logstashv1alpha1.LogstashSpec{
+				Version: "8.6.1",
+			}},
+			apiServerConfig:           GetDefaultAPIServer(),
+			setDefaultSecurityContext: false,
+			assertions: func(pod corev1.PodTemplateSpec) {
+				assert.Nil(t, pod.Spec.SecurityContext)
+			},
+		},
+		{
 			name: "with user-provided volumes and volume mounts",
 			logstash: logstashv1alpha1.Logstash{ObjectMeta: meta, Spec: logstashv1alpha1.LogstashSpec{
 				Version: "8.6.1",
@@ -339,6 +365,7 @@ func TestNewPodTemplateSpec(t *testing.T) {
 				Client:          k8s.NewFakeClient(&testHTTPCertsInternalSecret),
 				Logstash:        tt.logstash,
 				APIServerConfig: tt.apiServerConfig,
+				OperatorParams:  operator.Parameters{SetDefaultSecurityContext: tt.setDefaultSecurityContext},
 			}
 			configHash := fnv.New32a()
 			got, err := buildPodTemplate(params, configHash)


### PR DESCRIPTION
## Problem

ECK has an OpenShift detection mechanism that sets the `SetDefaultSecurityContext` operator parameter to `false` when running on OpenShift. Every controller in ECK gates the injection of `seccompProfile: RuntimeDefault` behind this flag - except Logstash, which unconditionally applied `DefaultSecurityContext` (including `seccompProfile: RuntimeDefault`) regardless of platform.

This caused Logstash pods to be rejected on OpenShift when the service account was bound to an SCC that does not permit seccomp profiles (e.g. `anyuid`), even though ECK was correctly detecting OpenShift and suppressing this behaviour for all other resources (Elasticsearch, Kibana, APM Server, Elastic Maps Server, Package Registry).

Fixes #9550

## Change

Gate the `WithPodSecurityContext(DefaultSecurityContext)` call in `buildPodTemplate` behind `params.OperatorParams.SetDefaultSecurityContext`, consistent with how all other controllers handle this:

```go
if params.OperatorParams.SetDefaultSecurityContext {
    builder = builder.WithPodSecurityContext(DefaultSecurityContext)
}
```

