### PR TITLE
e2e: mitigate Manticore strip() bug in Logstash mTLS tests

### DIFF
--- a/test/e2e/logstash/client_auth_test.go
+++ b/test/e2e/logstash/client_auth_test.go
@@ -12,10 +12,15 @@ import (
 	"strconv"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/common/v1"
 	logstashv1alpha1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/logstash/v1alpha1"
+	logstashcontroller "github.com/elastic/cloud-on-k8s/v3/pkg/controller/association/controller"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/certificates"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test"
 	clientauth "github.com/elastic/cloud-on-k8s/v3/test/e2e/test/client-auth"
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test/elasticsearch"
@@ -71,6 +76,39 @@ output {
 	esWithLicense.PostCheckSteps = func(k *test.K8sClient) test.StepList {
 		return test.StepList{
 			clientauth.CheckClientCertificatesCountStep(k, namespace, esBuilder.Elasticsearch.Name, 1),
+			{
+				// Delete the Logstash client cert secret if its PKCS#8 key's last DER byte falls in
+				// the ASCII whitespace range. Logstash crashes on startup with InvalidKeySpecException
+				// because manticore calls String#strip on the raw binary DER payload, truncating the
+				// key by one byte. Fixed in manticore v0.9.2 (cheald/manticore#113, #119); Logstash
+				// 8.18.x bundles v0.9.1. Deleting forces the operator to regenerate with a safe key.
+				Name: "Delete Logstash client certificate secret if PKCS#8 key last DER byte is ASCII whitespace",
+				Test: test.Eventually(func() error {
+					var secretList corev1.SecretList
+					if err := k.Client.List(t.Context(), &secretList,
+						k8sclient.InNamespace(namespace),
+						k8sclient.MatchingLabels{
+							labels.ClientCertificateLabelName:               "true",
+							logstashcontroller.LogstashAssociationLabelName: lsBuilder.Logstash.Name,
+						},
+					); err != nil {
+						return err
+					}
+					if len(secretList.Items) != 1 {
+						return fmt.Errorf("expected 1 Logstash client cert secret, got %d", len(secretList.Items))
+					}
+					secret := secretList.Items[0]
+					whitespaceByteAtEnd, err := helper.PKCS8KeyEndsWithWhitespaceByte(secret.Data[certificates.KeyFileName])
+					if err != nil {
+						return err
+					}
+					if whitespaceByteAtEnd {
+						_ = k.Client.Delete(t.Context(), &secret)
+						return fmt.Errorf("client cert secret %s has trailing whitespace byte; deleted to force regeneration", secret.Name)
+					}
+					return nil
+				}),
+			},
 			lsBuilder.CheckMetricsRequest(k,
 				logstash.Request{Name: "stats events", Path: "/_node/stats/events"},
 				logstash.Want{
@@ -159,7 +197,21 @@ func TestClientAuthRequiredCustomCertificate(t *testing.T) {
 	namespace := test.Ctx().ManagedNamespace(0)
 	userCertSecretName := name + "-user-client-cert"
 
-	certPEM, keyPEM := helper.GenerateSelfSignedClientCertPKCS8(t, name)
+	var certPEM, keyPEM []byte
+	test.Eventually(func() error {
+		certPEM, keyPEM = helper.GenerateSelfSignedClientCertPKCS8(t, name)
+		whitespaceByteAtEnd, err := helper.PKCS8KeyEndsWithWhitespaceByte(keyPEM)
+		if err != nil {
+			return err
+		}
+		if whitespaceByteAtEnd {
+			// Manticore v0.9.1 calls String#strip on the raw binary DER payload, truncating the
+			// key if its last byte is ASCII whitespace and causing InvalidKeySpecException.
+			// Fixed in manticore v0.9.2 (cheald/manticore#113, #119). Regenerate until safe.
+			return fmt.Errorf("regenerating client cert: PKCS#8 key ends with ASCII whitespace byte")
+		}
+		return nil
+	})(t)
 
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources).


### PR DESCRIPTION
## Summary

`TestClientAuthRequiredTransition` and `TestClientAuthRequiredCustomCertificate` are flaky in Logstash 8.10–8.18 and 9.0 due to a bug in manticore 0.9.1, the HTTP client library bundled by those Logstash versions ([CI run](https://buildkite.com/elastic/cloud-on-k8s-operator/builds/15473#019f7fd6-1d8b-461f-8466-451b207b2f3b)).

In `setup_key_store`, manticore calls Ruby's `String#strip` on the raw binary DER payload decoded from the PKCS#8 PEM key. `strip` removes leading/trailing bytes in the ASCII whitespace range (`\x09`–`\x0d`, `\x20`). For ~2.3% of RSA-2048 keys the last byte of the DER encoding falls in that range, causing `strip` to truncate the structure by one byte. `KeyFactory.generatePrivate` then fails to parse the corrupted DER, throwing `InvalidKeySpecException → pipeline crash → events.out = 0` for the entire 15-minute retry window.

The bug was confirmed against the captured diagnostics archive: the operator-generated Logstash client cert had last DER byte `0x0b` (`\v`), the SEQUENCE length declared 1216 bytes, exactly matching the actual DER — valid as-is, broken after `strip`.

The fix is in manticore 0.9.2 (cheald/manticore#113, #119, released 2025-10-20); Logstash 8.19 and 9.1+ have already picked it up.

## Changes

Applies the same mitigation used for Enterprise Search (#9611) to both Logstash mTLS tests:

- **`TestClientAuthRequiredTransition`** — adds a `PostCheckSteps` step that lists the operator-generated Logstash client cert secret by label, checks whether the last byte of its PKCS#8 DER payload is ASCII whitespace, and deletes it if so to force the operator to regenerate a safe key.
- **`TestClientAuthRequiredCustomCertificate`** — wraps `GenerateSelfSignedClientCertPKCS8` in an `Eventually` loop that regenerates the user-provided cert until its last DER byte is outside the ASCII whitespace range before the secret is created.

## Affected versions

| Logstash | Manticore | Affected |
|---|---|---|
| 8.10 – 8.18 | 0.9.1-java | Yes |
| 9.0 | 0.9.1-java | Yes |
| 8.19+ | 0.9.2-java | No |
| 9.1+ | 0.9.2-java | No |
