### PR TITLE
[e2e] Downscale GKE CI node type from n1-standard-8 to n1-standard-4

### DIFF
--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -4,7 +4,7 @@ plans:
   clusterName: ci
   provider: gke
   kubernetesVersion: 1.33
-  machineType: n1-standard-8
+  machineType: n1-standard-4
   serviceAccount: true
   enforceSecurityPolicies: true
   # use kustomize in GKE to remove the NVMe provisioning already taken care of by the platform


### PR DESCRIPTION
## Motivation

### GCP resource exhaustion

When release tags trigger the full e2e matrix, all GKE clusters are created in parallel in the
same GCP region (`us-central1`). Each cluster contains 3 nodes (`nodeCountPerZone: 1` across the
3 zones of that region), so the total number of n1-standard-8 nodes requested simultaneously is:

| Trigger | GKE clusters (n1-standard-8) | Nodes (×3 per cluster) |
|---|---|---|
| Tag / release branch | 26 stack versions + `gke` + `resilience` = **28 clusters** | **84 nodes** |
| Nightly | 5 stack versions + `gke` + `resilience` = **7 clusters** | **21 nodes** |

(The `gke-autopilot` clusters are excluded above as they do not use a fixed machine type.)

At this scale we routinely hit GCP's per-region capacity limit:

> _Google Compute Engine does not have enough resources available to fulfill request.
> Try a different location, or try again later._

Using n1-standard-4 halves the per-node resource footprint, which both reduces pressure on
regional quota and makes individual cluster creation less likely to be denied when many clusters
are provisioned at once.

### Cost

Halving the machine type roughly halves the compute cost for every CI run that uses the `gke-ci`
plan.

## Resource analysis

E2e tests run **sequentially** within each cluster (`-p=1`), so there is never more than one test
stack active at a time.

**n1-standard-4 per node: 4 vCPU / 15 GB RAM**

With ~2 GB consumed by the GKE system processes and 1 GB by the monitoring DaemonSet per node, each node has roughly **12 GB usable** for workload pods.

| Scenario | Peak ES pods | Total ES memory | Worst-case per node (anti-affinity 3 nodes) |
|---|---|---|---|
| Typical 3-node cluster | 3 × 2 Gi | 6 Gi | 2 Gi — comfortable |
| Rolling upgrade peak | 6 × 2 Gi | 12 Gi | 4 Gi (2-2-2) — comfortable |
| Resize tests (3 × 4 Gi) | 3 × 4 Gi | 12 Gi | 4 Gi (1-1-1) — comfortable |
| TestAutoscaling (worst case) | 4 × 4 Gi | 16 Gi | 8 Gi (2-1-1) + 1 Gi monitoring + ~2 Gi system = **11 Gi** — fits |

ECK sets soft pod anti-affinity by default so Elasticsearch pods spread across the 3 nodes.
The tightest realistic scenario is `TestAutoscaling` landing 2 of its 4-Gi pods on the same node,
leaving ~4 GB of headroom on a 15 GB node.

## Change

```yaml
# hack/deployer/config/plans.yml
- id: gke-ci
  machineType: n1-standard-4   # was n1-standard-8
```
