### PR TITLE
e2e: grant SA the RBAC permissions it needs to create agent ClusterRoles

### DIFF
--- a/config/e2e/rbac.yaml
+++ b/config/e2e/rbac.yaml
@@ -105,6 +105,7 @@ rules:
       - endpoints
       - secrets
       - persistentvolumeclaims
+      - persistentvolumeclaims/status
       - configmaps
       - events
       - serviceaccounts
@@ -208,6 +209,16 @@ rules:
     - get
     - list
     - watch
+  - nonResourceURLs:
+    - /healthz
+    - /healthz/*
+    - /livez
+    - /livez/*
+    - /metrics/slis
+    - /readyz
+    - /readyz/*
+    verbs:
+    - get
     # for Elastic Agent in Fleet mode
   - apiGroups:
     - "coordination.k8s.io"


### PR DESCRIPTION
## Summary

Follow-up to #9610: the commit added new RBAC permissions to the agent ClusterRoles but missed updating the e2e service account's own ClusterRole in config/e2e/rbac.yaml. Kubernetes blocks privilege escalation - a subject cannot grant permissions it doesn't itself hold - causing `TestKubernetesIntegrationRecipe` and `TestFleetKubernetesNonRootIntegrationRecipe` to fail when creating the elastic-agent ClusterRole.

## Changes

Added the two missing permission blocks to the e2e ClusterRole:
- persistentvolumeclaims/status (core API group, get/watch/list)
- nonResourceURLs /healthz/*, /livez/*, /metrics/slis, /readyz/* (get)