### PR TITLE
[3.5] e2e: skip unsupported versions in TestPauseOrchestration_AutoOps (#9589)

### DIFF
--- a/test/e2e/pause_orchestration_test.go
+++ b/test/e2e/pause_orchestration_test.go
@@ -92,6 +92,12 @@ func TestPauseOrchestration_AutoOps(t *testing.T) {
 		t.SkipNow()
 	}
 
+	v := version.MustParse(test.Ctx().ElasticStackVersion)
+	if v.LT(version.SupportedAutoOpsAgentEnterpriseVersions.Min) {
+		t.Skipf("Skipping test: version %s below minimum %s",
+			test.Ctx().ElasticStackVersion, version.SupportedAutoOpsAgentEnterpriseVersions.Min)
+	}
+
 	namespace := test.Ctx().ManagedNamespace(0)
 
 	esInitial := elasticsearch.NewBuilder(testName(label.Type)).


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.5`:
 - [e2e: skip unsupported versions in TestPauseOrchestration_AutoOps (#9589)](https://github.com/elastic/cloud-on-k8s/pull/9589)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)