### PR TITLE
[buildkite] Per-suite retryable groups in the e2e pipeline

### DIFF
--- a/.buildkite/e2e/pipeline-gen/main.go
+++ b/.buildkite/e2e/pipeline-gen/main.go
@@ -131,7 +131,6 @@ func main() {
 
 	// build a flat list of the tests to run
 	tests := make([]TestsSuiteRun, 0)
-	cleanup := false
 	for i := range groups {
 		if groups[i].Mixed == nil {
 			groups[i].Mixed = []Env{{}}
@@ -141,7 +140,6 @@ func main() {
 			handleErr("Failed to create tests suite", err)
 
 			tests = append(tests, ts)
-			cleanup = cleanup || ts.Cleanup
 		}
 	}
 
@@ -160,7 +158,6 @@ func main() {
 	handleErr("Failed to parse template", err)
 
 	err = tpl.Execute(os.Stdout, map[string]any{
-		"Cleanup":                cleanup,
 		"Tests":                  tests,
 		"K8sInDockerMachineType": K8sInDockerMachineType,
 	})

--- a/.buildkite/e2e/pipeline-gen/pipeline.tpl.yaml
+++ b/.buildkite/e2e/pipeline-gen/pipeline.tpl.yaml
@@ -6,107 +6,111 @@ steps:
 
 {{- range $test := .Tests }}
 
-  {{- if $test.RemoteKubeconfig }}
-
-  # create k8s cluster
-  - label: ":k8s: {{ $test.Name }}"
-    key: "e2e-cluster-{{ $test.SlugName }}"
-
-    env:
-      {{- range $key, $val := $test.Env }}
-      {{$key}}: "{{$val}}"
-      {{- end }}
-
-    commands:
-      - .buildkite/scripts/test/set-deployer-config.sh
-      {{- if $test.Dind }}
-      - make -C .buildkite TARGET="run-deployer" ci
-      {{- else }}
-      - make run-deployer
-      {{- end }}
-
-    agents:
-      {{- if $test.Dind }}
-      provider: "gcp"
-      image: "family/core-ubuntu-2204"
-      {{- if or (eq $test.Provider "kind") (eq $test.Provider "k3d") }}
-      machineType: "{{ $.K8sInDockerMachineType }}"
-      {{- end }}
-      {{- else }}
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:8aeecfdfe9b9d178a6087e5158946cc5d1ca2b3a15f24c2579a9730f30caa1bb
-      memory: "5G"
-      {{- end }}
-
-  {{- end }}
-
-  # create k8s cluster and run e2e tests, or just run e2e tests (if RemoteKubeconfig)
-  {{- if $test.RemoteKubeconfig }}
-  - label: ":go: {{ $test.Name }}"
-  {{- else }}
-  - label: ":k8s: :go: {{ $test.Name }}"
-  {{- end }}
-    key: "e2e-{{ $test.SlugName }}"
-
-    {{- if $test.RemoteKubeconfig }}
-    depends_on:
-      - "e2e-cluster-{{ $test.SlugName }}"
-      # let's be optimistic and run the tests without dependency on the images build
-    {{- end }}
-
-    env:
-      {{- range $key, $val := $test.Env }}
-      {{$key}}: "{{$val}}"
-      {{- end }}
-
-    commands:
-      {{- range $key, $val := $test.Env }}
-      - echo "{{$key}}={{$val}}" >> .env
-      {{- end }}
-
-      - .buildkite/scripts/test/set-deployer-config.sh
-
-      {{- $deployerCommand := "run-deployer" }}
-      {{- if $test.RemoteKubeconfig }}
-        {{- $deployerCommand = "set-kubeconfig" }}
-      {{- end }}
-
-      {{- if $test.Dind }}
-      - make -C .buildkite TARGET="{{ $deployerCommand }} e2e-run" ci
-      {{- else }}
-      - make {{ $deployerCommand }} e2e-run
-      {{- end }}
-
-    agents:
-      {{- if $test.Dind }}
-      provider: "gcp"
-      image: "family/core-ubuntu-2204"
-      {{- if or (eq $test.Provider "kind") (eq $test.Provider "k3d") }}
-      machineType: "{{ $.K8sInDockerMachineType }}"
-      diskSizeGb: 200
-      {{- end }}
-      {{- else }}
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:8aeecfdfe9b9d178a6087e5158946cc5d1ca2b3a15f24c2579a9730f30caa1bb
-      memory: "4G"
-      {{- end }}
-
-    artifact_paths:
-      - e2e-tests-*.json
-      - "eck-diagnostic*.zip"
-
-{{- end }}
-
-{{- if .Cleanup }}
-
-  - group: ":broom:"
+  # self-contained suite: create k8s cluster, run e2e tests, delete k8s cluster
+  - group: "{{ $test.Name }}"
     steps:
 
-{{- end }}
+    {{- if $test.RemoteKubeconfig }}
 
-{{- range $test := .Tests }}
+      # create k8s cluster
+      - label: ":k8s: create cluster {{ $test.Name }}"
+        key: "e2e-cluster-{{ $test.SlugName }}"
+
+        # allow re-running from the UI even after it passed
+        retry:
+          manual:
+            permit_on_passed: true
+
+        env:
+          {{- range $key, $val := $test.Env }}
+          {{$key}}: "{{$val}}"
+          {{- end }}
+
+        commands:
+          - .buildkite/scripts/test/set-deployer-config.sh
+          {{- if $test.Dind }}
+          - make -C .buildkite TARGET="run-deployer" ci
+          {{- else }}
+          - make run-deployer
+          {{- end }}
+
+        agents:
+          {{- if $test.Dind }}
+          provider: "gcp"
+          image: "family/core-ubuntu-2204"
+          {{- if or (eq $test.Provider "kind") (eq $test.Provider "k3d") }}
+          machineType: "{{ $.K8sInDockerMachineType }}"
+          {{- end }}
+          {{- else }}
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:8aeecfdfe9b9d178a6087e5158946cc5d1ca2b3a15f24c2579a9730f30caa1bb
+          memory: "5G"
+          {{- end }}
+
+    {{- end }}
+
+      # create k8s cluster and run e2e tests, or just run e2e tests (if RemoteKubeconfig)
+      {{- if $test.RemoteKubeconfig }}
+      - label: ":go: run e2e tests {{ $test.Name }}"
+      {{- else }}
+      - label: ":k8s: :go: run e2e tests {{ $test.Name }}"
+      {{- end }}
+        key: "e2e-{{ $test.SlugName }}"
+
+        # allow re-running from the UI even after it passed
+        retry:
+          manual:
+            permit_on_passed: true
+
+        {{- if $test.RemoteKubeconfig }}
+        depends_on:
+          - "e2e-cluster-{{ $test.SlugName }}"
+          # let's be optimistic and run the tests without dependency on the images build
+        {{- end }}
+
+        env:
+          {{- range $key, $val := $test.Env }}
+          {{$key}}: "{{$val}}"
+          {{- end }}
+
+        commands:
+          {{- range $key, $val := $test.Env }}
+          - echo "{{$key}}={{$val}}" >> .env
+          {{- end }}
+
+          - .buildkite/scripts/test/set-deployer-config.sh
+
+          {{- $deployerCommand := "run-deployer" }}
+          {{- if $test.RemoteKubeconfig }}
+            {{- $deployerCommand = "set-kubeconfig" }}
+          {{- end }}
+
+          {{- if $test.Dind }}
+          - make -C .buildkite TARGET="{{ $deployerCommand }} e2e-run" ci
+          {{- else }}
+          - make {{ $deployerCommand }} e2e-run
+          {{- end }}
+
+        agents:
+          {{- if $test.Dind }}
+          provider: "gcp"
+          image: "family/core-ubuntu-2204"
+          {{- if or (eq $test.Provider "kind") (eq $test.Provider "k3d") }}
+          machineType: "{{ $.K8sInDockerMachineType }}"
+          diskSizeGb: 200
+          {{- end }}
+          {{- else }}
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:8aeecfdfe9b9d178a6087e5158946cc5d1ca2b3a15f24c2579a9730f30caa1bb
+          memory: "4G"
+          {{- end }}
+
+        artifact_paths:
+          - e2e-tests-*.json
+          - "eck-diagnostic*.zip"
+
     {{- if $test.Cleanup }}
 
       # delete k8s cluster
-      - label: ":broom: {{ $test.Name }}"
+      - label: ":broom: cleanup {{ $test.Name }}"
         depends_on:
           - step: "e2e-{{ $test.SlugName }}"
             allow_failure: true
@@ -116,6 +120,10 @@ steps:
           {{- end }}
           DEPLOYER_OPERATION: delete
         soft_fail: true
+        # allow re-running from the UI even after it passed
+        retry:
+          manual:
+            permit_on_passed: true
         commands:
           - .buildkite/scripts/test/set-deployer-config.sh
         {{- if not $test.Dind }}
@@ -131,6 +139,7 @@ steps:
         {{- end }}
 
     {{- end }}
+
 {{- end }}
 
   - label: "aggregate tests-results"
@@ -139,6 +148,10 @@ steps:
       - step: "e2e-{{ $test.SlugName }}"
         allow_failure: true
       {{- end }}
+    # allow recalculating the results after retrying one or more suites
+    retry:
+      manual:
+        permit_on_passed: true
     command: .buildkite/scripts/test/report-tests-results.sh
     artifact_paths:
       - ".buildkite/e2e/reporter/*.md"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -65,7 +65,7 @@ steps:
   - group: build operator
     key: "operator-image-build"
     steps:
-      - label: ":buildkite:"
+      - label: ":buildkite: generate image build steps"
         key: "operator-image-build-step"
         agents:
           image: "docker.elastic.co/ci-agent-images/serverless-docker-builder:0.11.0@sha256:b59bd1dea06b89a7e5767724bebba04f73ccb21b05b0f028efe40aa701b55621"
@@ -92,7 +92,7 @@ steps:
   - group: build e2e-tests
     key: "e2e-tests-image-build"
     steps:
-      - label: ":buildkite:"
+      - label: ":buildkite: generate image build steps"
         agents:
           image: "docker.elastic.co/ci-agent-images/serverless-docker-builder:0.11.0@sha256:b59bd1dea06b89a7e5767724bebba04f73ccb21b05b0f028efe40aa701b55621"
         commands: make -C /agent generate-docker-images
@@ -105,7 +105,7 @@ steps:
   # step to run e2e-tests for PR are inlined for speed
 
   # for commits in all branches (PR, release) except main
-  - label: ":buildkite:"
+  - label: ":buildkite: upload e2e smoke pipeline"
     if: |
         ( build.branch != "main" )
         && build.env("GITHUB_PR_TRIGGER_COMMENT") !~ /^buildkite test this -[fm]/
@@ -129,7 +129,7 @@ steps:
       memory: "2G"
 
   # for PR comment
-  - label: ":buildkite:"
+  - label: ":buildkite: upload e2e pipeline (PR comment)"
     if: build.env("GITHUB_PR_TRIGGER_COMMENT") =~ /^buildkite test this -[fm]/
     command: |
       set -euo pipefail
@@ -142,7 +142,7 @@ steps:
       memory: "2G"
 
   # for the main branch (merge and nightly) and tags
-  - label: ":buildkite:"
+  - label: ":buildkite: upload e2e pipeline (main/tag)"
     command: buildkite-agent pipeline upload .buildkite/pipeline-e2e-tests.yml
     agents:
       image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:8aeecfdfe9b9d178a6087e5158946cc5d1ca2b3a15f24c2579a9730f30caa1bb
@@ -151,7 +151,7 @@ steps:
   # ----------
 
   # scan the operator image(s) for CVEs
-  - label: ":buildkite:"
+  - label: ":buildkite: upload cve scans pipeline"
     if: |  # merge-xyz, tag-bc, tag-final or nightly-main
       build.branch =~ /^[0-9]*\.[0-9]*\$/
       || build.tag != null
@@ -181,7 +181,7 @@ steps:
       image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:8aeecfdfe9b9d178a6087e5158946cc5d1ca2b3a15f24c2579a9730f30caa1bb
       memory: "256Mi"
 
-  - label: ":buildkite:"
+  - label: ":buildkite: upload release pipeline"
     depends_on:
       - "operator-image-build"
     command: buildkite-agent pipeline upload .buildkite/pipeline-release.yml


### PR DESCRIPTION
Implements proposal 1 (see [reference](https://github.com/elastic/cloud-on-k8s/issues/9627)).

**Before:** the generated e2e pipeline was a flat list, all cluster creates, then all test runs, then a single global `:broom:` cleanup group. The suites' steps were scattered across the build, and passed steps offered no retry button at all. Worse, retrying a failed cluster creation left an orphan cluster: the cleanup step had already run (its dependency uses `allow_failure: true`) and, having passed, could not be retried, so the newly created cluster could only be deleted manually.

**Now:** each suite is one Buildkite group (`create cluster` → `run e2e tests` → `cleanup`), and every suite step plus `aggregate tests-results` carries `retry.manual.permit_on_passed: true`. Any suite can be re-run from the UI — whether it failed or passed — by retrying its steps in order within the group; steps that never ran follow automatically once a retried dependency passes. Step keys and `depends_on` are unchanged, so the aggregate step works as before. The now-unused top-level `Cleanup` template variable is removed from the generator.

<img width="612" height="251" alt="Screenshot 2026-07-23 at 12 51 56 PM" src="https://github.com/user-attachments/assets/cacf8f55-45f8-4e07-a0d1-f1270593d350" />



Also gives the bare `:buildkite:` steps in `.buildkite/pipeline.yml` descriptive labels (display-only, no keys or dependencies touched).

