### PR TITLE
e2e: mitigate Manticore strip() bug in Enterprise Search mTLS tests

### DIFF
--- a/test/e2e/ent/client_auth_test.go
+++ b/test/e2e/ent/client_auth_test.go
@@ -11,11 +11,15 @@ import (
 	"fmt"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/common/v1"
 	entv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/enterprisesearch/v1"
 	entcontroller "github.com/elastic/cloud-on-k8s/v3/pkg/controller/association/controller"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/certificates"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test"
 	clientauth "github.com/elastic/cloud-on-k8s/v3/test/e2e/test/client-auth"
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test/elasticsearch"
@@ -46,7 +50,43 @@ func TestClientAuthRequiredTransition(t *testing.T) {
 	esWithLicense := test.LicenseTestBuilder(esBuilder)
 	esWithLicense.PostCheckSteps = func(k *test.K8sClient) test.StepList {
 		// 1 client certificate; enterprise-search
-		return test.StepList{clientauth.CheckClientCertificatesCountStep(k, namespace, esBuilder.Elasticsearch.Name, 1)}
+		return test.StepList{
+			clientauth.CheckClientCertificatesCountStep(k, namespace, esBuilder.Elasticsearch.Name, 1),
+			{
+				// Delete the Enterprise Search client cert secret if its PKCS#8 key's last DER
+				// byte falls in the ASCII whitespace range. Enterprise Search would crash on
+				// startup with an InvalidKeySpecException due to the Manticore strip() bug
+				// (https://github.com/elastic/search-team/issues/15173). Deleting forces the
+				// operator to regenerate; ENT's CheckPods step waits for the pod to come up
+				// with the new key.
+				Name: "Delete Enterprise Search client certificate secret if PKCS#8 key last DER byte is ASCII whitespace",
+				Test: test.Eventually(func() error {
+					var secretList corev1.SecretList
+					if err := k.Client.List(t.Context(), &secretList,
+						k8sclient.InNamespace(namespace),
+						k8sclient.MatchingLabels{
+							labels.ClientCertificateLabelName:       "true",
+							entcontroller.EntESAssociationLabelName: entBuilder.EnterpriseSearch.Name,
+						},
+					); err != nil {
+						return err
+					}
+					if len(secretList.Items) != 1 {
+						return fmt.Errorf("expected at most 1 Enterprise Search client cert secret, got %d", len(secretList.Items))
+					}
+					secret := secretList.Items[0]
+					whitespaceByteAtEnd, err := helper.PKCS8KeyEndsWithWhitespaceByte(secret.Data[certificates.KeyFileName])
+					if err != nil {
+						return err
+					}
+					if whitespaceByteAtEnd {
+						_ = k.Client.Delete(t.Context(), &secret)
+						return fmt.Errorf("client cert secret %s has trailing whitespace byte; deleted to force regeneration", secret.Name)
+					}
+					return nil
+				}),
+			},
+		}
 	}
 
 	// Transition ES to client auth disabled.
@@ -109,7 +149,22 @@ func TestClientAuthRequiredCustomCertificate(t *testing.T) {
 		WithClientCertificateSecret(userCertSecretName).
 		WithNodeCount(1)
 
-	certPEM, keyPEM := helper.GenerateSelfSignedClientCertPKCS8(t, name)
+	var certPEM, keyPEM []byte
+	test.Eventually(func() error {
+		certPEM, keyPEM = helper.GenerateSelfSignedClientCertPKCS8(t, name)
+		whitespaceByteAtEnd, err := helper.PKCS8KeyEndsWithWhitespaceByte(keyPEM)
+		if err != nil {
+			return err
+		}
+		if whitespaceByteAtEnd {
+			// Regenerate the Enterprise Search client user cert secret if its PKCS#8 key's last DER
+			// byte falls in the ASCII whitespace range. Enterprise Search would crash on
+			// startup with an InvalidKeySpecException due to the Manticore strip() bug
+			// (https://github.com/elastic/search-team/issues/15173).
+			return fmt.Errorf("regenerating client cert: PKCS#8 key ends with ASCII whitespace byte")
+		}
+		return nil
+	})(t)
 
 	entWrapped := test.WrappedBuilder{
 		BuildingThis: entBuilder,

--- a/test/e2e/test/helper/certs.go
+++ b/test/e2e/test/helper/certs.go
@@ -61,7 +61,7 @@ func PKCS8KeyEndsWithWhitespaceByte(keyPEM []byte) (bool, error) {
 		return false, errors.New("empty decoded block")
 	}
 	last := block.Bytes[len(block.Bytes)-1]
-	return last == '\t' || last == '\n' || last == '\v' || last == '\f' || last == '\r' || last == ' ', nil
+	return last == 0x00 || last == '\t' || last == '\n' || last == '\v' || last == '\f' || last == '\r' || last == ' ', nil
 }
 
 // generateSelfSignedCert creates a self-signed client certificate using the given key and signature algorithm.

--- a/test/e2e/test/helper/certs.go
+++ b/test/e2e/test/helper/certs.go
@@ -13,6 +13,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
 	"math/big"
 	"testing"
 	"time"
@@ -50,6 +51,17 @@ func GenerateSelfSignedClientCertPKCS8(t *testing.T, cn string) (certPEM, keyPEM
 
 	certPEM = generateSelfSignedCert(t, cn, x509.SHA256WithRSA, privateKey)
 	return certPEM, keyPEM
+}
+
+// PKCS8KeyEndsWithWhitespaceByte reports whether the last byte of the DER payload inside keyPEM is an ASCII
+// whitespace character.
+func PKCS8KeyEndsWithWhitespaceByte(keyPEM []byte) (bool, error) {
+	block, _ := pem.Decode(keyPEM)
+	if block == nil || len(block.Bytes) == 0 {
+		return false, errors.New("empty decoded block")
+	}
+	last := block.Bytes[len(block.Bytes)-1]
+	return last == '\t' || last == '\n' || last == '\v' || last == '\f' || last == '\r' || last == ' ', nil
 }
 
 // generateSelfSignedCert creates a self-signed client certificate using the given key and signature algorithm.

--- a/test/e2e/test/helper/certs_test.go
+++ b/test/e2e/test/helper/certs_test.go
@@ -1,0 +1,58 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package helper
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPKCS8KeyEndsWithWhitespaceByte(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		lastByte byte
+		want     bool
+	}{
+		{"NUL", 0x00, true},
+		{"tab", '\t', true},
+		{"newline", '\n', true},
+		{"vertical tab", '\v', true},
+		{"form feed", '\f', true},
+		{"carriage return", '\r', true},
+		{"space", ' ', true},
+		{"non-whitespace 0x01", 0x01, false},
+		{"non-whitespace 0x21", 0x21, false},
+		{"non-whitespace 0xff", 0xff, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			keyPEM := pkcs8PEMWithLastByte(t, tc.lastByte)
+			got, err := PKCS8KeyEndsWithWhitespaceByte(keyPEM)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+
+}
+
+func TestPKCS8KeyEndsWithWhitespaceByte_InvalidPEM(t *testing.T) {
+	_, err := PKCS8KeyEndsWithWhitespaceByte([]byte("not a pem block"))
+	require.Error(t, err)
+}
+
+// pkcs8PEMWithLastByte generates a real PKCS#8 DER key and overwrites its last byte with b.
+func pkcs8PEMWithLastByte(t *testing.T, b byte) []byte {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	der[len(der)-1] = b
+	return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+}

--- a/test/e2e/test/helper/certs_test.go
+++ b/test/e2e/test/helper/certs_test.go
@@ -38,7 +38,6 @@ func TestPKCS8KeyEndsWithWhitespaceByte(t *testing.T) {
 			require.Equal(t, tc.want, got)
 		})
 	}
-
 }
 
 func TestPKCS8KeyEndsWithWhitespaceByte_InvalidPEM(t *testing.T) {


### PR DESCRIPTION
## Summary

`TestClientAuthRequiredTransition` and `TestClientAuthRequiredCustomCertificate` are intermittently flaky (~2.3% of runs) due to a bug in `manticore-0.8.0-java` used by Enterprise Search.

In `setup_key_store`, Manticore calls Ruby's `String#strip` on the raw binary DER payload decoded from the PKCS#8 PEM key. `strip` removes leading/trailing ASCII whitespace bytes (`\x09`–`\x0d`, `\x20`) from any string, including binary data. For approximately 6/256 ≈ 2.3% of RSA-2048 keys, the last byte of the DER encoding falls in that range, causing `strip` to truncate the structure by one byte. `KeyFactory.generatePrivate` then fails to parse the corrupted DER, throwing `IOException → InvalidKeyException → InvalidKeySpecException → LoadError`, crashing Enterprise Search on startup.

Relates https://github.com/elastic/cloud-on-k8s/issues/9473

## Changes

Adds `PKCS8KeyEndsWithWhitespaceByte(keyPEM []byte) (bool, error)` to `test/e2e/test/helper/certs.go` to centralise the last-byte check.

**`TestClientAuthRequiredTransition`** (operator-managed cert): adds a `test.Eventually` step in `esWithLicense.PostCheckSteps` - placed after ES is healthy and the cert-count check confirms the secret exists, but before ENT's `CheckPods` runs. The step lists client cert secrets scoped to the ENT association label, and if the single expected secret has a bad last byte, deletes it so the operator regenerates with a new key.

**`TestClientAuthRequiredCustomCertificate`** (user-provided cert): calls `test.Eventually(f)(t)` immediately before `UserCustomCertificateSecretLifecycleSteps`, regenerating `certPEM`/`keyPEM` until the key is safe. 
