### PR TITLE
[3.5] scale es to 2 nodes in recipes/tests with kibana or fleet packages (#9604)

### DIFF
--- a/config/recipes/associations-rbac/apm_es_kibana_rbac.yaml
+++ b/config/recipes/associations-rbac/apm_es_kibana_rbac.yaml
@@ -87,7 +87,7 @@ spec:
   version: 9.4.3
   nodeSets:
     - name: default
-      count: 1
+      count: 2
       config:
         node.store.allow_mmap: false
 ---

--- a/config/recipes/autopilot/elasticsearch.yaml
+++ b/config/recipes/autopilot/elasticsearch.yaml
@@ -24,7 +24,7 @@ spec:
   version: 9.4.3
   nodeSets:
   - name: default
-    count: 1
+    count: 2
     resources:
       requests:
         memory: 1Gi

--- a/config/recipes/autopilot/fleet-kubernetes-integration.yaml
+++ b/config/recipes/autopilot/fleet-kubernetes-integration.yaml
@@ -23,7 +23,7 @@ spec:
   version: 9.4.3
   nodeSets:
   - name: default
-    count: 1
+    count: 2
     resources:
       requests:
         memory: 4Gi

--- a/config/recipes/mtls/manual/beats.yaml
+++ b/config/recipes/mtls/manual/beats.yaml
@@ -129,7 +129,7 @@ spec:
         secretName: elasticsearch-es-http-certs-cm
   nodeSets:
   - name: default
-    count: 1
+    count: 2
     config:
       node.store.allow_mmap: false
       xpack.security.http.ssl.client_authentication: optional

--- a/config/recipes/mtls/manual/fleet.yaml
+++ b/config/recipes/mtls/manual/fleet.yaml
@@ -156,7 +156,7 @@ spec:
         secretName: elasticsearch-es-http-certs-cm
   nodeSets:
   - name: default
-    count: 1
+    count: 2
     config:
       node.store.allow_mmap: false
       xpack.security.http.ssl.client_authentication: optional

--- a/config/recipes/mtls/manual/standalone-agent.yaml
+++ b/config/recipes/mtls/manual/standalone-agent.yaml
@@ -129,7 +129,7 @@ spec:
         secretName: elasticsearch-es-http-certs-cm
   nodeSets:
   - name: default
-    count: 1
+    count: 2
     config:
       node.store.allow_mmap: false
       xpack.security.http.ssl.client_authentication: optional

--- a/config/recipes/packageregistry/epr-eck.yaml
+++ b/config/recipes/packageregistry/epr-eck.yaml
@@ -51,7 +51,7 @@ spec:
   version: 9.4.3
   nodeSets:
   - name: default
-    count: 1
+    count: 2
     config:
       node.store.allow_mmap: false
 ---

--- a/config/recipes/packageregistry/epr-extra-ca.yaml
+++ b/config/recipes/packageregistry/epr-extra-ca.yaml
@@ -75,7 +75,7 @@ spec:
   version: 9.4.3
   nodeSets:
   - name: default
-    count: 1
+    count: 2
     config:
       node.store.allow_mmap: false
 ---

--- a/config/recipes/packageregistry/epr-volumes.yaml
+++ b/config/recipes/packageregistry/epr-volumes.yaml
@@ -65,7 +65,7 @@ spec:
   version: 9.4.3
   nodeSets:
   - name: default
-    count: 1
+    count: 2
     config:
       node.store.allow_mmap: false
 ---

--- a/config/samples/kibana/kibana_es.yaml
+++ b/config/samples/kibana/kibana_es.yaml
@@ -7,7 +7,7 @@ spec:
   version: 9.4.3
   nodeSets:
   - name: default
-    count: 1
+    count: 2
     config:
       # This setting could have performance implications for production clusters.
       # See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html

--- a/test/e2e/namespace_selector/namespace_selector_test.go
+++ b/test/e2e/namespace_selector/namespace_selector_test.go
@@ -173,7 +173,7 @@ func TestNamespaceSelectorDynamicLabelChangeAssociation(t *testing.T) {
 
 	esBuilder := elasticsearch.NewBuilder("ns-sel-assoc").
 		WithNamespace(esNamespace).
-		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 	kbBuilder := kibana.NewBuilder("ns-sel-assoc").
 		WithNamespace(kbNamespace).
 		WithElasticsearchRef(esBuilder.Ref()).


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.5`:
 - [scale es to 2 nodes in recipes/tests with kibana or fleet packages (#9604)](https://github.com/elastic/cloud-on-k8s/pull/9604)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)