### PR TITLE
[e2e]: fix kibana builder pattern usage in test pause orchestration

### DIFF
--- a/test/e2e/pause_orchestration_test.go
+++ b/test/e2e/pause_orchestration_test.go
@@ -528,7 +528,8 @@ func pauseOrchestrationBuilders(t *testing.T, optionalTypes ...string) (
 	phase2 []test.Builder,
 	phase3 []test.Builder,
 	phase4 []test.Builder,
-	phase6 []test.Builder) {
+	phase6 []test.Builder,
+) {
 	t.Helper()
 
 	testTypes := make(map[string]struct{})
@@ -653,10 +654,7 @@ func pauseOrchestrationBuilders(t *testing.T, optionalTypes ...string) (
 
 	// Phase 2: update topology of each application
 	phase2Builder := newPhaseBuilder(testTypes)
-	esUpdated := esEnabled.DeepCopy().WithESMasterNodes(1, corev1.ResourceRequirements{
-		Limits: map[corev1.ResourceName]resource.Quantity{
-			corev1.ResourceMemory: resource.MustParse("1Gi"),
-		}}).
+	esUpdated := esEnabled.DeepCopy().WithESMasterNodes(1, elasticsearch.DefaultResources).
 		WithESMasterDataNodes(2, elasticsearch.DefaultResources).
 		WithMutatedFrom(&esEnabled)
 	phase2Builder.AddBuilder(esUpdated)

--- a/test/e2e/pause_orchestration_test.go
+++ b/test/e2e/pause_orchestration_test.go
@@ -558,10 +558,10 @@ func pauseOrchestrationBuilders(t *testing.T, optionalTypes ...string) (
 		WithElasticsearchRef(esRef).
 		WithRestrictedSecurityContext()
 	if _, testEPR := testTypes[eprlabel.Type]; testEPR {
-		kbInitial.WithPackageRegistryRef(eprInitial.Ref())
+		kbInitial = kbInitial.WithPackageRegistryRef(eprInitial.Ref())
 	}
 	if _, testAPM := testTypes[apmlabel.Type]; testAPM {
-		kbInitial.WithAPMIntegration()
+		kbInitial = kbInitial.WithAPMIntegration()
 	}
 	kbRef := commonv1.ObjectSelector{Namespace: kbInitial.Kibana.Namespace, Name: kbInitial.Kibana.Name}
 	initialBuilder.AddBuilder(kbInitial)


### PR DESCRIPTION
Fix discarded builder return value. 

`kibana.Builder` is a Go value type (not a pointer receiver). Every `With*()` method has a value receiver and returns a new modified copy, callers must assign the result back or the change is lost.

Both calls here discard their return values, leaving `kbInitial` unchanged.

## Why the Tests Passe in Stack Versions >= 8.19 and 9.x
The bug is present in all versions, but the observable behavior differs by APM Server version:

**APM Server 8.19 changed the default of `apm-server.data_streams.wait_for_integration` from
`true` to `false`.**

In 8.19+, APM Server no longer blocks on the `precondition 'apm integration installed'` check.
It proceeds to write events to ES data streams regardless of whether the Fleet-managed index
templates exist. Elasticsearch auto-creates the data streams on first write, so the test step
succeeds in finding the expected documents.

| Version range | `WithAPMIntegration()` no-op? | `wait_for_integration` default | Test outcome |
|---|---|---|---|
| 8.0.0 – 8.18.x | No — sets `xpack.fleet.packages` | `true` (blocks on templates) | **Fails** (bug exposed) |
| 8.19+, 9.x | No — sets `xpack.fleet.packages` | `false` (no blocking check) | Passes (bug masked) |

___ 


Because of `OOM`, the memory limit for elasticsearch is increased to the default that is used in e2e (`1Gi` -> `2Gi`) 