### PR TITLE
e2e: Tolerate transient RED health in TestNonMasterFirstUpgradeComplexTopology

### DIFF
--- a/test/e2e/es/non_master_first_upgrade_test.go
+++ b/test/e2e/es/non_master_first_upgrade_test.go
@@ -92,7 +92,11 @@ func TestNonMasterFirstUpgradeComplexTopology(t *testing.T) {
 		WithVersion(srcVersion).
 		WithESMasterNodes(3, elasticsearch.DefaultResources).
 		WithESDataNodes(2, elasticsearch.DefaultResources).
-		WithESCoordinatingNodes(1, elasticsearch.DefaultResources)
+		WithESCoordinatingNodes(1, elasticsearch.DefaultResources).
+		// Tolerate mutation check failures as the upgrade can briefly turn the cluster RED
+		// if a node shuts down before a newly created replica completes its initialization.
+		// See https://github.com/elastic/cloud-on-k8s/issues/8267.
+		TolerateMutationChecksFailures()
 
 	mutated := initial.WithVersion(dstVersion).WithMutatedFrom(&initial)
 


### PR DESCRIPTION
## Summary

`TestNonMasterFirstUpgradeComplexTopology` failed in a nightly CI run ([build 1332](https://buildkite.com/elastic/cloud-on-k8s-operator-nightly/builds/1332#019f5030-3620-4f05-9bc8-d181e94a1ba8)) with `ContinuousHealthChecks failures count (11) is above the tolerance (0): 11 x [cluster health red]`. The root cause is the long-standing, known race tracked in [#8267](https://github.com/elastic/cloud-on-k8s/issues/8267) and upstream in [elastic/elasticsearch#87836](https://github.com/elastic/elasticsearch/issues/87836): 

Elasticsearch's `RESTART`-type node shutdown reports `COMPLETE` without waiting for a newly created shard's replica to finish initializing. In this run, the operator issued the pod-delete for `es-data-1` at `05:07:28.815Z`, and the `.ds-.logs-deprecation.elasticsearch-default-2026.07.11-000001` system index was auto-created 195ms later at `05:07:29.010Z` — before Elasticsearch's fault detection formally evicted `es-data-1` from the cluster state at `05:07:29.707Z`. Its primary shard was almost certainly routed to the already-dying `es-data-1` node, with no time for a replica to start before the node was declared gone, leaving that shard unassigned (RED) until `es-data-1` rejoined the cluster around `05:08:00Z`.

Several other mutation tests in this suite (`TestMutationResizeMemoryUp`, `TestMutationResizeMemoryDown`, `TestClientAuth`, restart-annotation and stack-monitoring tests) already opt out of the zero-tolerance health check via `.TolerateMutationChecksFailures()` for exactly this reason. 

## Change

Add `.TolerateMutationChecksFailures()` to the builder in `test/e2e/es/non_master_first_upgrade_test.go`, matching the existing pattern and referencing #8267.

## Investigation notes

Analyzed the `eck-diagnostics` bundle from the failing run end-to-end. Confirmed via the operator's own health observer (querying a healthy, untouched data node directly) that the cluster genuinely reported `red`, independent of the e2e test's own client, which rules out a client-side artifact. Confirmed the RED window started immediately after the first non-master pod (`es-data-1`) was deleted for its rolling restart, and recovered on its own once that pod rejoined — consistent with the known replica-not-yet-initialized race, not with an actual bug in the non-master-first ordering or `one_master_at_a_time` logic (both worked correctly; master rotations later in the same run showed no health degradation). 
