### PR TITLE
certificates: verify owner references when building client cert trust bundle

### DIFF
--- a/pkg/controller/common/certificates/client_cert_reconcile.go
+++ b/pkg/controller/common/certificates/client_cert_reconcile.go
@@ -21,6 +21,8 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -39,6 +41,9 @@ const (
 
 	// internalClientCertCommonName is the CommonName used in the operator's client certificate.
 	internalClientCertCommonName = "eck-internal"
+
+	// eckAPIGroupSuffix is the common suffix for all ECK custom resource API groups.
+	eckAPIGroupSuffix = ".k8s.elastic.co"
 
 	// clientCertTrustBundleSecretSuffix is the suffix appended to the owner name to form the trust bundle secret name.
 	clientCertTrustBundleSecretSuffix = "client-trust-bundle"
@@ -152,7 +157,9 @@ func (r Reconciler) ReconcileTrustBundle(ctx context.Context, ownerKind string, 
 }
 
 // discoverClientCertSecrets lists all secrets across namespaces that are labeled as client certificates
-// with soft-owner labels matching the specified owner.
+// with soft-owner labels matching the specified owner, then verifies each secret has an ECK-managed
+// owner reference. Only secrets created through the ECK association flow carry such a reference,
+// so secrets with labels set externally are excluded.
 func discoverClientCertSecrets(ctx context.Context, c k8s.Client, ownerName, ownerNamespace, ownerKind string) ([]corev1.Secret, error) {
 	log := ulog.FromContext(ctx)
 
@@ -166,13 +173,61 @@ func discoverClientCertSecrets(ctx context.Context, c k8s.Client, ownerName, own
 		return nil, fmt.Errorf("failed to list client certificate secrets: %w", err)
 	}
 
+	// Post-filter: only include secrets that have a verified ECK-managed owner reference.
+	// ECK always sets such an owner reference when creating client cert secrets through the
+	// association flow; secrets without one were not created by the operator.
+	var verified []corev1.Secret
+	for i := range clientCertificateSecrets.Items {
+		secret := &clientCertificateSecrets.Items[i]
+		ok, err := hasVerifiedECKOwnerRef(ctx, c, secret)
+		if err != nil {
+			return nil, fmt.Errorf("verifying owner reference for client certificate secret %s/%s: %w", secret.Namespace, secret.Name, err)
+		}
+		if ok {
+			verified = append(verified, *secret)
+		} else {
+			log.Info("Ignoring client certificate secret: no verified ECK owner reference",
+				"secret_namespace", secret.Namespace, "secret_name", secret.Name)
+		}
+	}
+
 	log.V(1).Info("Discovered client certificate secrets",
 		"owner_name", ownerName,
 		"owner_namespace", ownerNamespace,
 		"owner_kind", ownerKind,
-		"count", len(clientCertificateSecrets.Items))
+		"count", len(verified))
 
-	return clientCertificateSecrets.Items, nil
+	return verified, nil
+}
+
+// hasVerifiedECKOwnerRef returns true if the Secret has at least one owner reference pointing to
+// an ECK custom resource (API group ending in .k8s.elastic.co) that currently exists in the same
+// namespace with the expected UID. Kubernetes enforces that owner references are namespace-scoped,
+// so a cross-namespace attacker cannot plant a valid owner reference to an ECK resource they do
+// not control.
+func hasVerifiedECKOwnerRef(ctx context.Context, c k8s.Client, secret *corev1.Secret) (bool, error) {
+	for _, ref := range secret.OwnerReferences {
+		group := ref.APIVersion
+		if i := strings.Index(group, "/"); i != -1 {
+			group = group[:i]
+		}
+		if !strings.HasSuffix(group, eckAPIGroupSuffix) {
+			continue
+		}
+		owner := &unstructured.Unstructured{}
+		owner.SetAPIVersion(ref.APIVersion)
+		owner.SetKind(ref.Kind)
+		if err := c.Get(ctx, types.NamespacedName{Namespace: secret.Namespace, Name: ref.Name}, owner); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return false, err
+		}
+		if owner.GetUID() == ref.UID {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // buildTrustBundleFromSecrets extracts client certificates from the given secrets and concatenates them.

--- a/pkg/controller/common/certificates/client_cert_reconcile.go
+++ b/pkg/controller/common/certificates/client_cert_reconcile.go
@@ -186,7 +186,7 @@ func discoverClientCertSecrets(ctx context.Context, c k8s.Client, ownerName, own
 		if ok {
 			verified = append(verified, *secret)
 		} else {
-			log.Info("Ignoring client certificate secret: no verified ECK owner reference",
+			log.V(1).Info("Ignoring client certificate secret: no verified ECK owner reference",
 				"secret_namespace", secret.Namespace, "secret_name", secret.Name)
 		}
 	}
@@ -202,16 +202,25 @@ func discoverClientCertSecrets(ctx context.Context, c k8s.Client, ownerName, own
 
 // hasVerifiedECKOwnerRef returns true if the Secret has at least one owner reference pointing to
 // an ECK custom resource (API group ending in .k8s.elastic.co) that currently exists in the same
-// namespace with the expected UID. Kubernetes enforces that owner references are namespace-scoped,
-// so a cross-namespace attacker cannot plant a valid owner reference to an ECK resource they do
-// not control.
+// namespace with the expected UID. All ECK custom resources are namespace-scoped, and Kubernetes
+// prevents a namespace-scoped resource from carrying an owner reference to a resource in a
+// different namespace, so the owner is always co-located with the Secret.
 func hasVerifiedECKOwnerRef(ctx context.Context, c k8s.Client, secret *corev1.Secret) (bool, error) {
+	log := ulog.FromContext(ctx)
 	for _, ref := range secret.OwnerReferences {
 		group := ref.APIVersion
 		if i := strings.Index(group, "/"); i != -1 {
 			group = group[:i]
 		}
 		if !strings.HasSuffix(group, eckAPIGroupSuffix) {
+			continue
+		}
+		// Guard against malformed owner references (missing Kind or Name) that would
+		// cause c.Get to return a non-transient error. Treat them as a non-match.
+		if ref.Kind == "" || ref.Name == "" || ref.APIVersion == "" {
+			log.V(1).Info("Skipping malformed ECK owner reference",
+				"secret_namespace", secret.Namespace, "secret_name", secret.Name,
+				"api_version", ref.APIVersion, "kind", ref.Kind, "name", ref.Name)
 			continue
 		}
 		owner := &unstructured.Unstructured{}

--- a/pkg/controller/common/certificates/client_cert_reconcile.go
+++ b/pkg/controller/common/certificates/client_cert_reconcile.go
@@ -208,16 +208,13 @@ func discoverClientCertSecrets(ctx context.Context, c k8s.Client, ownerName, own
 func hasVerifiedECKOwnerRef(ctx context.Context, c k8s.Client, secret *corev1.Secret) (bool, error) {
 	log := ulog.FromContext(ctx)
 	for _, ref := range secret.OwnerReferences {
-		group := ref.APIVersion
-		if i := strings.Index(group, "/"); i != -1 {
-			group = group[:i]
-		}
+		group, _, _ := strings.Cut(ref.APIVersion, "/")
 		if !strings.HasSuffix(group, eckAPIGroupSuffix) {
 			continue
 		}
 		// Guard against malformed owner references (missing Kind or Name) that would
 		// cause c.Get to return a non-transient error. Treat them as a non-match.
-		if ref.Kind == "" || ref.Name == "" || ref.APIVersion == "" {
+		if ref.Kind == "" || ref.Name == "" {
 			log.V(1).Info("Skipping malformed ECK owner reference",
 				"secret_namespace", secret.Namespace, "secret_name", secret.Name,
 				"api_version", ref.APIVersion, "kind", ref.Kind, "name", ref.Name)

--- a/pkg/controller/common/certificates/client_cert_reconcile.go
+++ b/pkg/controller/common/certificates/client_cert_reconcile.go
@@ -22,7 +22,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -206,23 +206,21 @@ func discoverClientCertSecrets(ctx context.Context, c k8s.Client, ownerName, own
 // prevents a namespace-scoped resource from carrying an owner reference to a resource in a
 // different namespace, so the owner is always co-located with the Secret.
 func hasVerifiedECKOwnerRef(ctx context.Context, c k8s.Client, secret *corev1.Secret) (bool, error) {
-	log := ulog.FromContext(ctx)
 	for _, ref := range secret.OwnerReferences {
 		group, _, _ := strings.Cut(ref.APIVersion, "/")
 		if !strings.HasSuffix(group, eckAPIGroupSuffix) {
 			continue
 		}
-		// Guard against malformed owner references (missing Kind or Name) that would
-		// cause c.Get to return a non-transient error. Treat them as a non-match.
-		if ref.Kind == "" || ref.Name == "" {
-			log.V(1).Info("Skipping malformed ECK owner reference",
-				"secret_namespace", secret.Namespace, "secret_name", secret.Name,
-				"api_version", ref.APIVersion, "kind", ref.Kind, "name", ref.Name)
+		gvk := schema.FromAPIVersionAndKind(ref.APIVersion, ref.Kind)
+		runtimeObj, err := c.Scheme().New(gvk)
+		if err != nil {
+			// GVK not registered in the ECK scheme — not a CR we manage; skip this ref.
 			continue
 		}
-		owner := &unstructured.Unstructured{}
-		owner.SetAPIVersion(ref.APIVersion)
-		owner.SetKind(ref.Kind)
+		owner, ok := runtimeObj.(client.Object)
+		if !ok {
+			continue
+		}
 		if err := c.Get(ctx, types.NamespacedName{Namespace: secret.Namespace, Name: ref.Name}, owner); err != nil {
 			if apierrors.IsNotFound(err) {
 				continue

--- a/pkg/controller/common/certificates/client_cert_reconcile.go
+++ b/pkg/controller/common/certificates/client_cert_reconcile.go
@@ -186,7 +186,7 @@ func discoverClientCertSecrets(ctx context.Context, c k8s.Client, ownerName, own
 		if ok {
 			verified = append(verified, *secret)
 		} else {
-			log.V(1).Info("Ignoring client certificate secret: no verified ECK owner reference",
+			log.Info("Ignoring client certificate secret: no verified ECK owner reference",
 				"secret_namespace", secret.Namespace, "secret_name", secret.Name)
 		}
 	}

--- a/pkg/controller/common/certificates/client_cert_reconcile_test.go
+++ b/pkg/controller/common/certificates/client_cert_reconcile_test.go
@@ -261,11 +261,29 @@ func TestClientCertSecretCleanup(t *testing.T) {
 }
 
 func TestDiscoverClientCertSecrets(t *testing.T) {
-	t.Run("discovers secrets with matching labels", func(t *testing.T) {
+	// kibana1 / kibana2 act as ECK owners in their respective namespaces.
+	kibana1 := &kbv1.Kibana{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "client-ns-1", Name: "my-kibana-1", UID: "uid-kibana-1"},
+	}
+	kibana2 := &kbv1.Kibana{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "client-ns-2", Name: "my-kibana-2", UID: "uid-kibana-2"},
+	}
+
+	eckOwnerRef := func(kb *kbv1.Kibana) metav1.OwnerReference {
+		return metav1.OwnerReference{
+			APIVersion: "kibana.k8s.elastic.co/v1",
+			Kind:       "Kibana",
+			Name:       kb.Name,
+			UID:        kb.UID,
+		}
+	}
+
+	t.Run("discovers secrets with matching labels and verified ECK owner", func(t *testing.T) {
 		secret1 := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "client-ns-1",
-				Name:      "client-1-es-client-cert",
+				Namespace:       "client-ns-1",
+				Name:            "client-1-es-client-cert",
+				OwnerReferences: []metav1.OwnerReference{eckOwnerRef(kibana1)},
 				Labels: map[string]string{
 					labels.ClientCertificateLabelName:  "true",
 					reconciler.SoftOwnerNameLabel:      "my-es",
@@ -277,8 +295,9 @@ func TestDiscoverClientCertSecrets(t *testing.T) {
 		}
 		secret2 := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "client-ns-2",
-				Name:      "client-2-es-client-cert",
+				Namespace:       "client-ns-2",
+				Name:            "client-2-es-client-cert",
+				OwnerReferences: []metav1.OwnerReference{eckOwnerRef(kibana2)},
 				Labels: map[string]string{
 					labels.ClientCertificateLabelName:  "true",
 					reconciler.SoftOwnerNameLabel:      "my-es",
@@ -288,6 +307,7 @@ func TestDiscoverClientCertSecrets(t *testing.T) {
 			},
 			Data: map[string][]byte{CertFileName: []byte("cert-2")},
 		}
+		// Belongs to a different ES — should not appear in results.
 		secretOther := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "other-ns",
@@ -302,10 +322,93 @@ func TestDiscoverClientCertSecrets(t *testing.T) {
 			Data: map[string][]byte{CertFileName: []byte("other-cert")},
 		}
 
-		c := k8s.NewFakeClient(secret1, secret2, secretOther)
+		c := k8s.NewFakeClient(kibana1, kibana2, secret1, secret2, secretOther)
 		secrets, err := discoverClientCertSecrets(context.Background(), c, "my-es", "es-ns", esv1.Kind)
 		require.NoError(t, err)
 		require.Len(t, secrets, 2)
+	})
+
+	t.Run("excludes secret with no owner reference", func(t *testing.T) {
+		// Secret has correct soft-owner labels but was not created through the ECK
+		// association flow and therefore carries no owner reference.
+		unowned := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "other-ns",
+				Name:      "unowned-client-cert",
+				Labels: map[string]string{
+					labels.ClientCertificateLabelName:  "true",
+					reconciler.SoftOwnerNameLabel:      "my-es",
+					reconciler.SoftOwnerNamespaceLabel: "es-ns",
+					reconciler.SoftOwnerKindLabel:      esv1.Kind,
+				},
+			},
+			Data: map[string][]byte{CertFileName: []byte("cert-data")},
+		}
+
+		c := k8s.NewFakeClient(unowned)
+		secrets, err := discoverClientCertSecrets(context.Background(), c, "my-es", "es-ns", esv1.Kind)
+		require.NoError(t, err)
+		require.Empty(t, secrets, "secret without an ECK owner reference must not be included")
+	})
+
+	t.Run("excludes secret with non-ECK owner reference", func(t *testing.T) {
+		// Secret is owned by a core Kubernetes resource rather than an ECK custom resource.
+		nonECKOwned := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "other-ns",
+				Name:      "pod-owned-client-cert",
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "v1",
+					Kind:       "Pod",
+					Name:       "some-pod",
+					UID:        "uid-pod",
+				}},
+				Labels: map[string]string{
+					labels.ClientCertificateLabelName:  "true",
+					reconciler.SoftOwnerNameLabel:      "my-es",
+					reconciler.SoftOwnerNamespaceLabel: "es-ns",
+					reconciler.SoftOwnerKindLabel:      esv1.Kind,
+				},
+			},
+			Data: map[string][]byte{CertFileName: []byte("cert-data")},
+		}
+
+		c := k8s.NewFakeClient(nonECKOwned)
+		secrets, err := discoverClientCertSecrets(context.Background(), c, "my-es", "es-ns", esv1.Kind)
+		require.NoError(t, err)
+		require.Empty(t, secrets, "secret owned by a non-ECK resource must not be included")
+	})
+
+	t.Run("excludes secret with stale ECK owner reference", func(t *testing.T) {
+		// Owner reference points to an existing Kibana but the UID does not match,
+		// as would happen with a stale reference after a delete/recreate cycle.
+		kb := &kbv1.Kibana{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "other-ns", Name: "my-kibana", UID: "current-uid"},
+		}
+		staleRef := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "other-ns",
+				Name:      "stale-ref-client-cert",
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "kibana.k8s.elastic.co/v1",
+					Kind:       "Kibana",
+					Name:       kb.Name,
+					UID:        "old-uid",
+				}},
+				Labels: map[string]string{
+					labels.ClientCertificateLabelName:  "true",
+					reconciler.SoftOwnerNameLabel:      "my-es",
+					reconciler.SoftOwnerNamespaceLabel: "es-ns",
+					reconciler.SoftOwnerKindLabel:      esv1.Kind,
+				},
+			},
+			Data: map[string][]byte{CertFileName: []byte("cert-data")},
+		}
+
+		c := k8s.NewFakeClient(kb, staleRef)
+		secrets, err := discoverClientCertSecrets(context.Background(), c, "my-es", "es-ns", esv1.Kind)
+		require.NoError(t, err)
+		require.Empty(t, secrets, "secret with a mismatched owner UID must not be included")
 	})
 
 	t.Run("returns empty list when no matching secrets", func(t *testing.T) {


### PR DESCRIPTION
## Summary

`discoverClientCertSecrets` relied solely on label selectors to identify client certificate secrets, with no verification that the discovered secrets were actually created through the ECK association flow.

- Add a post-filter that checks each discovered secret has a Kubernetes owner reference pointing to an existing ECK custom resource (API group `*.k8s.elastic.co`) with a matching UID
- ECK always sets such owner references when creating client cert secrets through the association reconciler
- Kubernetes namespace-scoping of owner references ensures the owner lives in the same namespace as the secret; the UID check guards against stale references after a delete/recreate cycle
- Secrets whose labels were set externally (e.g. manually copied secrets) are excluded from the trust bundle, consistent with the intent of the association flow

## Test plan

- [ ] Unit tests updated: existing discovery test extended with owner objects in the fake client; three new cases cover secrets with no owner reference, a non-ECK owner, and a stale UID
- [ ] `go test ./pkg/controller/common/certificates/...` passes
- [ ] e2e: verify trust bundle is correctly built for Kibana→ES, APM→ES, Agent→ES, and AutoOps associations
