### PR TITLE
Increase the es nodes till of kibana_epr sample

### DIFF
--- a/config/samples/kibana/kibana_epr.yaml
+++ b/config/samples/kibana/kibana_epr.yaml
@@ -6,7 +6,7 @@ spec:
   version: 9.4.3
   nodeSets:
   - name: default
-    count: 1
+    count: 2
     config:
       node.store.allow_mmap: false
 ---


### PR DESCRIPTION
Till this is fixed: https://github.com/elastic/kibana/issues/276861

Let's scale the ES nodes to avoid the e2e test `TestSamples/kibana_epr` from failing. 