### PR TITLE
[3.5] e2e: grant SA the RBAC permissions it needs to create agent ClusterRoles (#9616)

### DIFF
--- a/config/e2e/rbac.yaml
+++ b/config/e2e/rbac.yaml
@@ -105,6 +105,7 @@ rules:
       - endpoints
       - secrets
       - persistentvolumeclaims
+      - persistentvolumeclaims/status
       - configmaps
       - events
       - serviceaccounts
@@ -208,6 +209,16 @@ rules:
     - get
     - list
     - watch
+  - nonResourceURLs:
+    - /healthz
+    - /healthz/*
+    - /livez
+    - /livez/*
+    - /metrics/slis
+    - /readyz
+    - /readyz/*
+    verbs:
+    - get
     # for Elastic Agent in Fleet mode
   - apiGroups:
     - "coordination.k8s.io"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `3.5`:
 - [e2e: grant SA the RBAC permissions it needs to create agent ClusterRoles (#9616)](https://github.com/elastic/cloud-on-k8s/pull/9616)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)