### PR TITLE
[e2e]: Fix Version Watcher, exclude pods in Terminating state

### DIFF
--- a/test/e2e/test/watcher.go
+++ b/test/e2e/test/watcher.go
@@ -112,7 +112,16 @@ func NewVersionWatcher(versionLabel string, opts ...client.ListOption) Watcher {
 			if pods, err := k.GetPods(opts...); err != nil {
 				t.Logf("failed to list pods: %v", err)
 			} else {
-				podObservations = append(podObservations, pods)
+				// Exclude Terminating pods: Kubernetes keeps them in the API throughout
+				// their grace period, so a List can return old-version Terminating pods
+				// alongside new-version pods, causing a false multi-version observation.
+				activePods := make([]v1.Pod, 0, len(pods))
+				for _, p := range pods {
+					if p.DeletionTimestamp == nil {
+						activePods = append(activePods, p)
+					}
+				}
+				podObservations = append(podObservations, activePods)
 			}
 		},
 		func(k *K8sClient, t *testing.T) { //nolint:thelper
@@ -121,5 +130,6 @@ func NewVersionWatcher(versionLabel string, opts ...client.ListOption) Watcher {
 					assert.Equal(t, pods[i-1].Labels[versionLabel], pods[i].Labels[versionLabel])
 				}
 			}
-		})
+		},
+	)
 }


### PR DESCRIPTION
During a version upgrade, Kubernetes keeps old pods in Terminating state throughout their grace period while already creating new pods for the new ReplicaSet. GetPods returns all pods regardless of phase, so the watcher could observe both versions in the same snapshot, causing a spurious test failure. Fix by excluding pods with a non-nil DeletionTimestamp before recording each observation.
