### PR TITLE
e2e: use emptyDir for Fleet Server state in mTLS transition test

### DIFF
--- a/test/e2e/agent/client_auth_test.go
+++ b/test/e2e/agent/client_auth_test.go
@@ -409,7 +409,13 @@ func TestClientAuthRequired_FleetServerToAgent(t *testing.T) {
 		WithKibanaRef(kbBuilder.Ref()).
 		WithFleetServerRef(fleetServerBuilder.Ref())
 
-	fleetServerBuilder = agent.ApplyYamls(t, fleetServerBuilder, "", E2EAgentFleetModePodTemplate)
+	// Use emptyDir for Fleet Server state to prevent stale fleet.enc from persisting across
+	// rolling updates on the same node. When mTLS is disabled the trust-bundle volume is removed,
+	// but the hostPath-backed fleet.enc still references the (now unmounted) CA path, causing
+	// Fleet Server to crash on startup. Until fixed upstream, use emptyDir as a workaround.
+	// See: https://github.com/elastic/cloud-on-k8s/issues/9443
+	fleetServerBuilder = agent.ApplyYamls(t, fleetServerBuilder, "", E2EAgentFleetModePodTemplate).
+		WithEmptyDirDataVolume()
 	agentBuilder = agent.ApplyYamls(t, agentBuilder, "", E2EAgentFleetModePodTemplate)
 
 	// Wrap the ES builder with license setup.

--- a/test/e2e/test/agent/builder.go
+++ b/test/e2e/test/agent/builder.go
@@ -455,6 +455,16 @@ func (b Builder) WithClientAuthenticationRequired() Builder {
 	return b
 }
 
+func (b Builder) WithEmptyDirDataVolume() Builder {
+	b.PodTemplate.Spec.Volumes = append(b.PodTemplate.Spec.Volumes, corev1.Volume{
+		Name: agent.DataVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	})
+	return b
+}
+
 func (b Builder) WithKibanaRef(ref commonv1.ObjectSelector) Builder {
 	b.Agent.Spec.KibanaRef = ref
 


### PR DESCRIPTION
## Summary

`TestClientAuthRequired_FleetServerToAgent` was failing intermittently [in CI](https://buildkite.com/elastic/cloud-on-k8s-operator-nightly/builds/1328#019f3c73-d1c5-44af-9560-d160ab340ee0) with:

```
unable to upgrade connection: container not found ("agent")
```

The root cause is an elastic-agent bug: when Fleet Server transitions from mTLS-enabled to mTLS-disabled, ECK creates a new ReplicaSet (rolling update). If the new pod lands on the same node as the old one, it inherits the hostPath
state directory containing a stale `fleet.enc` that still references the (now unmounted) trust-bundle CA path. Fleet Server crashes immediately on startup:

Relates https://github.com/elastic/cloud-on-k8s/issues/9443

```
failed to read from disk store: open .../client-trust-bundle.crt: no such file or directory
```

This is a partial gap in the upstream fix from elastic/elastic-agent#14408, which covered `ELASTIC_AGENT_CERT`/`ELASTIC_AGENT_CERT_KEY` but not `FLEET_CA`→ `fleet.ssl.certificate_authorities`. Tracked upstream at https://github.com/elastic/elastic-agent/issues/15408.

## Changes

- **`test/e2e/test/agent/builder.go`**: add `WithEmptyDirDataVolume()` builder method that pre-populates the `agent-data` volume as an `emptyDir`. Because `PodTemplateBuilder.WithVolumes` skips volumes already present in the
  template, this prevents the controller's hostPath default from being added. Each pod gets a fresh, empty state directory, eliminating the stale `fleet.enc` problem.

- **`test/e2e/agent/client_auth_test.go`**: apply `WithEmptyDirDataVolume()` to the Fleet Server builder in `TestClientAuthRequired_FleetServerToAgent`.