### PR TITLE
Relax custom ca secret parsing to support cert-manager secrets

### DIFF
--- a/pkg/controller/common/certificates/ca_secret.go
+++ b/pkg/controller/common/certificates/ca_secret.go
@@ -18,6 +18,9 @@ import (
 // ParseCustomCASecret checks that mandatory fields are present and returns a CA struct.
 // It does not check that the public key matches the private key.
 // Legacy tls.* keys are still supported while the expected default keys are ca.crt and ca.key.
+// A Secret may also contain ca.crt alongside tls.crt/tls.key without ca.key, as produced by a
+// cert-manager Certificate with isCA: true; in that case the tls.* pair is used unambiguously.
+// It's only a conflict when both complete key pairs (tls.crt+tls.key and ca.crt+ca.key) are present.
 func ParseCustomCASecret(s corev1.Secret) (*CA, error) {
 	keyFileName := CAKeyFileName
 	crtFileName := CAFileName
@@ -26,7 +29,7 @@ func ParseCustomCASecret(s corev1.Secret) (*CA, error) {
 	_, legacyCrtExists := s.Data[CertFileName]
 	_, keyExists := s.Data[keyFileName]
 	_, crtExists := s.Data[crtFileName]
-	if (legacyKeyExists || legacyCrtExists) && (keyExists || crtExists) {
+	if (legacyKeyExists && legacyCrtExists) && (keyExists && crtExists) {
 		return nil, fmt.Errorf("both tls.* keys and ca.* keys exist in secret %s/%s, this is likely a configuration error", s.Namespace, s.Name)
 	}
 	if legacyKeyExists && legacyCrtExists {

--- a/pkg/controller/common/certificates/ca_secret_test.go
+++ b/pkg/controller/common/certificates/ca_secret_test.go
@@ -17,6 +17,7 @@ import (
 func TestParseCustomCASecret(t *testing.T) {
 	ca := loadFileBytes("ca.crt")
 	key := loadFileBytes("tls.key")
+	corruptedCert := loadFileBytes("corrupted.crt")
 	corruptedKey := loadFileBytes("corrupted.key")
 	encryptedKey := loadFileBytes("encrypted.key")
 
@@ -81,6 +82,28 @@ func TestParseCustomCASecret(t *testing.T) {
 				},
 			},
 			wantErr: true,
+		},
+		{
+			name: "cert-manager isCA Certificate shape: tls.crt/tls.key alongside corrupted ca.crt, no ca.key",
+			s: corev1.Secret{
+				Data: map[string][]byte{
+					certFileName: ca,
+					keyFileName:  key,
+					caFileName:   corruptedCert,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "modern ca.crt/ca.key alongside a stray corrupted tls.crt, no tls.key",
+			s: corev1.Secret{
+				Data: map[string][]byte{
+					caFileName:    ca,
+					caKeyFileName: key,
+					certFileName:  corruptedCert,
+				},
+			},
+			wantErr: false,
 		},
 		{
 			name: "Empty certificate",


### PR DESCRIPTION
## Problem

`ParseCustomCASecret` (`pkg/controller/common/certificates/ca_secret.go`) rejects a transport CA Secret if it contains any overlap between the legacy `tls.*` keys and the modern `ca.*` keys. A cert-manager `Certificate` with `isCA: true` always emits `tls.crt` + `tls.key` + `ca.crt` (no `ca.key`), so this check makes it impossible to point ECK's transport CA directly at a cert-manager-issued Secret.

Fixes #8617

## Change

Narrow the conflict check so it only fires when both complete key pairs are present (`tls.crt`+`tls.key` *and* `ca.crt`+`ca.key`), instead of firing on any partial overlap. This lets the existing `tls.*`/`ca.*` auto-detection resolve the cert-manager shape unambiguously, with no new API surface.

```go
// before
if (legacyKeyExists || legacyCrtExists) && (keyExists || crtExists) {

// after
if (legacyKeyExists && legacyCrtExists) && (keyExists && crtExists) {
```

## Tests

Added to `TestParseCustomCASecret`: the cert-manager shape (`tls.crt`+`tls.key` valid, `ca.crt` corrupted, no `ca.key`) succeeds, proving `tls.*` is selected and `ca.crt` is ignored; and the symmetric case (`ca.crt`+`ca.key` valid, stray corrupted `tls.crt`, no `tls.key`) succeeds, proving `ca.*` is selected and the stray `tls.crt` is ignored. Existing conflict/error cases are unchanged and still pass.
