### PR TITLE
Validate secure settings sources against active StackConfigPolicies

### DIFF
--- a/pkg/controller/apmserver/deployment.go
+++ b/pkg/controller/apmserver/deployment.go
@@ -50,6 +50,7 @@ func (r *ReconcileApmServer) reconcileApmServerDeployment(
 		as,
 		Namer,
 		meta,
+		r.OperatorNamespace,
 		initContainerParameters,
 	)
 	if err != nil {

--- a/pkg/controller/beat/common/pod.go
+++ b/pkg/controller/beat/common/pod.go
@@ -93,6 +93,7 @@ func buildPodTemplate(
 		&params.Beat,
 		namer,
 		meta,
+		"", // operator namespace is not really needed for beats keystore resources
 		initContainerParameters(params.Beat.Spec.Type),
 	)
 	if err != nil {

--- a/pkg/controller/common/keystore/resources.go
+++ b/pkg/controller/common/keystore/resources.go
@@ -66,11 +66,12 @@ func ReconcileResources(
 	hasKeystore HasKeystore,
 	namer name.Namer,
 	meta metadata.Metadata,
+	operatorNamespace string,
 	initContainerParams InitContainerParameters,
 	additionalSources ...commonv1.NamespacedSecretSource,
 ) (*Resources, error) {
 	// setup a volume from the user-provided secure settings secret
-	secretVolume, hash, err := secureSettingsVolume(ctx, r, hasKeystore, meta, namer, additionalSources...)
+	secretVolume, hash, err := secureSettingsVolume(ctx, r, hasKeystore, meta, namer, operatorNamespace, additionalSources...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/common/keystore/resources_test.go
+++ b/pkg/controller/common/keystore/resources_test.go
@@ -261,7 +261,7 @@ echo "Keystore initialization successful."
 				Watches:      watches2.NewDynamicWatches(),
 				FakeRecorder: toolsevents.NewFakeRecorder(1000),
 			}
-			resources, err := ReconcileResources(context.Background(), testDriver, &tt.kb, kbNamer, metadata.Metadata{}, tt.initContainerParameters)
+			resources, err := ReconcileResources(context.Background(), testDriver, &tt.kb, kbNamer, metadata.Metadata{}, "", tt.initContainerParameters)
 			if tt.wantErrMsg != "" {
 				require.ErrorContains(t, err, tt.wantErrMsg)
 				return

--- a/pkg/controller/common/keystore/user_secret.go
+++ b/pkg/controller/common/keystore/user_secret.go
@@ -46,6 +46,7 @@ func secureSettingsVolume(
 	hasKeystore HasKeystore,
 	meta metadata.Metadata,
 	namer name.Namer,
+	operatorNamespace string,
 	additionalSources ...commonv1.NamespacedSecretSource,
 ) (*volume.SecretVolume, string, error) {
 	// setup (or remove) watches for the user-provided secret to reconcile on any change
@@ -56,7 +57,7 @@ func secureSettingsVolume(
 	// Additional sources, introduced to load remote cluster keys.
 	secretSources = append(secretSources, additionalSources...)
 	// user-provided Secrets referenced in a StackConfigPolicy that configures the resource
-	policySecretSources, err := stackconfigpolicy.GetSecureSettingsSecretSourcesForResources(ctx, r.K8sClient(), hasKeystore, hasKeystore.GetObjectKind().GroupVersionKind().Kind)
+	policySecretSources, err := stackconfigpolicy.GetSecureSettingsSecretSourcesForResources(ctx, r.K8sClient(), hasKeystore, hasKeystore.GetObjectKind().GroupVersionKind().Kind, operatorNamespace)
 	if err != nil {
 		return nil, "", pkgerrors.Wrap(err, "fail to get secure settings secret sources")
 	}

--- a/pkg/controller/common/keystore/user_secret_test.go
+++ b/pkg/controller/common/keystore/user_secret_test.go
@@ -104,7 +104,7 @@ func Test_secureSettingsVolume(t *testing.T) {
 				Watches:      tt.w,
 				FakeRecorder: toolsevents.NewFakeRecorder(1000),
 			}
-			vol, hash, err := secureSettingsVolume(context.Background(), testDriver, &tt.kb, metadata.Metadata{}, kbNamer)
+			vol, hash, err := secureSettingsVolume(context.Background(), testDriver, &tt.kb, metadata.Metadata{}, kbNamer, "")
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantVolume, vol)
 			assert.Equal(t, tt.wantHash, hash)

--- a/pkg/controller/elasticsearch/driver/shared/cluster_secrets.go
+++ b/pkg/controller/elasticsearch/driver/shared/cluster_secrets.go
@@ -28,6 +28,7 @@ func BuildClusterSecrets(
 	recorder toolsevents.EventRecorder,
 	dynamicWatches watches.DynamicWatches,
 	es esv1.Elasticsearch,
+	operatorNamespace string,
 ) (*commonv1.Config, error) {
 	secretSources := keystore.WatchedSecretNames(&es)
 
@@ -37,7 +38,7 @@ func BuildClusterSecrets(
 	}
 	secretSources = append(secretSources, remoteClusterAPIKeys...)
 
-	policySecretSources, err := stackconfigpolicy.GetSecureSettingsSecretSourcesForResources(ctx, c, &es, "Elasticsearch")
+	policySecretSources, err := stackconfigpolicy.GetSecureSettingsSecretSourcesForResources(ctx, c, &es, "Elasticsearch", operatorNamespace)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/elasticsearch/driver/shared/cluster_secrets.go
+++ b/pkg/controller/elasticsearch/driver/shared/cluster_secrets.go
@@ -38,7 +38,7 @@ func BuildClusterSecrets(
 	}
 	secretSources = append(secretSources, remoteClusterAPIKeys...)
 
-	policySecretSources, err := stackconfigpolicy.GetSecureSettingsSecretSourcesForResources(ctx, c, &es, "Elasticsearch", operatorNamespace)
+	policySecretSources, err := stackconfigpolicy.GetSecureSettingsSecretSourcesForResources(ctx, c, &es, esv1.Kind, operatorNamespace)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/elasticsearch/driver/shared/cluster_secrets_test.go
+++ b/pkg/controller/elasticsearch/driver/shared/cluster_secrets_test.go
@@ -86,7 +86,7 @@ func TestBuildClusterSecrets(t *testing.T) {
 			dw := watches.NewDynamicWatches()
 			recorder := &toolsevents.FakeRecorder{}
 
-			result, err := BuildClusterSecrets(context.Background(), c, recorder, dw, es)
+			result, err := BuildClusterSecrets(context.Background(), c, recorder, dw, es, "")
 			require.NoError(t, err)
 			require.NotNil(t, result)
 

--- a/pkg/controller/elasticsearch/driver/stateful/keystore.go
+++ b/pkg/controller/elasticsearch/driver/stateful/keystore.go
@@ -55,6 +55,7 @@ func (d *Driver) reconcileKeystore(ctx context.Context, meta metadata.Metadata) 
 		&d.ES,
 		esv1.ESNamer,
 		meta,
+		d.OperatorParameters.OperatorNamespace,
 		keystoreParams,
 		remoteClusterAPIKeys...,
 	)
@@ -106,7 +107,7 @@ func reconcileManagedKeystorePasswordSecret(
 // For all other cases the standard keystore init container path is used.
 func (d *Driver) reconcileSecureSettings(ctx context.Context, meta metadata.Metadata) (*keystore.Resources, error) {
 	if d.Version.GTE(esversion.FileBasedSecureSettingsMinVersion) && d.ES.HasFileBasedSecureSettingsAnnotation() {
-		clusterSecrets, err := shared.BuildClusterSecrets(ctx, d.Client, d.Recorder(), d.DynamicWatches(), d.ES)
+		clusterSecrets, err := shared.BuildClusterSecrets(ctx, d.Client, d.Recorder(), d.DynamicWatches(), d.ES, d.OperatorParameters.OperatorNamespace)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/elasticsearch/filesettings/secret.go
+++ b/pkg/controller/elasticsearch/filesettings/secret.go
@@ -67,7 +67,8 @@ func getSecureSettings(settingsSecret corev1.Secret) ([]commonv1.NamespacedSecre
 	return secretSources, nil
 }
 
-// GetSecureSettingsSecretSources gets SecureSettings Secret sources for a given Elastic resource.
+// GetSecureSettingsSecretSources returns the raw unvalidated secure settings sources stored in the annotation
+// of the ES file-settings secret.
 func GetSecureSettingsSecretSources(ctx context.Context, c k8s.Client, resource metav1.Object) ([]commonv1.NamespacedSecretSource, error) {
 	var secret corev1.Secret
 	err := c.Get(ctx, types.NamespacedName{Namespace: resource.GetNamespace(), Name: esv1.FileSettingsSecretName(resource.GetName())}, &secret)

--- a/pkg/controller/kibana/driver.go
+++ b/pkg/controller/kibana/driver.go
@@ -191,7 +191,7 @@ func (d *driver) Reconcile(
 	span, _ := apm.StartSpan(ctx, "reconcile_deployment", tracing.SpanTypeApp)
 	defer span.End()
 
-	deploymentParams, err := d.deploymentParams(ctx, kb, kibanaPolicyCfg.PodAnnotations, basePath, params.SetDefaultSecurityContext, meta)
+	deploymentParams, err := d.deploymentParams(ctx, kb, kibanaPolicyCfg.PodAnnotations, basePath, params.SetDefaultSecurityContext, params.OperatorNamespace, meta)
 	if err != nil {
 		return results.WithError(err)
 	}
@@ -238,7 +238,7 @@ func (d *driver) getStrategyType(kb *kbv1.Kibana) (appsv1.DeploymentStrategyType
 	return appsv1.RollingUpdateDeploymentStrategyType, nil
 }
 
-func (d *driver) deploymentParams(ctx context.Context, kb *kbv1.Kibana, policyAnnotations map[string]string, basePath string, setDefaultSecurityContext bool, meta metadata.Metadata) (deployment.Params, error) {
+func (d *driver) deploymentParams(ctx context.Context, kb *kbv1.Kibana, policyAnnotations map[string]string, basePath string, setDefaultSecurityContext bool, operatorNamespace string, meta metadata.Metadata) (deployment.Params, error) {
 	initContainersParameters, err := initcontainer.NewInitContainersParameters(kb)
 	if err != nil {
 		return deployment.Params{}, err
@@ -250,6 +250,7 @@ func (d *driver) deploymentParams(ctx context.Context, kb *kbv1.Kibana, policyAn
 		kb,
 		kbv1.KBNamer,
 		meta,
+		operatorNamespace,
 		initContainersParameters,
 	)
 	if err != nil {

--- a/pkg/controller/kibana/driver_test.go
+++ b/pkg/controller/kibana/driver_test.go
@@ -385,7 +385,7 @@ func TestDriverDeploymentParams(t *testing.T) {
 			d, err := newDriver(client, w, toolsevents.NewFakeRecorder(100), kb, corev1.IPv4Protocol)
 			require.NoError(t, err)
 
-			got, err := d.deploymentParams(context.Background(), kb, tt.args.policyAnnotations, "", tt.args.setDefaultSecurityContextFlag, metadata.Propagate(kb, metadata.Metadata{Labels: kb.GetIdentityLabels()}))
+			got, err := d.deploymentParams(context.Background(), kb, tt.args.policyAnnotations, "", tt.args.setDefaultSecurityContextFlag, "", metadata.Propagate(kb, metadata.Metadata{Labels: kb.GetIdentityLabels()}))
 			if tt.wantErr {
 				require.Error(t, err)
 				return

--- a/pkg/controller/logstash/keystore.go
+++ b/pkg/controller/logstash/keystore.go
@@ -90,6 +90,7 @@ func reconcileKeystore(params Params, configHash hash.Hash) (*keystore.Resources
 		&params.Logstash,
 		logstashv1alpha1.Namer,
 		params.Meta,
+		params.OperatorParams.OperatorNamespace,
 		initContainersParameters,
 	); err != nil {
 		return nil, err

--- a/pkg/controller/stackconfigpolicy/controller_test.go
+++ b/pkg/controller/stackconfigpolicy/controller_test.go
@@ -255,7 +255,7 @@ func TestReconcileStackConfigPolicy_Reconcile(t *testing.T) {
 	}}
 
 	kibanaConfigSecretFixture := MkKibanaConfigSecret("ns", policyFixture.Name, policyFixture.Namespace, "3077592849")
-	addSecureSettingsAnnotationToSecret(kibanaConfigSecretFixture, "ns")
+	addSecureSettingsAnnotationToSecret(kibanaConfigSecretFixture, "ns", "shared-secret")
 
 	type args struct {
 		client           k8s.Client

--- a/pkg/controller/stackconfigpolicy/secure_setings.go
+++ b/pkg/controller/stackconfigpolicy/secure_setings.go
@@ -98,7 +98,9 @@ func filterByAllowedSources(ctx context.Context, kubeClient k8s.Client, resource
 	// govern this resource (DoesPolicyMatchObject rejects all others), so restrict
 	// the list to those two namespaces instead of fetching cluster-wide.
 	namespacesToCheck := []string{resource.GetNamespace()}
-	if operatorNamespace != "" && operatorNamespace != resource.GetNamespace() {
+	if operatorNamespace == "" {
+		ulog.FromContext(ctx).Info("StackConfigPolicies in the operator namespace will not be evaluated for secure settings sources because the operator namespace is empty")
+	} else if operatorNamespace != resource.GetNamespace() {
 		namespacesToCheck = append(namespacesToCheck, operatorNamespace)
 	}
 

--- a/pkg/controller/stackconfigpolicy/secure_setings.go
+++ b/pkg/controller/stackconfigpolicy/secure_setings.go
@@ -12,23 +12,34 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/common/v1"
+	policyv1alpha1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/stackconfigpolicy/v1alpha1"
 	commonannotation "github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/annotation"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/filesettings"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
+	ulog "github.com/elastic/cloud-on-k8s/v3/pkg/utils/log"
 )
 
-func GetSecureSettingsSecretSourcesForResources(ctx context.Context, kubeClient k8s.Client, resource metav1.Object, resourceKind string) ([]commonv1.NamespacedSecretSource, error) {
+// GetSecureSettingsSecretSourcesForResources returns validated secure settings sources for the
+// given resource. Each returned source is cross-checked against the exact set declared by the
+// active StackConfigPolicies that govern this resource.
+func GetSecureSettingsSecretSourcesForResources(ctx context.Context, kubeClient k8s.Client, resource metav1.Object, resourceKind string, operatorNamespace string) ([]commonv1.NamespacedSecretSource, error) {
+	var sources []commonv1.NamespacedSecretSource
+	var err error
 	switch resourceKind {
 	case "Elasticsearch":
-		return filesettings.GetSecureSettingsSecretSources(ctx, kubeClient, resource)
+		sources, err = filesettings.GetSecureSettingsSecretSources(ctx, kubeClient, resource)
 	case "Kibana":
-		return getKibanaSecureSettingsSecretSources(ctx, kubeClient, resource)
+		sources, err = getKibanaSecureSettingsSecretSources(ctx, kubeClient, resource)
 	default:
-		// Just return empty since there are no other resource type monitored by the stack config policy
 		return []commonv1.NamespacedSecretSource{}, nil
 	}
+	if err != nil {
+		return nil, err
+	}
+	return filterByAllowedSources(ctx, kubeClient, resource, operatorNamespace, resourceKind, sources)
 }
 
 func getKibanaSecureSettingsSecretSources(ctx context.Context, kubeClient k8s.Client, resource metav1.Object) ([]commonv1.NamespacedSecretSource, error) {
@@ -48,6 +59,78 @@ func getKibanaSecureSettingsSecretSources(ctx context.Context, kubeClient k8s.Cl
 	if err := json.Unmarshal([]byte(rawString), &secretSources); err != nil {
 		return nil, err
 	}
-
 	return secretSources, nil
+}
+
+// filterByAllowedSources retains only those sources whose {namespace, secretName} pair is
+// declared by an active StackConfigPolicy governing this resource. Sources not present in
+// any governing SCP are dropped.
+func filterByAllowedSources(ctx context.Context, kubeClient k8s.Client, resource metav1.Object, operatorNamespace string, resourceKind string, sources []commonv1.NamespacedSecretSource) ([]commonv1.NamespacedSecretSource, error) {
+	if len(sources) == 0 {
+		return sources, nil
+	}
+
+	// Only SCPs in the resource's own namespace or the operator namespace can ever
+	// govern this resource (DoesPolicyMatchObject rejects all others), so restrict
+	// the list to those two namespaces instead of fetching cluster-wide.
+	namespacesToCheck := []string{resource.GetNamespace()}
+	if operatorNamespace != "" && operatorNamespace != resource.GetNamespace() {
+		namespacesToCheck = append(namespacesToCheck, operatorNamespace)
+	}
+
+	var policies []policyv1alpha1.StackConfigPolicy
+	for _, ns := range namespacesToCheck {
+		var policyList policyv1alpha1.StackConfigPolicyList
+		if err := kubeClient.List(ctx, &policyList, client.InNamespace(ns)); err != nil {
+			return nil, err
+		}
+		policies = append(policies, policyList.Items...)
+	}
+
+	// Build a set of {namespace, secretName} pairs declared by governing SCPs.
+	type sourceKey struct{ namespace, secretName string }
+	allowed := map[sourceKey]struct{}{}
+	for i := range policies {
+		policy := &policies[i]
+		matches, err := DoesPolicyMatchObject(policy, resource, operatorNamespace)
+		if err != nil {
+			return nil, err
+		}
+		if !matches {
+			continue
+		}
+		var policySources []commonv1.NamespacedSecretSource
+		switch resourceKind {
+		case "Kibana":
+			policySources = policy.GetKibanaNamespacedSecureSettings()
+		case "Elasticsearch":
+			policySources = policy.GetElasticsearchNamespacedSecureSettings()
+			// The deprecated top-level Spec.SecureSettings also applies to Elasticsearch and
+			// is still written to the annotation by the SCP controller. Include it so that
+			// sources from this field are not falsely rejected while the field is still supported.
+			for _, s := range policy.Spec.SecureSettings { //nolint:staticcheck
+				policySources = append(policySources, commonv1.NamespacedSecretSource{Namespace: policy.Namespace, SecretName: s.SecretName})
+			}
+		}
+		for _, s := range policySources {
+			allowed[sourceKey{s.Namespace, s.SecretName}] = struct{}{}
+		}
+	}
+
+	log := ulog.FromContext(ctx)
+	var validated []commonv1.NamespacedSecretSource
+	for _, src := range sources {
+		if _, ok := allowed[sourceKey{src.Namespace, src.SecretName}]; ok {
+			validated = append(validated, src)
+		} else {
+			log.Info("Ignoring secure settings source: not declared by any active StackConfigPolicy",
+				"rejected_namespace", src.Namespace,
+				"rejected_name", src.SecretName,
+			)
+		}
+	}
+	if validated == nil {
+		return []commonv1.NamespacedSecretSource{}, nil
+	}
+	return validated, nil
 }

--- a/pkg/controller/stackconfigpolicy/secure_setings.go
+++ b/pkg/controller/stackconfigpolicy/secure_setings.go
@@ -15,6 +15,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/common/v1"
+	esv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/elasticsearch/v1"
+	kbv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/kibana/v1"
 	policyv1alpha1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/stackconfigpolicy/v1alpha1"
 	commonannotation "github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/annotation"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/filesettings"
@@ -29,9 +31,9 @@ func GetSecureSettingsSecretSourcesForResources(ctx context.Context, kubeClient 
 	var sources []commonv1.NamespacedSecretSource
 	var err error
 	switch resourceKind {
-	case "Elasticsearch":
+	case esv1.Kind:
 		sources, err = filesettings.GetSecureSettingsSecretSources(ctx, kubeClient, resource)
-	case "Kibana":
+	case kbv1.Kind:
 		sources, err = getKibanaSecureSettingsSecretSources(ctx, kubeClient, resource)
 	default:
 		return []commonv1.NamespacedSecretSource{}, nil
@@ -62,6 +64,28 @@ func getKibanaSecureSettingsSecretSources(ctx context.Context, kubeClient k8s.Cl
 	return secretSources, nil
 }
 
+// allowedSourceKeys returns the {namespace, secretName} set declared by policy for the given resource kind.
+func allowedSourceKeys(policy *policyv1alpha1.StackConfigPolicy, resourceKind string) map[types.NamespacedName]struct{} {
+	var sources []commonv1.NamespacedSecretSource
+	switch resourceKind {
+	case kbv1.Kind:
+		sources = policy.GetKibanaNamespacedSecureSettings()
+	case esv1.Kind:
+		sources = policy.GetElasticsearchNamespacedSecureSettings()
+		// The deprecated top-level Spec.SecureSettings also applies to Elasticsearch and
+		// is still written to the annotation by the SCP controller. Include it so that
+		// sources from this field are not falsely rejected while the field is still supported.
+		for _, s := range policy.Spec.SecureSettings { //nolint:staticcheck
+			sources = append(sources, commonv1.NamespacedSecretSource{Namespace: policy.Namespace, SecretName: s.SecretName})
+		}
+	}
+	keys := make(map[types.NamespacedName]struct{}, len(sources))
+	for _, s := range sources {
+		keys[types.NamespacedName{Namespace: s.Namespace, Name: s.SecretName}] = struct{}{}
+	}
+	return keys
+}
+
 // filterByAllowedSources retains only those sources whose {namespace, secretName} pair is
 // declared by an active StackConfigPolicy governing this resource. Sources not present in
 // any governing SCP are dropped.
@@ -78,49 +102,32 @@ func filterByAllowedSources(ctx context.Context, kubeClient k8s.Client, resource
 		namespacesToCheck = append(namespacesToCheck, operatorNamespace)
 	}
 
-	var policies []policyv1alpha1.StackConfigPolicy
+	// Build the allowed set while listing — no intermediate slice needed.
+	allowed := map[types.NamespacedName]struct{}{}
 	for _, ns := range namespacesToCheck {
 		var policyList policyv1alpha1.StackConfigPolicyList
 		if err := kubeClient.List(ctx, &policyList, client.InNamespace(ns)); err != nil {
 			return nil, err
 		}
-		policies = append(policies, policyList.Items...)
-	}
-
-	// Build a set of {namespace, secretName} pairs declared by governing SCPs.
-	type sourceKey struct{ namespace, secretName string }
-	allowed := map[sourceKey]struct{}{}
-	for i := range policies {
-		policy := &policies[i]
-		matches, err := DoesPolicyMatchObject(policy, resource, operatorNamespace)
-		if err != nil {
-			return nil, err
-		}
-		if !matches {
-			continue
-		}
-		var policySources []commonv1.NamespacedSecretSource
-		switch resourceKind {
-		case "Kibana":
-			policySources = policy.GetKibanaNamespacedSecureSettings()
-		case "Elasticsearch":
-			policySources = policy.GetElasticsearchNamespacedSecureSettings()
-			// The deprecated top-level Spec.SecureSettings also applies to Elasticsearch and
-			// is still written to the annotation by the SCP controller. Include it so that
-			// sources from this field are not falsely rejected while the field is still supported.
-			for _, s := range policy.Spec.SecureSettings { //nolint:staticcheck
-				policySources = append(policySources, commonv1.NamespacedSecretSource{Namespace: policy.Namespace, SecretName: s.SecretName})
+		for i := range policyList.Items {
+			policy := &policyList.Items[i]
+			matches, err := DoesPolicyMatchObject(policy, resource, operatorNamespace)
+			if err != nil {
+				return nil, err
 			}
-		}
-		for _, s := range policySources {
-			allowed[sourceKey{s.Namespace, s.SecretName}] = struct{}{}
+			if !matches {
+				continue
+			}
+			for k := range allowedSourceKeys(policy, resourceKind) {
+				allowed[k] = struct{}{}
+			}
 		}
 	}
 
 	log := ulog.FromContext(ctx)
 	var validated []commonv1.NamespacedSecretSource
 	for _, src := range sources {
-		if _, ok := allowed[sourceKey{src.Namespace, src.SecretName}]; ok {
+		if _, ok := allowed[types.NamespacedName{Namespace: src.Namespace, Name: src.SecretName}]; ok {
 			validated = append(validated, src)
 		} else {
 			log.Info("Ignoring secure settings source: not declared by any active StackConfigPolicy",

--- a/pkg/controller/stackconfigpolicy/secure_settings_test.go
+++ b/pkg/controller/stackconfigpolicy/secure_settings_test.go
@@ -12,10 +12,11 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/elasticsearch/v1"
-	kibanav1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/kibana/v1"
+	kbv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/kibana/v1"
 	policyv1alpha1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/stackconfigpolicy/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
 )
@@ -28,7 +29,7 @@ func Test_GetSecureSettingsSecretSourcesForResources(t *testing.T) {
 		operatorNamespace string
 	}
 
-	kibana := &kibanav1.Kibana{ObjectMeta: metav1.ObjectMeta{Name: "test-kb", Namespace: "test-kb-ns"}}
+	kibana := &kbv1.Kibana{ObjectMeta: metav1.ObjectMeta{Name: "test-kb", Namespace: "test-kb-ns"}}
 
 	// Policy config secret whose annotation references a secret in the Kibana's own namespace.
 	kibanaConfigSameNs := MkKibanaConfigSecret("test-kb-ns", "test-policy", "test-policy-ns", "")
@@ -93,7 +94,7 @@ func Test_GetSecureSettingsSecretSourcesForResources(t *testing.T) {
 			name: "Kibana: source declared by governing SCP in resource namespace is allowed",
 			args: args{
 				resource:          kibana,
-				resourceKind:      "Kibana",
+				resourceKind:      kbv1.Kind,
 				client:            k8s.NewFakeClient(kibanaConfigSameNs, sameNsSCP),
 				operatorNamespace: "operator-ns",
 			},
@@ -103,7 +104,7 @@ func Test_GetSecureSettingsSecretSourcesForResources(t *testing.T) {
 			name: "Kibana: source rejected when no governing SCP declares it",
 			args: args{
 				resource:          kibana,
-				resourceKind:      "Kibana",
+				resourceKind:      kbv1.Kind,
 				client:            k8s.NewFakeClient(kibanaConfigSameNs),
 				operatorNamespace: "operator-ns",
 			},
@@ -113,7 +114,7 @@ func Test_GetSecureSettingsSecretSourcesForResources(t *testing.T) {
 			name: "Kibana: source in operator namespace allowed when operator SCP declares it",
 			args: args{
 				resource:          kibana,
-				resourceKind:      "Kibana",
+				resourceKind:      kbv1.Kind,
 				client:            k8s.NewFakeClient(kibanaConfigOpNs, operatorSCP),
 				operatorNamespace: "operator-ns",
 			},
@@ -123,7 +124,7 @@ func Test_GetSecureSettingsSecretSourcesForResources(t *testing.T) {
 			name: "Kibana: source in operator namespace rejected when no operator SCP is active",
 			args: args{
 				resource:          kibana,
-				resourceKind:      "Kibana",
+				resourceKind:      kbv1.Kind,
 				client:            k8s.NewFakeClient(kibanaConfigOpNs),
 				operatorNamespace: "operator-ns",
 			},
@@ -133,7 +134,7 @@ func Test_GetSecureSettingsSecretSourcesForResources(t *testing.T) {
 			name: "Kibana: source with correct namespace but undeclared secret name is rejected",
 			args: args{
 				resource:          kibana,
-				resourceKind:      "Kibana",
+				resourceKind:      kbv1.Kind,
 				client:            k8s.NewFakeClient(kibanaConfigOpNsWrongName, operatorSCP),
 				operatorNamespace: "operator-ns",
 			},
@@ -143,7 +144,7 @@ func Test_GetSecureSettingsSecretSourcesForResources(t *testing.T) {
 			name: "Kibana: cross-namespace source is always rejected",
 			args: args{
 				resource:          kibana,
-				resourceKind:      "Kibana",
+				resourceKind:      kbv1.Kind,
 				client:            k8s.NewFakeClient(kibanaConfigCrossNs),
 				operatorNamespace: "operator-ns",
 			},
@@ -153,7 +154,7 @@ func Test_GetSecureSettingsSecretSourcesForResources(t *testing.T) {
 			name: "Elasticsearch: source declared by governing SCP is allowed",
 			args: args{
 				resource:          &esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{Name: "test-es", Namespace: "test-es-ns"}},
-				resourceKind:      "Elasticsearch",
+				resourceKind:      esv1.Kind,
 				client:            k8s.NewFakeClient(elasticsearchSecret, esSCP),
 				operatorNamespace: "operator-ns",
 			},
@@ -163,7 +164,7 @@ func Test_GetSecureSettingsSecretSourcesForResources(t *testing.T) {
 			name: "Elasticsearch: source rejected when no governing SCP declares it",
 			args: args{
 				resource:          &esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{Name: "test-es", Namespace: "test-es-ns"}},
-				resourceKind:      "Elasticsearch",
+				resourceKind:      esv1.Kind,
 				client:            k8s.NewFakeClient(elasticsearchSecret),
 				operatorNamespace: "operator-ns",
 			},
@@ -176,7 +177,7 @@ func Test_GetSecureSettingsSecretSourcesForResources(t *testing.T) {
 			name: "Kibana: two SCPs with diverging Entries — all annotation entries with authorised secret pass",
 			args: args{
 				resource:     kibana,
-				resourceKind: "Kibana",
+				resourceKind: kbv1.Kind,
 				client: k8s.NewFakeClient(
 					func() *corev1.Secret {
 						s := MkKibanaConfigSecret("test-kb-ns", "test-policy", "test-policy-ns", "")
@@ -231,6 +232,53 @@ func Test_GetSecureSettingsSecretSourcesForResources(t *testing.T) {
 			got, err := GetSecureSettingsSecretSourcesForResources(context.Background(), tt.args.client, tt.args.resource, tt.args.resourceKind, tt.args.operatorNamespace)
 			require.NoError(t, err)
 			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_allowedSourceKeys(t *testing.T) {
+	policy := &policyv1alpha1.StackConfigPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "scp", Namespace: "ns"},
+		Spec: policyv1alpha1.StackConfigPolicySpec{
+			SecureSettings: []commonv1.SecretSource{{SecretName: "deprecated-secret"}}, //nolint:staticcheck
+			Elasticsearch: policyv1alpha1.ElasticsearchConfigPolicySpec{
+				SecureSettings: []commonv1.SecretSource{{SecretName: "es-secret"}},
+			},
+			Kibana: policyv1alpha1.KibanaConfigPolicySpec{
+				SecureSettings: []commonv1.SecretSource{{SecretName: "kb-secret"}},
+			},
+		},
+	}
+
+	tests := []struct {
+		name         string
+		resourceKind string
+		wantKeys     []types.NamespacedName
+	}{
+		{
+			name:         "Elasticsearch includes both Spec.Elasticsearch.SecureSettings and deprecated Spec.SecureSettings",
+			resourceKind: esv1.Kind,
+			wantKeys:     []types.NamespacedName{{"ns", "es-secret"}, {"ns", "deprecated-secret"}},
+		},
+		{
+			name:         "Kibana includes only Spec.Kibana.SecureSettings",
+			resourceKind: kbv1.Kind,
+			wantKeys:     []types.NamespacedName{{"ns", "kb-secret"}},
+		},
+		{
+			name:         "unknown kind returns empty set",
+			resourceKind: "Beat",
+			wantKeys:     []types.NamespacedName{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := allowedSourceKeys(policy, tt.resourceKind)
+			require.Len(t, got, len(tt.wantKeys))
+			for _, k := range tt.wantKeys {
+				require.Contains(t, got, k)
+			}
 		})
 	}
 }

--- a/pkg/controller/stackconfigpolicy/secure_settings_test.go
+++ b/pkg/controller/stackconfigpolicy/secure_settings_test.go
@@ -16,26 +16,73 @@ import (
 	commonv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/elasticsearch/v1"
 	kibanav1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/kibana/v1"
+	policyv1alpha1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/stackconfigpolicy/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
 )
 
 func Test_GetSecureSettingsSecretSourcesForResources(t *testing.T) {
 	type args struct {
-		resource     metav1.Object
-		resourceKind string
-		client       k8s.Client
+		resource          metav1.Object
+		resourceKind      string
+		client            k8s.Client
+		operatorNamespace string
 	}
 
-	kibanaConfigSecretFixture := MkKibanaConfigSecret("test-kb-ns", "test-policy", "test-policy-ns", "")
-	addSecureSettingsAnnotationToSecret(kibanaConfigSecretFixture, "test-policy-ns")
+	kibana := &kibanav1.Kibana{ObjectMeta: metav1.ObjectMeta{Name: "test-kb", Namespace: "test-kb-ns"}}
 
-	elasticsearchConfigSecretFixture := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-es-es-file-settings",
-			Namespace: "test-es-ns",
+	// Policy config secret whose annotation references a secret in the Kibana's own namespace.
+	kibanaConfigSameNs := MkKibanaConfigSecret("test-kb-ns", "test-policy", "test-policy-ns", "")
+	addSecureSettingsAnnotationToSecret(kibanaConfigSameNs, "test-kb-ns", "shared-secret")
+
+	// Policy config secret whose annotation references a secret in the operator namespace.
+	kibanaConfigOpNs := MkKibanaConfigSecret("test-kb-ns", "test-policy", "test-policy-ns", "")
+	addSecureSettingsAnnotationToSecret(kibanaConfigOpNs, "operator-ns", "shared-secret")
+
+	// Policy config secret whose annotation references a secret in an unrelated namespace.
+	kibanaConfigCrossNs := MkKibanaConfigSecret("test-kb-ns", "test-policy", "test-policy-ns", "")
+	addSecureSettingsAnnotationToSecret(kibanaConfigCrossNs, "other-tenant-ns", "shared-secret")
+
+	// Policy config secret with a source in the operator namespace but with a different secret name
+	// than what the governing SCP declares — tests exact {namespace, secretName} validation.
+	kibanaConfigOpNsWrongName := MkKibanaConfigSecret("test-kb-ns", "test-policy", "test-policy-ns", "")
+	addSecureSettingsAnnotationToSecret(kibanaConfigOpNsWrongName, "operator-ns", "injected-secret")
+
+	// SCP in the same namespace as the Kibana CR, declaring "shared-secret".
+	sameNsSCP := &policyv1alpha1.StackConfigPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "same-ns-scp", Namespace: "test-kb-ns"},
+		Spec: policyv1alpha1.StackConfigPolicySpec{
+			ResourceSelector: metav1.LabelSelector{},
+			Kibana: policyv1alpha1.KibanaConfigPolicySpec{
+				SecureSettings: []commonv1.SecretSource{{SecretName: "shared-secret"}},
+			},
 		},
 	}
-	addSecureSettingsAnnotationToSecret(elasticsearchConfigSecretFixture, "test-policy-ns")
+
+	// Operator-namespace SCP with an empty selector (matches any resource), declaring "shared-secret".
+	operatorSCP := &policyv1alpha1.StackConfigPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "op-scp", Namespace: "operator-ns"},
+		Spec: policyv1alpha1.StackConfigPolicySpec{
+			ResourceSelector: metav1.LabelSelector{},
+			Kibana: policyv1alpha1.KibanaConfigPolicySpec{
+				SecureSettings: []commonv1.SecretSource{{SecretName: "shared-secret"}},
+			},
+		},
+	}
+
+	elasticsearchSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-es-es-file-settings", Namespace: "test-es-ns"},
+	}
+	addSecureSettingsAnnotationToSecret(elasticsearchSecret, "test-es-ns", "shared-secret")
+
+	esSCP := &policyv1alpha1.StackConfigPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "es-scp", Namespace: "test-es-ns"},
+		Spec: policyv1alpha1.StackConfigPolicySpec{
+			ResourceSelector: metav1.LabelSelector{},
+			Elasticsearch: policyv1alpha1.ElasticsearchConfigPolicySpec{
+				SecureSettings: []commonv1.SecretSource{{SecretName: "shared-secret"}},
+			},
+		},
+	}
 
 	tests := []struct {
 		name string
@@ -43,48 +90,137 @@ func Test_GetSecureSettingsSecretSourcesForResources(t *testing.T) {
 		want []commonv1.NamespacedSecretSource
 	}{
 		{
-			name: "Get secure settings secrets for Kibana",
+			name: "Kibana: source declared by governing SCP in resource namespace is allowed",
 			args: args{
-				resource: &kibanav1.Kibana{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-kb",
-						Namespace: "test-kb-ns",
-					},
-				},
+				resource:          kibana,
+				resourceKind:      "Kibana",
+				client:            k8s.NewFakeClient(kibanaConfigSameNs, sameNsSCP),
+				operatorNamespace: "operator-ns",
+			},
+			want: []commonv1.NamespacedSecretSource{{SecretName: "shared-secret", Namespace: "test-kb-ns"}},
+		},
+		{
+			name: "Kibana: source rejected when no governing SCP declares it",
+			args: args{
+				resource:          kibana,
+				resourceKind:      "Kibana",
+				client:            k8s.NewFakeClient(kibanaConfigSameNs),
+				operatorNamespace: "operator-ns",
+			},
+			want: []commonv1.NamespacedSecretSource{},
+		},
+		{
+			name: "Kibana: source in operator namespace allowed when operator SCP declares it",
+			args: args{
+				resource:          kibana,
+				resourceKind:      "Kibana",
+				client:            k8s.NewFakeClient(kibanaConfigOpNs, operatorSCP),
+				operatorNamespace: "operator-ns",
+			},
+			want: []commonv1.NamespacedSecretSource{{SecretName: "shared-secret", Namespace: "operator-ns"}},
+		},
+		{
+			name: "Kibana: source in operator namespace rejected when no operator SCP is active",
+			args: args{
+				resource:          kibana,
+				resourceKind:      "Kibana",
+				client:            k8s.NewFakeClient(kibanaConfigOpNs),
+				operatorNamespace: "operator-ns",
+			},
+			want: []commonv1.NamespacedSecretSource{},
+		},
+		{
+			name: "Kibana: source with correct namespace but undeclared secret name is rejected",
+			args: args{
+				resource:          kibana,
+				resourceKind:      "Kibana",
+				client:            k8s.NewFakeClient(kibanaConfigOpNsWrongName, operatorSCP),
+				operatorNamespace: "operator-ns",
+			},
+			want: []commonv1.NamespacedSecretSource{},
+		},
+		{
+			name: "Kibana: cross-namespace source is always rejected",
+			args: args{
+				resource:          kibana,
+				resourceKind:      "Kibana",
+				client:            k8s.NewFakeClient(kibanaConfigCrossNs),
+				operatorNamespace: "operator-ns",
+			},
+			want: []commonv1.NamespacedSecretSource{},
+		},
+		{
+			name: "Elasticsearch: source declared by governing SCP is allowed",
+			args: args{
+				resource:          &esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{Name: "test-es", Namespace: "test-es-ns"}},
+				resourceKind:      "Elasticsearch",
+				client:            k8s.NewFakeClient(elasticsearchSecret, esSCP),
+				operatorNamespace: "operator-ns",
+			},
+			want: []commonv1.NamespacedSecretSource{{SecretName: "shared-secret", Namespace: "test-es-ns"}},
+		},
+		{
+			name: "Elasticsearch: source rejected when no governing SCP declares it",
+			args: args{
+				resource:          &esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{Name: "test-es", Namespace: "test-es-ns"}},
+				resourceKind:      "Elasticsearch",
+				client:            k8s.NewFakeClient(elasticsearchSecret),
+				operatorNamespace: "operator-ns",
+			},
+			want: []commonv1.NamespacedSecretSource{},
+		},
+		{
+			// Two SCPs declare the same secret with different Entries. The annotation contains
+			// both entries. Validation only checks {namespace, secretName} — entries are the
+			// SCP controller's concern and will be reconciled back. Both annotation entries pass.
+			name: "Kibana: two SCPs with diverging Entries — all annotation entries with authorised secret pass",
+			args: args{
+				resource:     kibana,
 				resourceKind: "Kibana",
-				client:       k8s.NewFakeClient(kibanaConfigSecretFixture),
-			},
-			want: []commonv1.NamespacedSecretSource{
-				{
-					SecretName: "shared-secret",
-					Namespace:  "test-policy-ns",
-				},
-			},
-		},
-		{
-			name: "Get secure settings secrets for Elasticsearch",
-			args: args{
-				resource: &esv1.Elasticsearch{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-es",
-						Namespace: "test-es-ns",
+				client: k8s.NewFakeClient(
+					func() *corev1.Secret {
+						s := MkKibanaConfigSecret("test-kb-ns", "test-policy", "test-policy-ns", "")
+						if s.Annotations == nil {
+							s.Annotations = make(map[string]string)
+						}
+						s.Annotations["policy.k8s.elastic.co/secure-settings-secrets"] = `[` +
+							`{"namespace":"test-kb-ns","secretName":"shared-secret","entries":[{"key":"k1"}]},` +
+							`{"namespace":"test-kb-ns","secretName":"shared-secret","entries":[{"key":"k2"}]}` +
+							`]`
+						return s
+					}(),
+					&policyv1alpha1.StackConfigPolicy{
+						ObjectMeta: metav1.ObjectMeta{Name: "scp-a", Namespace: "test-kb-ns"},
+						Spec: policyv1alpha1.StackConfigPolicySpec{
+							ResourceSelector: metav1.LabelSelector{},
+							Kibana: policyv1alpha1.KibanaConfigPolicySpec{
+								SecureSettings: []commonv1.SecretSource{{SecretName: "shared-secret", Entries: []commonv1.KeyToPath{{Key: "k1"}}}},
+							},
+						},
 					},
-				},
-				resourceKind: "Elasticsearch",
-				client:       k8s.NewFakeClient(elasticsearchConfigSecretFixture),
+					&policyv1alpha1.StackConfigPolicy{
+						ObjectMeta: metav1.ObjectMeta{Name: "scp-b", Namespace: "test-kb-ns"},
+						Spec: policyv1alpha1.StackConfigPolicySpec{
+							ResourceSelector: metav1.LabelSelector{},
+							Kibana: policyv1alpha1.KibanaConfigPolicySpec{
+								SecureSettings: []commonv1.SecretSource{{SecretName: "shared-secret", Entries: []commonv1.KeyToPath{{Key: "k2"}}}},
+							},
+						},
+					},
+				),
+				operatorNamespace: "operator-ns",
 			},
 			want: []commonv1.NamespacedSecretSource{
-				{
-					SecretName: "shared-secret",
-					Namespace:  "test-policy-ns",
-				},
+				{Namespace: "test-kb-ns", SecretName: "shared-secret", Entries: []commonv1.KeyToPath{{Key: "k1"}}},
+				{Namespace: "test-kb-ns", SecretName: "shared-secret", Entries: []commonv1.KeyToPath{{Key: "k2"}}},
 			},
 		},
 		{
-			name: "secure settings for unknow kind",
+			name: "unknown resource kind returns empty",
 			args: args{
-				resourceKind: "UnknownKind",
-				client:       k8s.NewFakeClient(elasticsearchConfigSecretFixture),
+				resourceKind:      "UnknownKind",
+				client:            k8s.NewFakeClient(elasticsearchSecret),
+				operatorNamespace: "operator-ns",
 			},
 			want: []commonv1.NamespacedSecretSource{},
 		},
@@ -92,16 +228,16 @@ func Test_GetSecureSettingsSecretSourcesForResources(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetSecureSettingsSecretSourcesForResources(context.Background(), tt.args.client, tt.args.resource, tt.args.resourceKind)
+			got, err := GetSecureSettingsSecretSourcesForResources(context.Background(), tt.args.client, tt.args.resource, tt.args.resourceKind, tt.args.operatorNamespace)
 			require.NoError(t, err)
 			require.Equal(t, tt.want, got)
 		})
 	}
 }
 
-func addSecureSettingsAnnotationToSecret(secret *corev1.Secret, namespace string) {
+func addSecureSettingsAnnotationToSecret(secret *corev1.Secret, namespace, secretName string) {
 	if secret.Annotations == nil {
 		secret.Annotations = make(map[string]string)
 	}
-	secret.Annotations["policy.k8s.elastic.co/secure-settings-secrets"] = fmt.Sprintf(`[{"namespace":"%s","secretName":"shared-secret"}]`, namespace)
+	secret.Annotations["policy.k8s.elastic.co/secure-settings-secrets"] = fmt.Sprintf(`[{"namespace":"%s","secretName":"%s"}]`, namespace, secretName)
 }

--- a/pkg/controller/stackconfigpolicy/secure_settings_test.go
+++ b/pkg/controller/stackconfigpolicy/secure_settings_test.go
@@ -240,7 +240,7 @@ func Test_allowedSourceKeys(t *testing.T) {
 	policy := &policyv1alpha1.StackConfigPolicy{
 		ObjectMeta: metav1.ObjectMeta{Name: "scp", Namespace: "ns"},
 		Spec: policyv1alpha1.StackConfigPolicySpec{
-			SecureSettings: []commonv1.SecretSource{{SecretName: "deprecated-secret"}}, //nolint:staticcheck
+			SecureSettings: []commonv1.SecretSource{{SecretName: "deprecated-secret"}},
 			Elasticsearch: policyv1alpha1.ElasticsearchConfigPolicySpec{
 				SecureSettings: []commonv1.SecretSource{{SecretName: "es-secret"}},
 			},
@@ -258,12 +258,12 @@ func Test_allowedSourceKeys(t *testing.T) {
 		{
 			name:         "Elasticsearch includes both Spec.Elasticsearch.SecureSettings and deprecated Spec.SecureSettings",
 			resourceKind: esv1.Kind,
-			wantKeys:     []types.NamespacedName{{"ns", "es-secret"}, {"ns", "deprecated-secret"}},
+			wantKeys:     []types.NamespacedName{{Namespace: "ns", Name: "es-secret"}, {Namespace: "ns", Name: "deprecated-secret"}},
 		},
 		{
 			name:         "Kibana includes only Spec.Kibana.SecureSettings",
 			resourceKind: kbv1.Kind,
-			wantKeys:     []types.NamespacedName{{"ns", "kb-secret"}},
+			wantKeys:     []types.NamespacedName{{Namespace: "ns", Name: "kb-secret"}},
 		},
 		{
 			name:         "unknown kind returns empty set",


### PR DESCRIPTION
## Summary

The operator caches the secure settings secret sources declared by a `StackConfigPolicy` in an annotation on the operator-managed secret (`<es>-es-file-settings` for Elasticsearch, `<kb>-kb-policy-config` for Kibana). During keystore reconciliation the operator reads this annotation to determine which secrets to load into the keystore.

This PR adds a validation step that cross-checks each `{namespace, secretName}` pair in the annotation against the live set of `StackConfigPolicies` that actively govern the resource before acting on it. Any source not declared by a governing policy is silently dropped and logged. This makes keystore reconciliation consistent with the current policy state rather than blindly trusting a potentially stale or incorrect annotation value.

## Changes

- **`pkg/controller/stackconfigpolicy/secure_setings.go`**: add `filterByAllowedSources`, which lists SCPs in the resource's own namespace and the operator namespace (the only two namespaces that can ever govern a resource), builds an allowed `{namespace, secretName}` set from their declared secure settings, and filters the annotation sources against it. The deprecated top-level `Spec.SecureSettings` field is included in the allowed set while it remains supported.

- **`pkg/controller/common/keystore/`**, **`pkg/controller/kibana/driver.go`**, **`pkg/controller/elasticsearch/driver/`**: thread `operatorNamespace` through to `GetSecureSettingsSecretSourcesForResources` so the filter can evaluate operator-namespace SCPs.