### PR TITLE
[3.5] e2e: NamespaceSelector add more logs (#9622)

### DIFF
--- a/test/e2e/namespace_selector/namespace_selector_test.go
+++ b/test/e2e/namespace_selector/namespace_selector_test.go
@@ -7,14 +7,15 @@
 package namespace_selector
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
-
 	"k8s.io/apimachinery/pkg/types"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/common/v1"
 	kbv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/kibana/v1"
@@ -300,22 +301,25 @@ func registerNamespaceSelectorCleanup(t *testing.T, k *test.K8sClient, labelToDe
 	t.Helper()
 	t.Cleanup(func() {
 		// restore original config
+		logf.Log.Info("Restoring operator config")
 		test.Eventually(func() error {
-			if err := helper.SetOperatorConfig(k.Client, originalConfig); err != nil {
-				t.Logf("WARNING: failed to restore operator config: %v", err)
+			if err := helper.SetOperatorConfig(context.Background(), k.Client, originalConfig); err != nil {
+				logf.Log.Error(err, "failed to restore operator config, retrying...")
 				return err
 			}
+			logf.Log.Info("operator config was restored")
 			return nil
 		})(t)
 
 		// Ensure that the operator restarts.
+		logf.Log.Info("Waiting for operator restart after config change")
 		waitForOperatorRestart(k, restartCount, 1*time.Minute)(t)
 
 		// Clean up the namespace labels only after the operator config has been successfully restored,
 		// so the operator is back to its original (non namespace-selector) configuration before the
 		// labels these tests rely on are removed.
-		if err := helper.DeleteNamespaceLabel(t.Context(), k.Client, labelToDelete, namespaces...); err != nil {
-			t.Logf("WARNING: failed to delete namespaces labels: %s", err.Error())
+		if err := helper.DeleteNamespaceLabel(context.Background(), k.Client, labelToDelete, namespaces...); err != nil {
+			logf.Log.Error(err, "failed to delete namespaces labels")
 		}
 	})
 }
@@ -324,22 +328,26 @@ func registerNamespaceSelectorCleanup(t *testing.T, k *test.K8sClient, labelToDe
 // only when chaos job is deployed.
 func waitForOperatorRestart(k *test.K8sClient, restartCount *int32, chaosSleepDuration time.Duration) func(*testing.T) {
 	return func(t *testing.T) {
-		test.Eventually(func() error {
-			if test.Ctx().DeployChaosJob {
-				// In chaos mode restart counting is unreliable, so we cannot wait for a restart-count increment.
-				// Instead just wait and hope the ECK operator has restarted.
-				time.Sleep(chaosSleepDuration)
-				return nil
-			}
+		test.UntilSuccess(
+			func() error {
+				if test.Ctx().DeployChaosJob {
+					// In chaos mode restart counting is unreliable, so we cannot wait for a restart-count increment.
+					// Instead just wait and hope the ECK operator has restarted.
+					time.Sleep(chaosSleepDuration)
+					return nil
+				}
 
-			newCount, err := helper.OperatorRestartCount(k)
-			if err != nil {
-				return err
-			}
-			if newCount <= *restartCount {
-				return fmt.Errorf("waiting for operator restart after (current restarts: %d)", newCount)
-			}
-			return nil
-		})(t)
+				newCount, err := helper.OperatorRestartCount(k)
+				if err != nil {
+					return err
+				}
+				if newCount <= *restartCount {
+					return fmt.Errorf("waiting for operator restart after (current restarts: %d)", newCount)
+				}
+				return nil
+			},
+			// kubelet ConfigMap propagation + file watcher poll (15s) + pod recreation
+			3*time.Minute,
+		)(t)
 	}
 }

--- a/test/e2e/test/helper/config.go
+++ b/test/e2e/test/helper/config.go
@@ -44,7 +44,7 @@ func UpdateOperatorConfig(k k8s.Client, f func(map[string]any)) error {
 	return k.Update(context.Background(), cm)
 }
 
-func SetOperatorConfig(k k8s.Client, cnf map[string]any) error {
+func SetOperatorConfig(ctx context.Context, k k8s.Client, cnf map[string]any) error {
 	cm, _, err := getOperatorConfig(k)
 	if err != nil {
 		return err
@@ -55,7 +55,7 @@ func SetOperatorConfig(k k8s.Client, cnf map[string]any) error {
 		return err
 	}
 	cm.Data["eck.yaml"] = string(bytes)
-	return k.Update(context.Background(), cm)
+	return k.Update(ctx, cm)
 }
 
 // GetOperatorConfig returns the operator configuration (the eck.yaml entry of the operator

--- a/test/e2e/test/helper/namespace.go
+++ b/test/e2e/test/helper/namespace.go
@@ -19,7 +19,7 @@ import (
 // SetNamespaceLabel sets the given label on the namespace identified by name.
 func SetNamespaceLabel(ctx context.Context, k k8s.Client, name, key, value string) error {
 	var ns corev1.Namespace
-	if err := k.Get(context.Background(), types.NamespacedName{Name: name}, &ns); err != nil {
+	if err := k.Get(ctx, types.NamespacedName{Name: name}, &ns); err != nil {
 		return err
 	}
 	if ns.Labels == nil {
@@ -33,9 +33,9 @@ func DeleteNamespaceLabel(ctx context.Context, k k8s.Client, labelName string, n
 	errs := make([]error, 0, len(namespacesNames))
 	for _, nsName := range namespacesNames {
 		var ns corev1.Namespace
-		if err := k.Get(context.Background(), types.NamespacedName{Name: nsName}, &ns); err == nil {
+		if err := k.Get(ctx, types.NamespacedName{Name: nsName}, &ns); err == nil {
 			delete(ns.Labels, labelName)
-			errs = append(errs, k.Update(context.Background(), &ns))
+			errs = append(errs, k.Update(ctx, &ns))
 		}
 	}
 


### PR DESCRIPTION
backport of https://github.com/elastic/cloud-on-k8s/pull/9622