### PR TITLE
Scale es to 2 nodes in recipes/tests with kibana or fleet packages

### DIFF
--- a/config/recipes/associations-rbac/apm_es_kibana_rbac.yaml
+++ b/config/recipes/associations-rbac/apm_es_kibana_rbac.yaml
@@ -87,7 +87,7 @@ spec:
   version: 9.4.3
   nodeSets:
     - name: default
-      count: 1
+      count: 2
       config:
         node.store.allow_mmap: false
 ---

--- a/config/recipes/autopilot/elasticsearch.yaml
+++ b/config/recipes/autopilot/elasticsearch.yaml
@@ -24,7 +24,7 @@ spec:
   version: 9.4.3
   nodeSets:
   - name: default
-    count: 1
+    count: 2
     resources:
       requests:
         memory: 1Gi

--- a/config/recipes/autopilot/fleet-kubernetes-integration.yaml
+++ b/config/recipes/autopilot/fleet-kubernetes-integration.yaml
@@ -23,7 +23,7 @@ spec:
   version: 9.4.3
   nodeSets:
   - name: default
-    count: 1
+    count: 2
     resources:
       requests:
         memory: 4Gi

--- a/config/recipes/mtls/manual/beats.yaml
+++ b/config/recipes/mtls/manual/beats.yaml
@@ -129,7 +129,7 @@ spec:
         secretName: elasticsearch-es-http-certs-cm
   nodeSets:
   - name: default
-    count: 1
+    count: 2
     config:
       node.store.allow_mmap: false
       xpack.security.http.ssl.client_authentication: optional

--- a/config/recipes/mtls/manual/fleet.yaml
+++ b/config/recipes/mtls/manual/fleet.yaml
@@ -156,7 +156,7 @@ spec:
         secretName: elasticsearch-es-http-certs-cm
   nodeSets:
   - name: default
-    count: 1
+    count: 2
     config:
       node.store.allow_mmap: false
       xpack.security.http.ssl.client_authentication: optional

--- a/config/recipes/mtls/manual/standalone-agent.yaml
+++ b/config/recipes/mtls/manual/standalone-agent.yaml
@@ -129,7 +129,7 @@ spec:
         secretName: elasticsearch-es-http-certs-cm
   nodeSets:
   - name: default
-    count: 1
+    count: 2
     config:
       node.store.allow_mmap: false
       xpack.security.http.ssl.client_authentication: optional

--- a/config/recipes/packageregistry/epr-eck.yaml
+++ b/config/recipes/packageregistry/epr-eck.yaml
@@ -51,7 +51,7 @@ spec:
   version: 9.4.3
   nodeSets:
   - name: default
-    count: 1
+    count: 2
     config:
       node.store.allow_mmap: false
 ---

--- a/config/recipes/packageregistry/epr-extra-ca.yaml
+++ b/config/recipes/packageregistry/epr-extra-ca.yaml
@@ -75,7 +75,7 @@ spec:
   version: 9.4.3
   nodeSets:
   - name: default
-    count: 1
+    count: 2
     config:
       node.store.allow_mmap: false
 ---

--- a/config/recipes/packageregistry/epr-volumes.yaml
+++ b/config/recipes/packageregistry/epr-volumes.yaml
@@ -65,7 +65,7 @@ spec:
   version: 9.4.3
   nodeSets:
   - name: default
-    count: 1
+    count: 2
     config:
       node.store.allow_mmap: false
 ---

--- a/config/samples/kibana/kibana_es.yaml
+++ b/config/samples/kibana/kibana_es.yaml
@@ -7,7 +7,7 @@ spec:
   version: 9.4.3
   nodeSets:
   - name: default
-    count: 1
+    count: 2
     config:
       # This setting could have performance implications for production clusters.
       # See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html

--- a/test/e2e/namespace_selector/namespace_selector_test.go
+++ b/test/e2e/namespace_selector/namespace_selector_test.go
@@ -173,7 +173,7 @@ func TestNamespaceSelectorDynamicLabelChangeAssociation(t *testing.T) {
 
 	esBuilder := elasticsearch.NewBuilder("ns-sel-assoc").
 		WithNamespace(esNamespace).
-		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 	kbBuilder := kibana.NewBuilder("ns-sel-assoc").
 		WithNamespace(kbNamespace).
 		WithElasticsearchRef(esBuilder.Ref()).


### PR DESCRIPTION
## Summary

Two related issues affect single-node Elasticsearch clusters in our e2e tests:

**Kibana internal indices** - https://github.com/elastic/kibana/issues/276861: Kibana creates internal data streams and ILM policies that are missing `auto_expand_replicas: "0-1"`. On a single-node cluster replica shards cannot be assigned, leaving those indices yellow and causing Kibana health checks to fail.

**Fleet-installed packages** - The same problem applies to data streams created by Fleet-managed packages (system, elastic_agent, kubernetes, fleet_server, etc.). These packages install index templates and ILM policies without `auto_expand_replicas`, which has the same effect on single-node clusters.

The upstream fix needs to land in Kibana/Fleet. Until then, the safest workaround for our tests and recipes is to ensure any Elasticsearch cluster that runs alongside Kibana or Fleet has at least 2 nodes, so replica assignment is not blocked and cluster health remains green.

## Changes

Bumped Elasticsearch `count` from 1 to 2 in all affected files:

**e2e tests**
- `test/e2e/namespace_selector/namespace_selector_test.go` - `TestNamespaceSelectorDynamicLabelChangeAssociation`

**config/samples** (used by `TestSamples`)
- `config/samples/kibana/kibana_es.yaml`

**config/recipes**
- `config/recipes/autopilot/fleet-kubernetes-integration.yaml` (used by `TestAutopilot`)
- `config/recipes/autopilot/elasticsearch.yaml`
- `config/recipes/associations-rbac/apm_es_kibana_rbac.yaml`
- `config/recipes/mtls/manual/beats.yaml`
- `config/recipes/mtls/manual/fleet.yaml`
- `config/recipes/mtls/manual/standalone-agent.yaml`
- `config/recipes/packageregistry/epr-eck.yaml`
- `config/recipes/packageregistry/epr-extra-ca.yaml`
- `config/recipes/packageregistry/epr-volumes.yaml`