### PR TITLE
[3.5] fix: add missing RBAC for kubernetes metricsets to agent ClusterRoles (#9610)

### DIFF
--- a/config/e2e/monitoring.yaml
+++ b/config/e2e/monitoring.yaml
@@ -395,55 +395,79 @@ kind: ClusterRole
 metadata:
   name: e2e-agent
 rules:
-  - apiGroups: [""] # "" indicates the core API group
-    resources:
-      - namespaces
-      - pods
-      - nodes
-      - nodes/metrics
-      - nodes/proxy
-      - nodes/stats
-      - events
-    verbs:
-      - get
-      - watch
-      - list
-  - apiGroups: ["events.k8s.io"]
-    resources:
-      - events
-    verbs:
-      - get
-      - watch
-      - list
-  - apiGroups: ["batch"]
-    resources:
-      - jobs
-    verbs:
-      - "get"
-      - "list"
-      - "watch"
-  - apiGroups: ["apps"]
-    resources:
-      - deployments
-      - replicasets
-      - statefulsets
-    verbs:
-      - get
-      - list
-      - watch
-  - nonResourceURLs:
-      - /metrics
-    verbs:
-      - get
-      - watch
-      - list
-  - apiGroups: ["coordination.k8s.io"]
-    resources:
-      - leases
-    verbs:
-      - get
-      - create
-      - update
+- apiGroups: [""]
+  resources:
+    - nodes
+    - nodes/metrics
+    - nodes/proxy
+    - nodes/stats
+    - namespaces
+    - pods
+    - services
+    - configmaps
+    - events
+    - persistentvolumes
+    - persistentvolumeclaims
+    - persistentvolumeclaims/status
+  verbs:
+    - get
+    - watch
+    - list
+- apiGroups: ["events.k8s.io"]
+  resources:
+    - events
+  verbs:
+    - get
+    - watch
+    - list
+- apiGroups: ["coordination.k8s.io"]
+  resources:
+    - leases
+  verbs:
+    - get
+    - create
+    - update
+- nonResourceURLs:
+    - /metrics
+  verbs:
+    - get
+    - watch
+    - list
+- nonResourceURLs:
+    - /healthz
+    - /healthz/*
+    - /livez
+    - /livez/*
+    - /metrics/slis
+    - /readyz
+    - /readyz/*
+  verbs:
+    - get
+- apiGroups: ["apps"]
+  resources:
+    - replicasets
+    - deployments
+    - daemonsets
+    - statefulsets
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups: ["batch"]
+  resources:
+    - jobs
+    - cronjobs
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups: ["storage.k8s.io"]
+  resources:
+    - storageclasses
+  verbs:
+    - get
+    - list
+    - watch
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/config/e2e/roles.yaml
+++ b/config/e2e/roles.yaml
@@ -83,10 +83,27 @@ kind: ClusterRole
 metadata:
   name: elastic-agent-fleet
 rules:
-- apiGroups: [""] # "" indicates the core API group
+- apiGroups: [""]
   resources:
+  - nodes
+  - nodes/metrics
+  - nodes/proxy
+  - nodes/stats
   - namespaces
   - pods
+  - services
+  - configmaps
+  - events
+  - persistentvolumes
+  - persistentvolumeclaims
+  - persistentvolumeclaims/status
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups: ["events.k8s.io"]
+  resources:
+  - events
   verbs:
   - get
   - watch
@@ -99,36 +116,43 @@ rules:
   - create
   - update
 - nonResourceURLs:
-  - "/metrics"
+  - /metrics
   verbs:
   - get
   - watch
   - list
-- apiGroups:
-  - apps
+- nonResourceURLs:
+  - /healthz
+  - /healthz/*
+  - /livez
+  - /livez/*
+  - /metrics/slis
+  - /readyz
+  - /readyz/*
+  verbs:
+  - get
+- apiGroups: ["apps"]
   resources:
   - replicasets
+  - deployments
+  - daemonsets
+  - statefulsets
   verbs:
   - get
   - list
   - watch
-- apiGroups:
-  - ""
+- apiGroups: ["batch"]
   resources:
-  - nodes
-  - nodes/metrics
-  - nodes/proxy
-  - nodes/stats
-  - events
+  - jobs
+  - cronjobs
   verbs:
   - get
-  - watch
   - list
-- apiGroups:
-  - events.k8s.io
+  - watch
+- apiGroups: ["storage.k8s.io"]
   resources:
-  - events
+  - storageclasses
   verbs:
   - get
-  - watch
   - list
+  - watch

--- a/config/recipes/autopilot/fleet-kubernetes-integration.yaml
+++ b/config/recipes/autopilot/fleet-kubernetes-integration.yaml
@@ -242,65 +242,77 @@ metadata:
 rules:
 - apiGroups: [""]
   resources:
-  - pods
-  - nodes
-  - namespaces
-  - events
-  - services
-  - configmaps
+    - nodes
+    - nodes/metrics
+    - nodes/proxy
+    - nodes/stats
+    - namespaces
+    - pods
+    - services
+    - configmaps
+    - events
+    - persistentvolumes
+    - persistentvolumeclaims
+    - persistentvolumeclaims/status
   verbs:
-  - get
-  - watch
-  - list
+    - get
+    - watch
+    - list
 - apiGroups: ["events.k8s.io"]
   resources:
-  - events
+    - events
   verbs:
-  - get
-  - watch
-  - list
+    - get
+    - watch
+    - list
 - apiGroups: ["coordination.k8s.io"]
   resources:
-  - leases
+    - leases
   verbs:
-  - get
-  - create
-  - update
+    - get
+    - create
+    - update
 - nonResourceURLs:
-  - "/metrics"
+    - /metrics
   verbs:
-  - get
-- apiGroups: ["extensions"]
+    - get
+    - watch
+    - list
+- nonResourceURLs:
+    - /healthz
+    - /healthz/*
+    - /livez
+    - /livez/*
+    - /metrics/slis
+    - /readyz
+    - /readyz/*
+  verbs:
+    - get
+- apiGroups: ["apps"]
   resources:
     - replicasets
-  verbs: 
-  - "get"
-  - "list"
-  - "watch"
-- apiGroups:
-  - "apps"
-  resources:
-  - statefulsets
-  - deployments
-  - replicasets
+    - deployments
+    - daemonsets
+    - statefulsets
   verbs:
-  - "get"
-  - "list"
-  - "watch"
-- apiGroups:
-  - ""
+    - get
+    - list
+    - watch
+- apiGroups: ["batch"]
   resources:
-  - nodes/stats
+    - jobs
+    - cronjobs
   verbs:
-  - get
-- apiGroups:
-  - "batch"
+    - get
+    - list
+    - watch
+- apiGroups: ["storage.k8s.io"]
   resources:
-  - jobs
+    - storageclasses
   verbs:
-  - "get"
-  - "list"
-  - "watch"
+    - get
+    - list
+    - watch
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/config/recipes/autopilot/kubernetes-integration.yaml
+++ b/config/recipes/autopilot/kubernetes-integration.yaml
@@ -387,65 +387,77 @@ metadata:
 rules:
 - apiGroups: [""]
   resources:
-  - namespaces
-  - persistentvolumes
-  - persistentvolumeclaims
-  - pods
-  - nodes
-  - nodes/metrics
-  - nodes/proxy
-  - nodes/stats
-  - services
-  - events
+    - nodes
+    - nodes/metrics
+    - nodes/proxy
+    - nodes/stats
+    - namespaces
+    - pods
+    - services
+    - configmaps
+    - events
+    - persistentvolumes
+    - persistentvolumeclaims
+    - persistentvolumeclaims/status
   verbs:
-  - get
-  - watch
-  - list
+    - get
+    - watch
+    - list
 - apiGroups: ["events.k8s.io"]
   resources:
-  - events
+    - events
   verbs:
-  - get
-  - watch
-  - list
-- nonResourceURLs:
-  - /metrics
-  verbs:
-  - get
-  - watch
-  - list
+    - get
+    - watch
+    - list
 - apiGroups: ["coordination.k8s.io"]
   resources:
-  - leases
+    - leases
   verbs:
-  - get
-  - create
-  - update
+    - get
+    - create
+    - update
+- nonResourceURLs:
+    - /metrics
+  verbs:
+    - get
+    - watch
+    - list
+- nonResourceURLs:
+    - /healthz
+    - /healthz/*
+    - /livez
+    - /livez/*
+    - /metrics/slis
+    - /readyz
+    - /readyz/*
+  verbs:
+    - get
 - apiGroups: ["apps"]
   resources:
-  - deployments
-  - statefulsets
-  - daemonsets
-  - replicasets
+    - replicasets
+    - deployments
+    - daemonsets
+    - statefulsets
   verbs:
-  - get
-  - list
-  - watch
+    - get
+    - list
+    - watch
 - apiGroups: ["batch"]
   resources:
-  - cronjobs
-  - jobs
+    - jobs
+    - cronjobs
   verbs:
-  - get
-  - list
-  - watch
+    - get
+    - list
+    - watch
 - apiGroups: ["storage.k8s.io"]
   resources:
-  - storageclasses
+    - storageclasses
   verbs:
-  - get
-  - list
-  - watch
+    - get
+    - list
+    - watch
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/config/recipes/elastic-agent/fleet-ingress-setup.yaml
+++ b/config/recipes/elastic-agent/fleet-ingress-setup.yaml
@@ -268,12 +268,18 @@ metadata:
 rules:
 - apiGroups: [""]
   resources:
-  - pods
   - nodes
+  - nodes/metrics
+  - nodes/proxy
+  - nodes/stats
   - namespaces
-  - events
+  - pods
   - services
   - configmaps
+  - events
+  - persistentvolumes
+  - persistentvolumeclaims
+  - persistentvolumeclaims/status
   verbs:
   - get
   - watch
@@ -293,54 +299,46 @@ rules:
   - create
   - update
 - nonResourceURLs:
-  - "/metrics"
+  - /metrics
   verbs:
   - get
-- apiGroups: ["extensions"]
-  resources:
-    - replicasets
-  verbs: 
-  - "get"
-  - "list"
-  - "watch"
-- apiGroups:
-  - "apps"
-  resources:
-  - statefulsets
-  - deployments
-  - replicasets
-  - daemonsets
-  verbs:
-  - "get"
-  - "list"
-  - "watch"
-- apiGroups:
-  - ""
-  resources:
-  - nodes/stats
-  verbs:
-  - get
+  - watch
+  - list
 - nonResourceURLs:
-  - "/metrics"
+  - /healthz
+  - /healthz/*
+  - /livez
+  - /livez/*
+  - /metrics/slis
+  - /readyz
+  - /readyz/*
   verbs:
   - get
-- apiGroups:
-  - "batch"
+- apiGroups: ["apps"]
+  resources:
+  - replicasets
+  - deployments
+  - daemonsets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["batch"]
   resources:
   - jobs
   - cronjobs
   verbs:
-  - "get"
-  - "list"
-  - "watch"
-- apiGroups:
-  - "storage.k8s.io"
+  - get
+  - list
+  - watch
+- apiGroups: ["storage.k8s.io"]
   resources:
   - storageclasses
   verbs:
-  - "get"
-  - "list"
-  - "watch"
+  - get
+  - list
+  - watch
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/config/recipes/elastic-agent/fleet-kubernetes-integration-nonroot.yaml
+++ b/config/recipes/elastic-agent/fleet-kubernetes-integration-nonroot.yaml
@@ -237,25 +237,29 @@ metadata:
 rules:
 - apiGroups: [""]
   resources:
-  - pods
   - nodes
+  - nodes/metrics
+  - nodes/proxy
+  - nodes/stats
   - namespaces
-  - events
+  - pods
   - services
   - configmaps
+  - events
   - persistentvolumes
   - persistentvolumeclaims
+  - persistentvolumeclaims/status
   verbs:
   - get
   - watch
   - list
 - apiGroups: ["events.k8s.io"]
   resources:
-  - events
+    - events
   verbs:
-  - get
-  - watch
-  - list
+    - get
+    - watch
+    - list
 - apiGroups: ["coordination.k8s.io"]
   resources:
   - leases
@@ -264,54 +268,46 @@ rules:
   - create
   - update
 - nonResourceURLs:
-  - "/metrics"
+  - /metrics
   verbs:
   - get
-- apiGroups: ["extensions"]
-  resources:
-    - replicasets
-  verbs: 
-  - "get"
-  - "list"
-  - "watch"
-- apiGroups:
-  - "apps"
-  resources:
-  - statefulsets
-  - deployments
-  - replicasets
-  - daemonsets
-  verbs:
-  - "get"
-  - "list"
-  - "watch"
-- apiGroups:
-  - ""
-  resources:
-  - nodes/stats
-  verbs:
-  - get
+  - watch
+  - list
 - nonResourceURLs:
-  - "/metrics"
+  - /healthz
+  - /healthz/*
+  - /livez
+  - /livez/*
+  - /metrics/slis
+  - /readyz
+  - /readyz/*
   verbs:
   - get
-- apiGroups:
-  - "batch"
+- apiGroups: ["apps"]
+  resources:
+  - replicasets
+  - deployments
+  - daemonsets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["batch"]
   resources:
   - jobs
   - cronjobs
   verbs:
-  - "get"
-  - "list"
-  - "watch"
-- apiGroups:
-  - "storage.k8s.io"
+  - get
+  - list
+  - watch
+- apiGroups: ["storage.k8s.io"]
   resources:
   - storageclasses
   verbs:
-  - "get"
-  - "list"
-  - "watch"
+  - get
+  - list
+  - watch
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
@@ -179,25 +179,29 @@ metadata:
 rules:
 - apiGroups: [""]
   resources:
-  - pods
   - nodes
+  - nodes/metrics
+  - nodes/proxy
+  - nodes/stats
   - namespaces
-  - events
+  - pods
   - services
   - configmaps
+  - events
   - persistentvolumes
   - persistentvolumeclaims
+  - persistentvolumeclaims/status
   verbs:
   - get
   - watch
   - list
 - apiGroups: ["events.k8s.io"]
   resources:
-  - events
+    - events
   verbs:
-  - get
-  - watch
-  - list
+    - get
+    - watch
+    - list
 - apiGroups: ["coordination.k8s.io"]
   resources:
   - leases
@@ -206,54 +210,46 @@ rules:
   - create
   - update
 - nonResourceURLs:
-  - "/metrics"
+  - /metrics
   verbs:
   - get
-- apiGroups: ["extensions"]
-  resources:
-    - replicasets
-  verbs: 
-  - "get"
-  - "list"
-  - "watch"
-- apiGroups:
-  - "apps"
-  resources:
-  - statefulsets
-  - deployments
-  - replicasets
-  - daemonsets
-  verbs:
-  - "get"
-  - "list"
-  - "watch"
-- apiGroups:
-  - ""
-  resources:
-  - nodes/stats
-  verbs:
-  - get
+  - watch
+  - list
 - nonResourceURLs:
-  - "/metrics"
+  - /healthz
+  - /healthz/*
+  - /livez
+  - /livez/*
+  - /metrics/slis
+  - /readyz
+  - /readyz/*
   verbs:
   - get
-- apiGroups:
-  - "batch"
+- apiGroups: ["apps"]
+  resources:
+  - replicasets
+  - deployments
+  - daemonsets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["batch"]
   resources:
   - jobs
   - cronjobs
   verbs:
-  - "get"
-  - "list"
-  - "watch"
-- apiGroups:
-  - "storage.k8s.io"
+  - get
+  - list
+  - watch
+- apiGroups: ["storage.k8s.io"]
   resources:
   - storageclasses
   verbs:
-  - "get"
-  - "list"
-  - "watch"
+  - get
+  - list
+  - watch
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/config/recipes/elastic-agent/kubernetes-integration.yaml
+++ b/config/recipes/elastic-agent/kubernetes-integration.yaml
@@ -128,59 +128,64 @@ kind: ClusterRole
 metadata:
   name: elastic-agent
 rules:
-- apiGroups: [""] # "" indicates the core API group
+- apiGroups: [""]
   resources:
-  - namespaces
-  - pods
   - nodes
   - nodes/metrics
   - nodes/proxy
   - nodes/stats
+  - namespaces
+  - pods
+  - services
+  - configmaps
   - events
   - persistentvolumes
   - persistentvolumeclaims
+  - persistentvolumeclaims/status
   verbs:
   - get
   - watch
   - list
 - apiGroups: ["events.k8s.io"]
   resources:
-  - events
+    - events
+  verbs:
+    - get
+    - watch
+    - list
+- apiGroups: ["coordination.k8s.io"]
+  resources:
+  - leases
   verbs:
   - get
-  - watch
-  - list
+  - create
+  - update
 - nonResourceURLs:
   - /metrics
   verbs:
   - get
   - watch
   - list
-- apiGroups: ["coordination.k8s.io"]
-  resources:
-    - leases
+- nonResourceURLs:
+  - /healthz
+  - /healthz/*
+  - /livez
+  - /livez/*
+  - /metrics/slis
+  - /readyz
+  - /readyz/*
   verbs:
-    - get
-    - create
-    - update
+  - get
 - apiGroups: ["apps"]
   resources:
   - replicasets
+  - deployments
+  - daemonsets
+  - statefulsets
   verbs:
   - get
   - list
   - watch
-- apiGroups:
-  - "apps"
-  resources:
-  - statefulsets
-  - deployments
-  - replicasets
-  - daemonsets
-  verbs:
-  - "get"
-  - "list"
-  - "watch"
 - apiGroups: ["batch"]
   resources:
   - jobs
@@ -189,14 +194,13 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - "storage.k8s.io"
+- apiGroups: ["storage.k8s.io"]
   resources:
   - storageclasses
   verbs:
-  - "get"
-  - "list"
-  - "watch"
+  - get
+  - list
+  - watch
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/deploy/eck-stack/charts/eck-agent/templates/tests/elastic-agent-cluster-role_test.yaml
+++ b/deploy/eck-stack/charts/eck-agent/templates/tests/elastic-agent-cluster-role_test.yaml
@@ -19,12 +19,18 @@ tests:
       - equal:
           path: rules[0].resources
           value:
-          - pods
           - nodes
+          - nodes/metrics
+          - nodes/proxy
+          - nodes/stats
           - namespaces
-          - events
+          - pods
           - services
           - configmaps
+          - events
+          - persistentvolumes
+          - persistentvolumeclaims
+          - persistentvolumeclaims/status
       - equal:
           path: rules[0].verbs
           value:
@@ -74,29 +80,32 @@ tests:
           path: rules[3].verbs
           value:
           - get
+          - watch
+          - list
       - equal:
-          path: rules[4].apiGroups[0]
-          value: "extensions"
-      - equal:
-          path: rules[4].resources
+          path: rules[4].nonResourceURLs
           value:
-          - replicasets
+          - /healthz
+          - /healthz/*
+          - /livez
+          - /livez/*
+          - /metrics/slis
+          - /readyz
+          - /readyz/*
       - equal:
           path: rules[4].verbs
           value:
           - get
-          - list
-          - watch
       - equal:
           path: rules[5].apiGroups[0]
           value: apps
       - equal:
           path: rules[5].resources
           value:
-          - statefulsets
-          - deployments
           - replicasets
+          - deployments
           - daemonsets
+          - statefulsets
       - equal:
           path: rules[5].verbs
           value:
@@ -105,25 +114,27 @@ tests:
           - watch
       - equal:
           path: rules[6].apiGroups[0]
-          value: ""
-      - equal:
-          path: rules[6].resources
-          value:
-          - nodes/stats
-      - equal:
-          path: rules[6].verbs
-          value:
-          - get
-      - equal:
-          path: rules[8].apiGroups[0]
           value: batch
       - equal:
-          path: rules[8].resources
+          path: rules[6].resources
           value:
           - jobs
           - cronjobs
       - equal:
-          path: rules[8].verbs
+          path: rules[6].verbs
+          value:
+          - get
+          - list
+          - watch
+      - equal:
+          path: rules[7].apiGroups[0]
+          value: storage.k8s.io
+      - equal:
+          path: rules[7].resources
+          value:
+          - storageclasses
+      - equal:
+          path: rules[7].verbs
           value:
           - get
           - list

--- a/deploy/eck-stack/charts/eck-agent/values.yaml
+++ b/deploy/eck-stack/charts/eck-agent/values.yaml
@@ -194,23 +194,29 @@ clusterRole:
   rules:
   - apiGroups: [""]
     resources:
-    - pods
     - nodes
+    - nodes/metrics
+    - nodes/proxy
+    - nodes/stats
     - namespaces
-    - events
+    - pods
     - services
     - configmaps
+    - events
+    - persistentvolumes
+    - persistentvolumeclaims
+    - persistentvolumeclaims/status
     verbs:
     - get
     - watch
     - list
   - apiGroups: ["events.k8s.io"]
     resources:
-    - events
+      - events
     verbs:
-    - get
-    - watch
-    - list
+      - get
+      - watch
+      - list
   - apiGroups: ["coordination.k8s.io"]
     resources:
     - leases
@@ -219,54 +225,46 @@ clusterRole:
     - create
     - update
   - nonResourceURLs:
-    - "/metrics"
+    - /metrics
     verbs:
     - get
-  - apiGroups: ["extensions"]
-    resources:
-      - replicasets
-    verbs:
-    - "get"
-    - "list"
-    - "watch"
-  - apiGroups:
-    - "apps"
-    resources:
-    - statefulsets
-    - deployments
-    - replicasets
-    - daemonsets
-    verbs:
-    - "get"
-    - "list"
-    - "watch"
-  - apiGroups:
-    - ""
-    resources:
-    - nodes/stats
-    verbs:
-    - get
+    - watch
+    - list
   - nonResourceURLs:
-    - "/metrics"
+    - /healthz
+    - /healthz/*
+    - /livez
+    - /livez/*
+    - /metrics/slis
+    - /readyz
+    - /readyz/*
     verbs:
     - get
-  - apiGroups:
-    - "batch"
+  - apiGroups: ["apps"]
+    resources:
+    - replicasets
+    - deployments
+    - daemonsets
+    - statefulsets
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups: ["batch"]
     resources:
     - jobs
     - cronjobs
     verbs:
-    - "get"
-    - "list"
-    - "watch"
-  - apiGroups:
-    - "storage.k8s.io"
+    - get
+    - list
+    - watch
+  - apiGroups: ["storage.k8s.io"]
     resources:
     - storageclasses
     verbs:
-    - "get"
-    - "list"
-    - "watch"
+    - get
+    - list
+    - watch
 
 # extraObjects allows injecting additional Kubernetes resources into the chart.
 # These resources will be created/deleted alongside the chart release.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.5`:
 - [fix: add missing RBAC for kubernetes metricsets to agent ClusterRoles (#9610)](https://github.com/elastic/cloud-on-k8s/pull/9610)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)