### PR TITLE
bump docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent

### DIFF
--- a/.buildkite/Makefile
+++ b/.buildkite/Makefile
@@ -5,7 +5,7 @@
 # This Makefile is used to run the buildkite agent in virtual machines when Docker access is required.
 
 # If you change the CI_IMAGE format, make sure the regex in .github/renovate.json still matches.
-CI_IMAGE               ?= docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1d41d937393794f1b55b5beb14d8040905cb3963efb7da05e2781d4aaef591f7
+CI_IMAGE               ?= docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1faa746580da83750c129c62f1a7a9e1c7ebccb5526f4bbf4bcd0fc05a997699
 ROOT_DIR               := $(CURDIR)/..
 GO_MOUNT_PATH          ?= /go/src/github.com/elastic/cloud-on-k8s
 export VAULT_ROOT_PATH = secret/ci/elastic-cloud-on-k8s

--- a/.buildkite/e2e/pipeline-gen/pipeline.tpl.yaml
+++ b/.buildkite/e2e/pipeline-gen/pipeline.tpl.yaml
@@ -33,7 +33,7 @@ steps:
       machineType: "{{ $.K8sInDockerMachineType }}"
       {{- end }}
       {{- else }}
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1d41d937393794f1b55b5beb14d8040905cb3963efb7da05e2781d4aaef591f7
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1faa746580da83750c129c62f1a7a9e1c7ebccb5526f4bbf4bcd0fc05a997699
       memory: "5G"
       {{- end }}
 
@@ -85,7 +85,7 @@ steps:
       diskSizeGb: 200
       {{- end }}
       {{- else }}
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1d41d937393794f1b55b5beb14d8040905cb3963efb7da05e2781d4aaef591f7
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1faa746580da83750c129c62f1a7a9e1c7ebccb5526f4bbf4bcd0fc05a997699
       memory: "4G"
       {{- end }}
 
@@ -121,7 +121,7 @@ steps:
         {{- if not $test.Dind }}
           - make run-deployer
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1d41d937393794f1b55b5beb14d8040905cb3963efb7da05e2781d4aaef591f7
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1faa746580da83750c129c62f1a7a9e1c7ebccb5526f4bbf4bcd0fc05a997699
           memory: "4G"
         {{- else }}
           - make -C .buildkite TARGET="run-deployer" ci
@@ -144,5 +144,5 @@ steps:
       - ".buildkite/e2e/reporter/*.md"
       - ".buildkite/e2e/reporter/*.yml"
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1d41d937393794f1b55b5beb14d8040905cb3963efb7da05e2781d4aaef591f7
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1faa746580da83750c129c62f1a7a9e1c7ebccb5526f4bbf4bcd0fc05a997699
       memory: "2G"

--- a/.buildkite/e2e/reporter/templates/notify-failures.tpl.yml
+++ b/.buildkite/e2e/reporter/templates/notify-failures.tpl.yml
@@ -4,7 +4,7 @@ steps:
   - label: "{{ .ShortFailuresCount }} failure(s)"
     command: exit {{ .ShortFailuresCount }}
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1d41d937393794f1b55b5beb14d8040905cb3963efb7da05e2781d4aaef591f7
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1faa746580da83750c129c62f1a7a9e1c7ebccb5526f4bbf4bcd0fc05a997699
       memory: "2G"
 
   # notify e2e tests failures for the main branch and tags
@@ -13,7 +13,7 @@ steps:
     if: build.branch == "main" || build.tag != null
     command: echo "notify"
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1d41d937393794f1b55b5beb14d8040905cb3963efb7da05e2781d4aaef591f7
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1faa746580da83750c129c62f1a7a9e1c7ebccb5526f4bbf4bcd0fc05a997699
       memory: "2G"
 
     notify:

--- a/.buildkite/pipeline-e2e-clusters-cleanup.yml
+++ b/.buildkite/pipeline-e2e-clusters-cleanup.yml
@@ -10,7 +10,7 @@ steps:
       - make build-deployer
       - buildkite-agent artifact upload hack/deployer/deployer
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1d41d937393794f1b55b5beb14d8040905cb3963efb7da05e2781d4aaef591f7
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1faa746580da83750c129c62f1a7a9e1c7ebccb5526f4bbf4bcd0fc05a997699
       memory: 2G
 
   - label: ":broom: e2e test cluster cleanup gke"
@@ -26,7 +26,7 @@ steps:
       - chmod u+x /usr/local/hack/deployer/deployer
       - /usr/local/hack/deployer/deployer cleanup --plans-file hack/deployer/config/plans.yml --cluster-prefix $${E2E_TEST_CLUSTER_PREFIX} --config-file deployer-config.yml
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1d41d937393794f1b55b5beb14d8040905cb3963efb7da05e2781d4aaef591f7
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1faa746580da83750c129c62f1a7a9e1c7ebccb5526f4bbf4bcd0fc05a997699
       memory: 2G
 
   - label: ":broom: e2e test cluster cleanup aks"
@@ -55,7 +55,7 @@ steps:
       - chmod u+x /usr/local/hack/deployer/deployer
       - /usr/local/hack/deployer/deployer cleanup --plans-file hack/deployer/config/plans.yml --cluster-prefix $${E2E_TEST_CLUSTER_PREFIX} --config-file deployer-config.yml
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1d41d937393794f1b55b5beb14d8040905cb3963efb7da05e2781d4aaef591f7
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1faa746580da83750c129c62f1a7a9e1c7ebccb5526f4bbf4bcd0fc05a997699
       memory: 2G
 
   - label: ":broom: e2e test cluster cleanup eks-arm"
@@ -71,7 +71,7 @@ steps:
       - chmod u+x /usr/local/hack/deployer/deployer
       - /usr/local/hack/deployer/deployer cleanup --plans-file hack/deployer/config/plans.yml --cluster-prefix $${E2E_TEST_CLUSTER_PREFIX} --config-file deployer-config.yml
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1d41d937393794f1b55b5beb14d8040905cb3963efb7da05e2781d4aaef591f7
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1faa746580da83750c129c62f1a7a9e1c7ebccb5526f4bbf4bcd0fc05a997699
       memory: 2G
 
   - label: ":broom: e2e test cluster cleanup ocp"

--- a/.buildkite/pipeline-e2e-tests.yml
+++ b/.buildkite/pipeline-e2e-tests.yml
@@ -17,7 +17,7 @@ steps:
               E2E_PROVIDER: gke
           DEF
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1d41d937393794f1b55b5beb14d8040905cb3963efb7da05e2781d4aaef591f7
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1faa746580da83750c129c62f1a7a9e1c7ebccb5526f4bbf4bcd0fc05a997699
           memory: "2G"
 
       # for nightly builds from main
@@ -30,7 +30,7 @@ steps:
           cd .buildkite/e2e/pipeline-gen && go build -o pipeline-gen
           cat ../nightly-main-matrix.yaml | ./pipeline-gen | buildkite-agent pipeline upload
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1d41d937393794f1b55b5beb14d8040905cb3963efb7da05e2781d4aaef591f7
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1faa746580da83750c129c62f1a7a9e1c7ebccb5526f4bbf4bcd0fc05a997699
           memory: "2G"
 
       # for all tags
@@ -41,5 +41,5 @@ steps:
           cd .buildkite/e2e/pipeline-gen && go build -o pipeline-gen
           cat ../release-branch-matrix.yaml | ./pipeline-gen | buildkite-agent pipeline upload
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1d41d937393794f1b55b5beb14d8040905cb3963efb7da05e2781d4aaef591f7
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1faa746580da83750c129c62f1a7a9e1c7ebccb5526f4bbf4bcd0fc05a997699
           memory: "2G"

--- a/.buildkite/pipeline-release-helm.yml
+++ b/.buildkite/pipeline-release-helm.yml
@@ -11,7 +11,7 @@ steps:
       - make build
       - buildkite-agent artifact upload bin/releaser
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1d41d937393794f1b55b5beb14d8040905cb3963efb7da05e2781d4aaef591f7
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1faa746580da83750c129c62f1a7a9e1c7ebccb5526f4bbf4bcd0fc05a997699
       memory: "2G"
 
   - label: "operator dev helm chart"
@@ -30,7 +30,7 @@ steps:
       - chmod u+x /usr/local/bin/releaser
       - releaser --env=dev --charts-dir=deploy/eck-operator
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1d41d937393794f1b55b5beb14d8040905cb3963efb7da05e2781d4aaef591f7
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1faa746580da83750c129c62f1a7a9e1c7ebccb5526f4bbf4bcd0fc05a997699
       memory: "2G"
 
   - label: "eck-stack dev helm charts"
@@ -50,7 +50,7 @@ steps:
       - chmod u+x /usr/local/bin/releaser
       - releaser --env=dev --charts-dir=deploy/eck-stack
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1d41d937393794f1b55b5beb14d8040905cb3963efb7da05e2781d4aaef591f7
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1faa746580da83750c129c62f1a7a9e1c7ebccb5526f4bbf4bcd0fc05a997699
       memory: "2G"
 
   - label: "operator prod helm chart"
@@ -67,7 +67,7 @@ steps:
       - chmod u+x /usr/local/bin/releaser
       - releaser --env=prod --charts-dir=deploy/eck-operator
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1d41d937393794f1b55b5beb14d8040905cb3963efb7da05e2781d4aaef591f7
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1faa746580da83750c129c62f1a7a9e1c7ebccb5526f4bbf4bcd0fc05a997699
       memory: "2G"
 
   - label: "eck-stack prod helm charts"
@@ -83,5 +83,5 @@ steps:
       - chmod u+x /usr/local/bin/releaser
       - releaser --env=prod --charts-dir=deploy/eck-stack
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1d41d937393794f1b55b5beb14d8040905cb3963efb7da05e2781d4aaef591f7
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1faa746580da83750c129c62f1a7a9e1c7ebccb5526f4bbf4bcd0fc05a997699
       memory: "2G"

--- a/.buildkite/pipeline-release-redhat.yml
+++ b/.buildkite/pipeline-release-redhat.yml
@@ -7,7 +7,7 @@ steps:
       - make build
       - buildkite-agent artifact upload bin/operatorhub
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1d41d937393794f1b55b5beb14d8040905cb3963efb7da05e2781d4aaef591f7
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1faa746580da83750c129c62f1a7a9e1c7ebccb5526f4bbf4bcd0fc05a997699
       memory: "4G"
 
   - label: ":docker: push container"
@@ -20,7 +20,7 @@ steps:
         cd hack/operatorhub
         operatorhub container push
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1d41d937393794f1b55b5beb14d8040905cb3963efb7da05e2781d4aaef591f7
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1faa746580da83750c129c62f1a7a9e1c7ebccb5526f4bbf4bcd0fc05a997699
       memory: "4G"
 
   - label: ":docker: preflight container check"
@@ -32,7 +32,7 @@ steps:
     commands:
       - .buildkite/scripts/release/redhat-preflight.sh
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1d41d937393794f1b55b5beb14d8040905cb3963efb7da05e2781d4aaef591f7
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1faa746580da83750c129c62f1a7a9e1c7ebccb5526f4bbf4bcd0fc05a997699
       memory: "4G"
 
   - label: ":docker: publish container"
@@ -47,7 +47,7 @@ steps:
         cd hack/operatorhub
         operatorhub container publish
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1d41d937393794f1b55b5beb14d8040905cb3963efb7da05e2781d4aaef591f7
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1faa746580da83750c129c62f1a7a9e1c7ebccb5526f4bbf4bcd0fc05a997699
       memory: "4G"
 
   - label: ":redhat: generate and create-pr"
@@ -62,5 +62,5 @@ steps:
         operatorhub generate-manifests
         operatorhub bundle create-pr
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1d41d937393794f1b55b5beb14d8040905cb3963efb7da05e2781d4aaef591f7
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1faa746580da83750c129c62f1a7a9e1c7ebccb5526f4bbf4bcd0fc05a997699
       memory: "4G"

--- a/.buildkite/pipeline-release.yml
+++ b/.buildkite/pipeline-release.yml
@@ -10,7 +10,7 @@ steps:
         commands:
           - .buildkite/scripts/release/k8s-manifests.sh
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1d41d937393794f1b55b5beb14d8040905cb3963efb7da05e2781d4aaef591f7
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1faa746580da83750c129c62f1a7a9e1c7ebccb5526f4bbf4bcd0fc05a997699
           memory: "2G"
 
       - label: "copy images to dockerhub"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,14 +9,14 @@ steps:
       - label: ":go: lint"
         command: "make lint check-local-changes"
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1d41d937393794f1b55b5beb14d8040905cb3963efb7da05e2781d4aaef591f7
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1faa746580da83750c129c62f1a7a9e1c7ebccb5526f4bbf4bcd0fc05a997699
           cpu: "6"
           memory: "7G"
 
       - label: ":go: generate"
         command: "make generate check-local-changes"
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1d41d937393794f1b55b5beb14d8040905cb3963efb7da05e2781d4aaef591f7
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1faa746580da83750c129c62f1a7a9e1c7ebccb5526f4bbf4bcd0fc05a997699
           cpu: "4"
           memory: "4G"
 
@@ -25,7 +25,7 @@ steps:
           - "make check-license-header check-predicates shellcheck reattach-pv"
           - "make -C hack/helm/release build"
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1d41d937393794f1b55b5beb14d8040905cb3963efb7da05e2781d4aaef591f7
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1faa746580da83750c129c62f1a7a9e1c7ebccb5526f4bbf4bcd0fc05a997699
           cpu: "4"
           memory: "4G"
 
@@ -35,28 +35,28 @@ steps:
       - label: ":go: unit-tests"
         command: "make unit-xml"
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1d41d937393794f1b55b5beb14d8040905cb3963efb7da05e2781d4aaef591f7
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1faa746580da83750c129c62f1a7a9e1c7ebccb5526f4bbf4bcd0fc05a997699
           cpu: "4"
           memory: "4G"
 
       - label: ":go: integration-tests"
         command: "make integration-xml"
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1d41d937393794f1b55b5beb14d8040905cb3963efb7da05e2781d4aaef591f7
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1faa746580da83750c129c62f1a7a9e1c7ebccb5526f4bbf4bcd0fc05a997699
           cpu: "4"
           memory: "4G"
 
       - label: ":go: manifest-gen-tests"
         command: "make manifest-gen-test"
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1d41d937393794f1b55b5beb14d8040905cb3963efb7da05e2781d4aaef591f7
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1faa746580da83750c129c62f1a7a9e1c7ebccb5526f4bbf4bcd0fc05a997699
           cpu: "4"
           memory: "2G"
 
       - label: ":go: helm-tests"
         command: "make helm-test"
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1d41d937393794f1b55b5beb14d8040905cb3963efb7da05e2781d4aaef591f7
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1faa746580da83750c129c62f1a7a9e1c7ebccb5526f4bbf4bcd0fc05a997699
           cpu: "4"
           memory: "2G"
 
@@ -125,7 +125,7 @@ steps:
           E2E_SKIP_CLEANUP: true
       DEF
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1d41d937393794f1b55b5beb14d8040905cb3963efb7da05e2781d4aaef591f7
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1faa746580da83750c129c62f1a7a9e1c7ebccb5526f4bbf4bcd0fc05a997699
       memory: "2G"
 
   # for PR comment
@@ -138,14 +138,14 @@ steps:
       read -ra args <<< "$$GITHUB_PR_COMMENT_VAR_ARGS"
       ./pipeline-gen "$${args[@]}" | tee /dev/stderr | buildkite-agent pipeline upload
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1d41d937393794f1b55b5beb14d8040905cb3963efb7da05e2781d4aaef591f7
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1faa746580da83750c129c62f1a7a9e1c7ebccb5526f4bbf4bcd0fc05a997699
       memory: "2G"
 
   # for the main branch (merge and nightly) and tags
   - label: ":buildkite:"
     command: buildkite-agent pipeline upload .buildkite/pipeline-e2e-tests.yml
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1d41d937393794f1b55b5beb14d8040905cb3963efb7da05e2781d4aaef591f7
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1faa746580da83750c129c62f1a7a9e1c7ebccb5526f4bbf4bcd0fc05a997699
       memory: "2G"
 
   # ----------
@@ -178,7 +178,7 @@ steps:
         done
       ) | buildkite-agent pipeline upload
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1d41d937393794f1b55b5beb14d8040905cb3963efb7da05e2781d4aaef591f7
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1faa746580da83750c129c62f1a7a9e1c7ebccb5526f4bbf4bcd0fc05a997699
       memory: "256Mi"
 
   - label: ":buildkite:"
@@ -186,7 +186,7 @@ steps:
       - "operator-image-build"
     command: buildkite-agent pipeline upload .buildkite/pipeline-release.yml
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1d41d937393794f1b55b5beb14d8040905cb3963efb7da05e2781d4aaef591f7
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1faa746580da83750c129c62f1a7a9e1c7ebccb5526f4bbf4bcd0fc05a997699
       memory: "2G"
 
   - group: sign images
@@ -203,7 +203,7 @@ steps:
           - .buildkite/scripts/build/image-signing.sh
           - buildkite-agent artifact upload eck-container-images-digest.txt
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1d41d937393794f1b55b5beb14d8040905cb3963efb7da05e2781d4aaef591f7
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:1faa746580da83750c129c62f1a7a9e1c7ebccb5526f4bbf4bcd0fc05a997699
           cpu: "1"
           memory: "1G"
       - label: ":key: sign images"

--- a/.buildkite/scripts/test/trigger-bk-e2e-cleanup.sh
+++ b/.buildkite/scripts/test/trigger-bk-e2e-cleanup.sh
@@ -13,7 +13,7 @@ set -eu
 : "$BK_TOKEN"
 : "$GH_USERNAME"
 
-curl "https://api.buildkite.com/v2/organizations/elastic/pipelines/cloud-on-k8s-operator-e2e-cluster-cleanup/builds" -XPOST \
+curl "https://api.buildkite.com/v2/organizations/elastic/pipelines/cloud-on-k8s-operator-e2e-clusters-cleanup/builds" -XPOST \
     -H "Authorization: Bearer $BK_TOKEN" -d '
 {
     "commit": "HEAD",


### PR DESCRIPTION
redhat-openshift-ecosystem/openshift-preflight	patch	1.19.1 → 1.19.2