### PR TITLE
[3.5] [e2e]: fix kibana builder pattern usage in test pause orchestration (#9595)

### DIFF
--- a/test/e2e/pause_orchestration_test.go
+++ b/test/e2e/pause_orchestration_test.go
@@ -528,7 +528,8 @@ func pauseOrchestrationBuilders(t *testing.T, optionalTypes ...string) (
 	phase2 []test.Builder,
 	phase3 []test.Builder,
 	phase4 []test.Builder,
-	phase6 []test.Builder) {
+	phase6 []test.Builder,
+) {
 	t.Helper()
 
 	testTypes := make(map[string]struct{})
@@ -558,10 +559,10 @@ func pauseOrchestrationBuilders(t *testing.T, optionalTypes ...string) (
 		WithElasticsearchRef(esRef).
 		WithRestrictedSecurityContext()
 	if _, testEPR := testTypes[eprlabel.Type]; testEPR {
-		kbInitial.WithPackageRegistryRef(eprInitial.Ref())
+		kbInitial = kbInitial.WithPackageRegistryRef(eprInitial.Ref())
 	}
 	if _, testAPM := testTypes[apmlabel.Type]; testAPM {
-		kbInitial.WithAPMIntegration()
+		kbInitial = kbInitial.WithAPMIntegration()
 	}
 	kbRef := commonv1.ObjectSelector{Namespace: kbInitial.Kibana.Namespace, Name: kbInitial.Kibana.Name}
 	initialBuilder.AddBuilder(kbInitial)
@@ -653,10 +654,7 @@ func pauseOrchestrationBuilders(t *testing.T, optionalTypes ...string) (
 
 	// Phase 2: update topology of each application
 	phase2Builder := newPhaseBuilder(testTypes)
-	esUpdated := esEnabled.DeepCopy().WithESMasterNodes(1, corev1.ResourceRequirements{
-		Limits: map[corev1.ResourceName]resource.Quantity{
-			corev1.ResourceMemory: resource.MustParse("1Gi"),
-		}}).
+	esUpdated := esEnabled.DeepCopy().WithESMasterNodes(1, elasticsearch.DefaultResources).
 		WithESMasterDataNodes(2, elasticsearch.DefaultResources).
 		WithMutatedFrom(&esEnabled)
 	phase2Builder.AddBuilder(esUpdated)


### PR DESCRIPTION
Backport of: #9595
