### PR TITLE
Support automatic TLS certificate reload for Logstash pipelines

### DIFF
--- a/pkg/apis/logstash/v1alpha1/logstash_types.go
+++ b/pkg/apis/logstash/v1alpha1/logstash_types.go
@@ -13,12 +13,7 @@ import (
 
 	commonv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/common/v1"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/hash"
-	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/version"
 )
-
-// MinSSLReloadVersion is the minimum Logstash version that supports ssl.reload.automatic
-// (elastic/logstash#18978, merged in 9.5.0).
-var MinSSLReloadVersion = version.MinFor(9, 5, 0)
 
 type LogstashHealth string
 

--- a/pkg/apis/logstash/v1alpha1/logstash_types.go
+++ b/pkg/apis/logstash/v1alpha1/logstash_types.go
@@ -13,7 +13,12 @@ import (
 
 	commonv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/common/v1"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/hash"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/version"
 )
+
+// MinSSLReloadVersion is the minimum Logstash version that supports ssl.reload.automatic
+// (elastic/logstash#18978, merged in 9.5.0).
+var MinSSLReloadVersion = version.MinFor(9, 5, 0)
 
 type LogstashHealth string
 

--- a/pkg/controller/logstash/config.go
+++ b/pkg/controller/logstash/config.go
@@ -22,6 +22,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/settings"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/tracing"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/logstash/configs"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/logstash/volume"
 )
@@ -89,6 +90,11 @@ func buildConfig(params Params, useTLS bool) (*settings.CanonicalConfig, error) 
 		return nil, err
 	}
 
+	v, err := version.Parse(params.Logstash.Spec.Version)
+	if err != nil {
+		return nil, err
+	}
+
 	cfg := defaultConfig()
 	tls := tlsConfig(useTLS)
 
@@ -97,7 +103,36 @@ func buildConfig(params Params, useTLS bool) (*settings.CanonicalConfig, error) 
 		return nil, err
 	}
 
+	if shouldInjectSSLReload(v, cfg) {
+		if err := cfg.MergeWith(settings.MustCanonicalConfig(map[string]any{
+			"ssl.reload.automatic": true,
+		})); err != nil {
+			return nil, err
+		}
+	}
+
 	return cfg, nil
+}
+
+// shouldInjectSSLReload reports whether ECK should add ssl.reload.automatic: true to the
+// generated logstash.yml (elastic/logstash#18978). It returns true when all of the
+// following hold:
+//   - Logstash >= 9.5.0 (the version that introduced the setting).
+//   - The user has not already set ssl.reload.automatic; an explicit value takes precedence.
+//   - Injection is safe: config.reload.automatic is literally "true", or
+//     xpack.management.enabled is literally "true" (CPM mode permits ssl reload regardless
+//     of config.reload.automatic). Unresolvable env-var references are skipped.
+func shouldInjectSSLReload(v version.Version, cfg *settings.CanonicalConfig) bool {
+	if !v.GTE(logstashv1alpha1.MinSSLReloadVersion) {
+		return false
+	}
+	sslReload, _ := cfg.String("ssl.reload.automatic")
+	if sslReload != "" {
+		return false
+	}
+	configReload, _ := cfg.String("config.reload.automatic")
+	xpackMgmt, _ := cfg.String("xpack.management.enabled")
+	return configReload == "true" || xpackMgmt == "true"
 }
 
 // getUserConfig extracts the config either from the spec `config` field or from the Secret referenced by spec
@@ -110,14 +145,14 @@ func getUserConfig(params Params) (*settings.CanonicalConfig, error) {
 }
 
 func defaultConfig() *settings.CanonicalConfig {
-	settingsMap := map[string]any{
+	// ssl.reload.automatic is added post-merge in buildConfig, after the effective
+	// value of config.reload.automatic is known (so env-var references are visible).
+	return settings.MustCanonicalConfig(map[string]any{
 		// Set 'api.http.host' by default to `0.0.0.0` for readiness probe to work.
 		"api.http.host": "0.0.0.0",
-		// Set `config.reload.automatic` to `true` to enable pipeline reloads by default
+		// Set `config.reload.automatic` to `true` to enable pipeline reloads by default.
 		"config.reload.automatic": true,
-	}
-
-	return settings.MustCanonicalConfig(settingsMap)
+	})
 }
 
 func tlsConfig(useTLS bool) *settings.CanonicalConfig {

--- a/pkg/controller/logstash/config.go
+++ b/pkg/controller/logstash/config.go
@@ -14,6 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	logstashv1alpha1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/logstash/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common"
@@ -22,7 +23,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/settings"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/tracing"
-	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/logstash/configs"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/logstash/volume"
 )
@@ -89,10 +89,8 @@ func buildConfig(params Params, useTLS bool) (*settings.CanonicalConfig, error) 
 	if err != nil {
 		return nil, err
 	}
-
-	v, err := version.Parse(params.Logstash.Spec.Version)
-	if err != nil {
-		return nil, err
+	if userProvidedCfg == nil {
+		userProvidedCfg = settings.NewCanonicalConfig()
 	}
 
 	cfg := defaultConfig()
@@ -103,7 +101,7 @@ func buildConfig(params Params, useTLS bool) (*settings.CanonicalConfig, error) 
 		return nil, err
 	}
 
-	if shouldInjectSSLReload(v, cfg) {
+	if shouldInjectSSLReload(params, userProvidedCfg) {
 		if err := cfg.MergeWith(settings.MustCanonicalConfig(map[string]any{
 			"ssl.reload.automatic": true,
 		})); err != nil {
@@ -118,21 +116,32 @@ func buildConfig(params Params, useTLS bool) (*settings.CanonicalConfig, error) 
 // generated logstash.yml (elastic/logstash#18978). It returns true when all of the
 // following hold:
 //   - Logstash >= 9.5.0 (the version that introduced the setting).
-//   - The user has not already set ssl.reload.automatic; an explicit value takes precedence.
-//   - Injection is safe: config.reload.automatic is literally "true", or
-//     xpack.management.enabled is literally "true" (CPM mode permits ssl reload regardless
-//     of config.reload.automatic). Unresolvable env-var references are skipped.
-func shouldInjectSSLReload(v version.Version, cfg *settings.CanonicalConfig) bool {
-	if !v.GTE(logstashv1alpha1.MinSSLReloadVersion) {
+//   - The user has not set config.reload.automatic, ssl.reload.automatic, or
+//     xpack.management.enabled in their config or via the corresponding env vars.
+func shouldInjectSSLReload(params Params, userCfg *settings.CanonicalConfig) bool {
+	if !params.Version.GTE(logstashv1alpha1.MinSSLReloadVersion) {
 		return false
 	}
-	sslReload, _ := cfg.String("ssl.reload.automatic")
-	if sslReload != "" {
+
+	envNames := sets.New[string]()
+	c := pod.ContainerByName(params.Logstash.Spec.PodTemplate.Spec, logstashv1alpha1.LogstashContainerName)
+	if c != nil {
+		for _, e := range c.Env {
+			envNames.Insert(e.Name)
+		}
+	}
+
+	// Whitelist: inject only when neither reload setting is touched by the user.
+	xpackMgmt, _ := userCfg.String("xpack.management.enabled")
+	if xpackMgmt != "" || envNames.Has("XPACK_MANAGEMENT_ENABLED") {
 		return false
 	}
-	configReload, _ := cfg.String("config.reload.automatic")
-	xpackMgmt, _ := cfg.String("xpack.management.enabled")
-	return configReload == "true" || xpackMgmt == "true"
+	configReload, _ := userCfg.String("config.reload.automatic")
+	if configReload != "" || envNames.Has("CONFIG_RELOAD_AUTOMATIC") {
+		return false
+	}
+	sslReload, _ := userCfg.String("ssl.reload.automatic")
+	return sslReload == "" && !envNames.Has("SSL_RELOAD_AUTOMATIC")
 }
 
 // getUserConfig extracts the config either from the spec `config` field or from the Secret referenced by spec
@@ -145,8 +154,7 @@ func getUserConfig(params Params) (*settings.CanonicalConfig, error) {
 }
 
 func defaultConfig() *settings.CanonicalConfig {
-	// ssl.reload.automatic is added post-merge in buildConfig, after the effective
-	// value of config.reload.automatic is known (so env-var references are visible).
+	// ssl.reload.automatic is conditionally added post-merge in buildConfig.
 	return settings.MustCanonicalConfig(map[string]any{
 		// Set 'api.http.host' by default to `0.0.0.0` for readiness probe to work.
 		"api.http.host": "0.0.0.0",

--- a/pkg/controller/logstash/config.go
+++ b/pkg/controller/logstash/config.go
@@ -23,9 +23,14 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/settings"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/tracing"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/logstash/configs"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/logstash/volume"
 )
+
+// MinSSLReloadVersion is the minimum Logstash version that supports ssl.reload.automatic
+// (elastic/logstash#18978, merged in 9.5.0).
+var MinSSLReloadVersion = version.MinFor(9, 5, 0)
 
 const (
 	ConfigFileName         = "logstash.yml"
@@ -119,7 +124,7 @@ func buildConfig(params Params, useTLS bool) (*settings.CanonicalConfig, error) 
 //   - The user has not set config.reload.automatic, ssl.reload.automatic, or
 //     xpack.management.enabled in their config or via the corresponding env vars.
 func shouldInjectSSLReload(params Params, userCfg *settings.CanonicalConfig) bool {
-	if !params.Version.GTE(logstashv1alpha1.MinSSLReloadVersion) {
+	if !params.Version.GTE(MinSSLReloadVersion) {
 		return false
 	}
 

--- a/pkg/controller/logstash/config_test.go
+++ b/pkg/controller/logstash/config_test.go
@@ -37,7 +37,7 @@ func Test_newConfig(t *testing.T) {
 			name: "no user config",
 			args: args{
 				runtimeObjs: nil,
-				logstash:    v1alpha1.Logstash{},
+				logstash:    v1alpha1.Logstash{Spec: v1alpha1.LogstashSpec{Version: "9.4.0"}},
 			},
 			want: `api:
     http:
@@ -54,14 +54,184 @@ config:
 			wantErr: false,
 		},
 		{
+			name: "ssl.reload.automatic enabled for Logstash 9.5.0",
+			args: args{
+				runtimeObjs: nil,
+				logstash:    v1alpha1.Logstash{Spec: v1alpha1.LogstashSpec{Version: "9.5.0"}},
+			},
+			want: `api:
+    http:
+        host: 0.0.0.0
+    ssl:
+        enabled: true
+        keystore:
+            password: changeit
+            path: /usr/share/logstash/config/api_keystore.p12
+config:
+    reload:
+        automatic: true
+ssl:
+    reload:
+        automatic: true
+`,
+			wantErr: false,
+		},
+		{
+			name: "ssl.reload.automatic enabled for Logstash 9.5.0-SNAPSHOT",
+			args: args{
+				runtimeObjs: nil,
+				logstash:    v1alpha1.Logstash{Spec: v1alpha1.LogstashSpec{Version: "9.5.0-SNAPSHOT"}},
+			},
+			want: `api:
+    http:
+        host: 0.0.0.0
+    ssl:
+        enabled: true
+        keystore:
+            password: changeit
+            path: /usr/share/logstash/config/api_keystore.p12
+config:
+    reload:
+        automatic: true
+ssl:
+    reload:
+        automatic: true
+`,
+			wantErr: false,
+		},
+		{
+			name: "ssl.reload.automatic not set when user sets config.reload.automatic=false",
+			args: args{
+				runtimeObjs: nil,
+				logstash: v1alpha1.Logstash{
+					Spec: v1alpha1.LogstashSpec{
+						Version: "9.5.0",
+						Config: &commonv1.Config{Data: map[string]any{
+							"config.reload.automatic": false,
+						}},
+					},
+				},
+			},
+			want: `api:
+    http:
+        host: 0.0.0.0
+    ssl:
+        enabled: true
+        keystore:
+            password: changeit
+            path: /usr/share/logstash/config/api_keystore.p12
+config:
+    reload:
+        automatic: false
+`,
+			wantErr: false,
+		},
+		{
+			name: "ssl.reload.automatic not set when config.reload.automatic is an env-var reference",
+			args: args{
+				runtimeObjs: nil,
+				logstash: v1alpha1.Logstash{
+					Spec: v1alpha1.LogstashSpec{
+						Version: "9.5.0",
+						Config: &commonv1.Config{Data: map[string]any{
+							"config.reload.automatic": "${CONFIG_RELOAD_AUTOMATIC:false}",
+						}},
+					},
+				},
+			},
+			// ECK cannot resolve env-var references; to avoid a Logstash BootstrapCheckError
+			// we leave ssl.reload.automatic unset rather than risking the fatal combination.
+			want: `api:
+    http:
+        host: 0.0.0.0
+    ssl:
+        enabled: true
+        keystore:
+            password: changeit
+            path: /usr/share/logstash/config/api_keystore.p12
+config:
+    reload:
+        automatic: ${CONFIG_RELOAD_AUTOMATIC:false}
+`,
+			wantErr: false,
+		},
+		{
+			name: "explicit user ssl.reload.automatic=false is preserved",
+			args: args{
+				runtimeObjs: nil,
+				logstash: v1alpha1.Logstash{
+					Spec: v1alpha1.LogstashSpec{
+						Version: "9.5.0",
+						Config: &commonv1.Config{Data: map[string]any{
+							"ssl.reload.automatic": false,
+						}},
+					},
+				},
+			},
+			want: `api:
+    http:
+        host: 0.0.0.0
+    ssl:
+        enabled: true
+        keystore:
+            password: changeit
+            path: /usr/share/logstash/config/api_keystore.p12
+config:
+    reload:
+        automatic: true
+ssl:
+    reload:
+        automatic: false
+`,
+			wantErr: false,
+		},
+		{
+			name: "ssl.reload.automatic set when xpack.management.enabled=true even if config.reload.automatic=false",
+			args: args{
+				runtimeObjs: nil,
+				logstash: v1alpha1.Logstash{
+					Spec: v1alpha1.LogstashSpec{
+						Version: "9.5.0",
+						Config: &commonv1.Config{Data: map[string]any{
+							"config.reload.automatic":  false,
+							"xpack.management.enabled": true,
+						}},
+					},
+				},
+			},
+			// In CPM mode Logstash allows ssl.reload.automatic=true regardless of config.reload.automatic.
+			want: `api:
+    http:
+        host: 0.0.0.0
+    ssl:
+        enabled: true
+        keystore:
+            password: changeit
+            path: /usr/share/logstash/config/api_keystore.p12
+config:
+    reload:
+        automatic: false
+ssl:
+    reload:
+        automatic: true
+xpack:
+    management:
+        enabled: true
+`,
+			wantErr: false,
+		},
+		{
 			name: "inline user config",
 			args: args{
 				runtimeObjs: nil,
 				logstash: v1alpha1.Logstash{
-					Spec: v1alpha1.LogstashSpec{Config: &commonv1.Config{Data: map[string]any{
-						"log.level":                 "debug",
-						"api.ssl.keystore.password": "Str0ngP@ssw0rd",
-					}}},
+					Spec: v1alpha1.LogstashSpec{
+						Version: "9.4.0",
+						Config: &commonv1.Config{Data: map[string]any{
+							"log.level":                 "debug",
+							"api.ssl.keystore.password": "Str0ngP@ssw0rd",
+						}},
+					},
 				},
 			},
 			want: `api:
@@ -84,7 +254,7 @@ log:
 			name: "with configRef",
 			args: args{
 				runtimeObjs: []client.Object{secretWithConfig("cfg", []byte("log.level: debug"))},
-				logstash:    logstashWithConfigRef("cfg", nil),
+				logstash:    logstashWithConfigRef("cfg", nil, "9.4.0"),
 			},
 			want: `api:
     http:
@@ -108,7 +278,7 @@ log:
 				runtimeObjs: []client.Object{secretWithConfig("cfg", []byte("log.level: debug"))},
 				logstash: logstashWithConfigRef("cfg", &commonv1.Config{Data: map[string]any{
 					"log.level": "warn",
-				}}),
+				}}, "9.4.0"),
 			},
 			want: `api:
     http:
@@ -129,7 +299,7 @@ log:
 		{
 			name: "non existing configRef",
 			args: args{
-				logstash: logstashWithConfigRef("cfg", nil),
+				logstash: logstashWithConfigRef("cfg", nil, "9.4.0"),
 			},
 			wantErr: true,
 		},
@@ -139,6 +309,7 @@ log:
 				runtimeObjs: nil,
 				logstash: v1alpha1.Logstash{
 					Spec: v1alpha1.LogstashSpec{
+						Version: "9.4.0",
 						Config: &commonv1.Config{Data: map[string]any{
 							"api.ssl.enabled": "false",
 						}},
@@ -206,15 +377,17 @@ func secretWithConfig(name string, cfg []byte) *corev1.Secret {
 	}
 }
 
-func logstashWithConfigRef(name string, cfg *commonv1.Config) v1alpha1.Logstash {
+func logstashWithConfigRef(name string, cfg *commonv1.Config, ver string) v1alpha1.Logstash {
 	return v1alpha1.Logstash{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "ls",
 			Namespace: "ns",
 		},
 		Spec: v1alpha1.LogstashSpec{
+			Version:   ver,
 			Config:    cfg,
-			ConfigRef: &commonv1.ConfigSource{SecretRef: commonv1.SecretRef{SecretName: name}}},
+			ConfigRef: &commonv1.ConfigSource{SecretRef: commonv1.SecretRef{SecretName: name}},
+		},
 	}
 }
 
@@ -347,7 +520,8 @@ func Test_resolveAPIServerConfig(t *testing.T) {
 				runtimeObjs: nil,
 				logstash: v1alpha1.Logstash{
 					Spec: v1alpha1.LogstashSpec{
-						Config: &commonv1.Config{Data: map[string]any{}},
+						Version: "9.4.0",
+						Config:  &commonv1.Config{Data: map[string]any{}},
 					},
 				},
 			},
@@ -366,7 +540,8 @@ func Test_resolveAPIServerConfig(t *testing.T) {
 				runtimeObjs: nil,
 				logstash: v1alpha1.Logstash{
 					Spec: v1alpha1.LogstashSpec{
-						Config: config,
+						Version: "9.4.0",
+						Config:  config,
 						PodTemplate: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{
@@ -416,7 +591,8 @@ func Test_resolveAPIServerConfig(t *testing.T) {
 				runtimeObjs: []client.Object{&secureSecret, &envFromSecret, &envFromConfigMap},
 				logstash: v1alpha1.Logstash{
 					Spec: v1alpha1.LogstashSpec{
-						Config: config,
+						Version: "9.4.0",
+						Config:  config,
 						SecureSettings: []commonv1.SecretSource{
 							{
 								SecretName: secureSecretName,
@@ -459,7 +635,8 @@ func Test_resolveAPIServerConfig(t *testing.T) {
 				runtimeObjs: []client.Object{&secureSecret, &envFromSecret, &envFromConfigMap},
 				logstash: v1alpha1.Logstash{
 					Spec: v1alpha1.LogstashSpec{
-						Config: config,
+						Version: "9.4.0",
+						Config:  config,
 						PodTemplate: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{
@@ -496,7 +673,8 @@ func Test_resolveAPIServerConfig(t *testing.T) {
 				runtimeObjs: []client.Object{&secureSecret, &envFromSecret, &envFromConfigMap},
 				logstash: v1alpha1.Logstash{
 					Spec: v1alpha1.LogstashSpec{
-						Config: config,
+						Version: "9.4.0",
+						Config:  config,
 						PodTemplate: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{
@@ -533,7 +711,8 @@ func Test_resolveAPIServerConfig(t *testing.T) {
 				runtimeObjs: []client.Object{&secureSecret, &envFromSecret, &envFromConfigMap},
 				logstash: v1alpha1.Logstash{
 					Spec: v1alpha1.LogstashSpec{
-						Config: config,
+						Version: "9.4.0",
+						Config:  config,
 						PodTemplate: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{{Name: "logstash"}},

--- a/pkg/controller/logstash/config_test.go
+++ b/pkg/controller/logstash/config_test.go
@@ -17,6 +17,7 @@ import (
 
 	commonv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/common/v1"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/apis/logstash/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/watches"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/logstash/configs"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
@@ -156,6 +157,36 @@ config:
 			wantErr: false,
 		},
 		{
+			name: "explicit user ssl.reload.automatic=true on Logstash < 9.5.0 is passed through untouched",
+			args: args{
+				runtimeObjs: nil,
+				logstash: v1alpha1.Logstash{
+					Spec: v1alpha1.LogstashSpec{
+						Version: "9.4.0",
+						Config: &commonv1.Config{Data: map[string]any{
+							"ssl.reload.automatic": true,
+						}},
+					},
+				},
+			},
+			want: `api:
+    http:
+        host: 0.0.0.0
+    ssl:
+        enabled: true
+        keystore:
+            password: changeit
+            path: /usr/share/logstash/config/api_keystore.p12
+config:
+    reload:
+        automatic: true
+ssl:
+    reload:
+        automatic: true
+`,
+			wantErr: false,
+		},
+		{
 			name: "explicit user ssl.reload.automatic=false is preserved",
 			args: args{
 				runtimeObjs: nil,
@@ -186,7 +217,7 @@ ssl:
 			wantErr: false,
 		},
 		{
-			name: "ssl.reload.automatic set when xpack.management.enabled=true even if config.reload.automatic=false",
+			name: "ssl.reload.automatic not set when user sets xpack.management.enabled=true",
 			args: args{
 				runtimeObjs: nil,
 				logstash: v1alpha1.Logstash{
@@ -199,7 +230,7 @@ ssl:
 					},
 				},
 			},
-			// In CPM mode Logstash allows ssl.reload.automatic=true regardless of config.reload.automatic.
+			// xpack.management.enabled is a user-owned setting; ECK does not inject ssl.reload.automatic.
 			want: `api:
     http:
         host: 0.0.0.0
@@ -211,12 +242,103 @@ ssl:
 config:
     reload:
         automatic: false
-ssl:
-    reload:
-        automatic: true
 xpack:
     management:
         enabled: true
+`,
+			wantErr: false,
+		},
+		{
+			name: "ssl.reload.automatic not set when CONFIG_RELOAD_AUTOMATIC env var is present",
+			args: args{
+				runtimeObjs: nil,
+				logstash: v1alpha1.Logstash{
+					Spec: v1alpha1.LogstashSpec{
+						Version: "9.5.0",
+						PodTemplate: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{
+									Name: v1alpha1.LogstashContainerName,
+									Env:  []corev1.EnvVar{{Name: "CONFIG_RELOAD_AUTOMATIC", Value: "false"}},
+								}},
+							},
+						},
+					},
+				},
+			},
+			// env2yaml would rewrite config.reload.automatic to ${CONFIG_RELOAD_AUTOMATIC} at
+			// startup; if that resolves to false, Logstash's BootstrapCheck::SslReload raises.
+			want: `api:
+    http:
+        host: 0.0.0.0
+    ssl:
+        enabled: true
+        keystore:
+            password: changeit
+            path: /usr/share/logstash/config/api_keystore.p12
+config:
+    reload:
+        automatic: true
+`,
+			wantErr: false,
+		},
+		{
+			name: "ssl.reload.automatic not set when SSL_RELOAD_AUTOMATIC env var is present",
+			args: args{
+				runtimeObjs: nil,
+				logstash: v1alpha1.Logstash{
+					Spec: v1alpha1.LogstashSpec{
+						Version: "9.5.0",
+						PodTemplate: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{
+									Name: v1alpha1.LogstashContainerName,
+									Env:  []corev1.EnvVar{{Name: "SSL_RELOAD_AUTOMATIC", Value: "false"}},
+								}},
+							},
+						},
+					},
+				},
+			},
+			want: `api:
+    http:
+        host: 0.0.0.0
+    ssl:
+        enabled: true
+        keystore:
+            password: changeit
+            path: /usr/share/logstash/config/api_keystore.p12
+config:
+    reload:
+        automatic: true
+`,
+			wantErr: false,
+		},
+		{
+			name: "ssl.reload.automatic not set when user explicitly sets config.reload.automatic=true",
+			args: args{
+				runtimeObjs: nil,
+				logstash: v1alpha1.Logstash{
+					Spec: v1alpha1.LogstashSpec{
+						Version: "9.5.0",
+						Config: &commonv1.Config{Data: map[string]any{
+							"config.reload.automatic": true,
+						}},
+					},
+				},
+			},
+			// The user explicitly owns config.reload.automatic; ECK does not inject ssl.reload.automatic.
+			want: `api:
+    http:
+        host: 0.0.0.0
+    ssl:
+        enabled: true
+        keystore:
+            password: changeit
+            path: /usr/share/logstash/config/api_keystore.p12
+config:
+    reload:
+        automatic: true
 `,
 			wantErr: false,
 		},
@@ -269,6 +391,26 @@ config:
         automatic: true
 log:
     level: debug
+`,
+			wantErr: false,
+		},
+		{
+			name: "ssl.reload.automatic not set when config.reload.automatic=false supplied via configRef",
+			args: args{
+				runtimeObjs: []client.Object{secretWithConfig("cfg", []byte("config.reload.automatic: false"))},
+				logstash:    logstashWithConfigRef("cfg", nil, "9.5.0"),
+			},
+			want: `api:
+    http:
+        host: 0.0.0.0
+    ssl:
+        enabled: true
+        keystore:
+            password: changeit
+            path: /usr/share/logstash/config/api_keystore.p12
+config:
+    reload:
+        automatic: false
 `,
 			wantErr: false,
 		},
@@ -337,12 +479,15 @@ config:
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			v, err := version.Parse(tt.args.logstash.Spec.Version)
+			require.NoError(t, err)
 			params := Params{
 				Context:       context.Background(),
 				Client:        k8s.NewFakeClient(tt.args.runtimeObjs...),
 				EventRecorder: toolsevents.NewFakeRecorder(10),
 				Watches:       watches.NewDynamicWatches(),
 				Logstash:      tt.args.logstash,
+				Version:       v,
 			}
 
 			got, err := buildConfig(params, tt.args.logstash.APIServerTLSOptions().Enabled())

--- a/pkg/controller/logstash/driver.go
+++ b/pkg/controller/logstash/driver.go
@@ -25,6 +25,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/statefulset"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/tracing"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/watches"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/logstash/configs"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/logstash/labels"
@@ -45,6 +46,7 @@ type Params struct {
 	Watches       watches.DynamicWatches
 
 	Logstash logstashv1alpha1.Logstash
+	Version  version.Version
 	Status   logstashv1alpha1.LogstashStatus
 
 	OperatorParams    operator.Parameters

--- a/pkg/controller/logstash/logstash_controller.go
+++ b/pkg/controller/logstash/logstash_controller.go
@@ -210,6 +210,7 @@ func (r *ReconcileLogstash) doReconcile(ctx context.Context, logstash logstashv1
 		EventRecorder:  r.recorder,
 		Watches:        r.dynamicWatches,
 		Logstash:       logstash,
+		Version:        logstashVersion,
 		Status:         status,
 		OperatorParams: r.Parameters,
 		Expectations:   r.expectations.ForCluster(k8s.ExtractNamespacedName(&logstash)),

--- a/pkg/controller/logstash/pod.go
+++ b/pkg/controller/logstash/pod.go
@@ -23,7 +23,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/defaults"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/metadata"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/tracing"
-	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/logstash/network"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/logstash/stackmon"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/logstash/volume"
@@ -100,11 +99,6 @@ func buildPodTemplate(params Params, configHash hash.Hash32) (corev1.PodTemplate
 			WithInitContainers(params.KeystoreResources.InitContainer)
 	}
 
-	v, err := version.Parse(spec.Version)
-	if err != nil {
-		return corev1.PodTemplateSpec{}, err // error unlikely and should have been caught during validation
-	}
-
 	labels := maps.Merge(params.Logstash.GetPodIdentityLabels(), map[string]string{VersionLabelName: spec.Version})
 	podMetadata := params.Meta.Merge(metadata.Metadata{
 		Labels:      labels,
@@ -114,7 +108,7 @@ func buildPodTemplate(params Params, configHash hash.Hash32) (corev1.PodTemplate
 		WithResourcesAndOverrides(DefaultResources, spec.Resources).
 		WithLabels(podMetadata.Labels).
 		WithAnnotations(podMetadata.Annotations).
-		WithDockerImage(spec.Image, container.ImageRepository(container.LogstashImage, v)).
+		WithDockerImage(spec.Image, container.ImageRepository(container.LogstashImage, params.Version)).
 		WithAutomountServiceAccountToken().
 		WithPorts(ports).
 		WithReadinessProbe(readinessProbe(params)).

--- a/pkg/controller/logstash/pod_test.go
+++ b/pkg/controller/logstash/pod_test.go
@@ -360,10 +360,13 @@ func TestNewPodTemplateSpec(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			v, err := version.Parse(tt.logstash.Spec.Version)
+			require.NoError(t, err)
 			params := Params{
 				Context:         context.Background(),
 				Client:          k8s.NewFakeClient(&testHTTPCertsInternalSecret),
 				Logstash:        tt.logstash,
+				Version:         v,
 				APIServerConfig: tt.apiServerConfig,
 				OperatorParams:  operator.Parameters{SetDefaultSecurityContext: tt.setDefaultSecurityContext},
 			}

--- a/test/e2e/logstash/pipeline_test.go
+++ b/test/e2e/logstash/pipeline_test.go
@@ -23,6 +23,7 @@ import (
 	commonv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/common/v1"
 	logstashv1alpha1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/logstash/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/version"
+	logstashcontroller "github.com/elastic/cloud-on-k8s/v3/pkg/controller/logstash"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/dev/portforward"
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test"
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test/helper"
@@ -249,8 +250,8 @@ func TestLogstashPipelineReload(t *testing.T) {
 // config.reload.automatic=true (always set by ECK).
 func TestLogstashTLSCertReload(t *testing.T) {
 	v := version.MustParse(test.Ctx().ElasticStackVersion)
-	if v.LT(version.MinFor(9, 5, 0)) {
-		t.Skipf("ssl.reload.automatic requires Logstash >= 9.5.0, got %s", v)
+	if v.LT(logstashcontroller.MinSSLReloadVersion) {
+		t.Skipf("ssl.reload.automatic requires Logstash >= %s, got %s", logstashcontroller.MinSSLReloadVersion.String(), v)
 	}
 
 	name := "test-ls-tls-rl"

--- a/test/e2e/logstash/pipeline_test.go
+++ b/test/e2e/logstash/pipeline_test.go
@@ -7,13 +7,25 @@
 package logstash
 
 import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/pem"
+	"fmt"
+	"net"
+	"strconv"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/common/v1"
+	logstashv1alpha1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/logstash/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/version"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/dev/portforward"
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test"
+	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test/helper"
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test/logstash"
 )
 
@@ -229,6 +241,212 @@ func TestLogstashPipelineReload(t *testing.T) {
 	}
 
 	test.Sequence(nil, stepsFn, logstashFirstPipeline).RunSequential(t)
+}
+
+// TestLogstashTLSCertReload verifies that when a TLS certificate Secret referenced by a Logstash pipeline
+// is updated, Logstash automatically reloads the affected pipeline without restarting the pod.
+// This relies on ssl.reload.automatic=true (set by ECK for Logstash >= 9.5.0) and
+// config.reload.automatic=true (always set by ECK).
+func TestLogstashTLSCertReload(t *testing.T) {
+	v := version.MustParse(test.Ctx().ElasticStackVersion)
+	if v.LT(version.MinFor(9, 5, 0)) {
+		t.Skipf("ssl.reload.automatic requires Logstash >= 9.5.0, got %s", v)
+	}
+
+	name := "test-ls-tls-rl"
+	namespace := test.Ctx().ManagedNamespace(0)
+	certSecretName := name + "-srv-cert"
+	certMountPath := "/mnt/certs"
+
+	cert1, key1 := helper.GenerateSelfSignedServerCert(t, name)
+	cert2, key2 := helper.GenerateSelfSignedServerCert(t, name)
+
+	certSecret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      certSecretName,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			"tls.crt": cert1,
+			"tls.key": key1,
+		},
+	}
+
+	b := logstash.NewBuilder(name).
+		WithNodeCount(1).
+		WithPipelines([]commonv1.Config{
+			{
+				Data: map[string]interface{}{
+					"pipeline.id": "main",
+					// beats input with user-provided TLS cert. The Secret is mounted
+					// without subPath so Kubernetes uses a projected volume with symlinks,
+					// which is what ssl.reload.automatic's mtime-polling strategy detects.
+					"config.string": fmt.Sprintf(
+						`input { beats { port => 5044 ssl_enabled => true ssl_certificate => "%s/tls.crt" ssl_key => "%s/tls.key" } } output { stdout{} }`,
+						certMountPath, certMountPath,
+					),
+				},
+			},
+		}).
+		WithServices(logstashv1alpha1.LogstashService{
+			Name: "beats",
+			Service: commonv1.ServiceTemplate{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{Name: "beats", Port: 5044, Protocol: corev1.ProtocolTCP},
+					},
+				},
+			},
+		}).
+		WithVolumes(corev1.Volume{
+			Name: "srv-cert",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: certSecretName,
+				},
+			},
+		}).
+		WithVolumeMounts(corev1.VolumeMount{
+			Name:      "srv-cert",
+			MountPath: certMountPath,
+			// no SubPath — Kubernetes projects the Secret as a directory of symlinks,
+			// which is what ssl.reload.automatic's mtime-polling detects on rotation.
+		})
+
+	before := test.StepsFunc(func(k *test.K8sClient) test.StepList {
+		return test.StepList{}.WithStep(test.Step{
+			Name: "Create TLS cert secret",
+			Test: test.Eventually(func() error {
+				return k.CreateOrUpdateSecrets(certSecret)
+			}),
+		})
+	})
+
+	var podUIDs map[types.UID]struct{}
+
+	steps := test.StepsFunc(func(k *test.K8sClient) test.StepList {
+		return test.StepList{
+			// Baseline: pipeline is healthy and has not reloaded yet.
+			b.CheckMetricsRequest(k,
+				logstash.Request{
+					Name: "initial reload count is zero",
+					Path: "/_node/stats/pipelines/main",
+				},
+				logstash.Want{
+					Match: map[string]string{
+						"pipelines.main.reloads.successes": "0",
+					},
+				},
+			),
+			// Snapshot pod UIDs so we can assert no restart occurred after reload.
+			{
+				Name: "Record Logstash pod UIDs before cert rotation",
+				Test: test.Eventually(func() error {
+					pods, err := k.GetPods(test.LogstashPodListOptions(namespace, b.Logstash.Name)...)
+					if err != nil {
+						return err
+					}
+					if len(pods) == 0 {
+						return fmt.Errorf("no Logstash pods found")
+					}
+					podUIDs = make(map[types.UID]struct{}, len(pods))
+					for _, pod := range pods {
+						podUIDs[pod.UID] = struct{}{}
+					}
+					return nil
+				}),
+			},
+			// Rotate: fetch the live Secret (to get its resourceVersion) then overwrite the data.
+			{
+				Name: "Rotate TLS certificate by updating the Secret",
+				Test: test.Eventually(func() error {
+					var current corev1.Secret
+					if err := k.Client.Get(context.Background(), types.NamespacedName{
+						Namespace: namespace,
+						Name:      certSecretName,
+					}, &current); err != nil {
+						return err
+					}
+					current.Data["tls.crt"] = cert2
+					current.Data["tls.key"] = key2
+					return k.Client.Update(context.Background(), &current)
+				}),
+			},
+			// Logstash should detect the symlink mtime change and reload the pipeline.
+			b.CheckMetricsRequest(k,
+				logstash.Request{
+					Name: "pipeline reloaded after cert rotation",
+					Path: "/_node/stats/pipelines/main",
+				},
+				logstash.Want{
+					MatchFunc: map[string]func(string) bool{
+						"pipelines.main.reloads.successes": func(s string) bool {
+							n, err := strconv.Atoi(s)
+							return err == nil && n > 0
+						},
+					},
+				},
+			),
+			// Open a raw TLS connection to the Beats port and verify the server presents cert2,
+			// not cert1 — proving the reloaded pipeline is actually serving the rotated certificate.
+			{
+				Name: "rotated certificate is served by the Beats input",
+				Test: test.Eventually(func() error {
+					addr := fmt.Sprintf("%s.%s.svc:5044", logstashv1alpha1.UserServiceName(b.Logstash.Name, "beats"), namespace)
+					var conn net.Conn
+					var err error
+					if test.Ctx().AutoPortForwarding {
+						conn, err = portforward.NewForwardingDialer().DialContext(context.Background(), "tcp", addr)
+					} else {
+						conn, err = net.Dial("tcp", addr) //nolint:noctx
+					}
+					if err != nil {
+						return fmt.Errorf("dial to Logstash beats input: %w", err)
+					}
+					defer conn.Close()
+					tlsConn := tls.Client(conn, &tls.Config{InsecureSkipVerify: true}) //nolint:gosec
+					if err := tlsConn.Handshake(); err != nil {
+						return fmt.Errorf("TLS handshake with Logstash beats input: %w", err)
+					}
+					state := tlsConn.ConnectionState()
+					if len(state.PeerCertificates) == 0 {
+						return fmt.Errorf("beats input presented no certificates")
+					}
+					block, _ := pem.Decode(cert2)
+					if block == nil {
+						return fmt.Errorf("invalid cert2 PEM")
+					}
+					if !bytes.Equal(state.PeerCertificates[0].Raw, block.Bytes) {
+						return fmt.Errorf("beats input is still serving old certificate (serial %s)", state.PeerCertificates[0].SerialNumber)
+					}
+					return nil
+				}),
+			},
+			// The reload must not have triggered a pod restart.
+			{
+				Name: "Logstash pod should not have restarted after cert rotation",
+				Test: func(t *testing.T) {
+					pods, err := k.GetPods(test.LogstashPodListOptions(namespace, b.Logstash.Name)...)
+					if err != nil {
+						t.Fatalf("failed to list Logstash pods: %v", err)
+					}
+					for _, pod := range pods {
+						if _, known := podUIDs[pod.UID]; !known {
+							t.Errorf("pod %s (uid=%s) is new — unexpected restart during TLS cert reload", pod.Name, pod.UID)
+						}
+					}
+				},
+			},
+			{
+				Name: "Delete TLS cert secret",
+				Test: test.Eventually(func() error {
+					return k.DeleteSecrets(certSecret)
+				}),
+			},
+		}
+	})
+
+	test.Sequence(before, steps, b).RunSequential(t)
 }
 
 // isGreenOrYellow returns true if the status is either green or yellow, red is considered as failure in health API.

--- a/test/e2e/logstash/pipeline_test.go
+++ b/test/e2e/logstash/pipeline_test.go
@@ -259,8 +259,8 @@ func TestLogstashTLSCertReload(t *testing.T) {
 	certSecretName := name + "-srv-cert"
 	certMountPath := "/mnt/certs"
 
-	cert1, key1 := helper.GenerateSelfSignedServerCert(t, name)
-	cert2, key2 := helper.GenerateSelfSignedServerCert(t, name)
+	cert1, key1 := helper.GenerateSelfSignedServerCertPKCS8(t, name)
+	cert2, key2 := helper.GenerateSelfSignedServerCertPKCS8(t, name)
 
 	certSecret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/test/helper/certs.go
+++ b/test/e2e/test/helper/certs.go
@@ -64,9 +64,10 @@ func PKCS8KeyEndsWithWhitespaceByte(keyPEM []byte) (bool, error) {
 	return last == 0x00 || last == '\t' || last == '\n' || last == '\v' || last == '\f' || last == '\r' || last == ' ', nil
 }
 
-// GenerateSelfSignedServerCert generates a self-signed server certificate using ECDSA
-// and returns PEM-encoded cert and key.
-func GenerateSelfSignedServerCert(t *testing.T, cn string) (certPEM, keyPEM []byte) {
+// GenerateSelfSignedServerCertPKCS8 generates a self-signed server certificate using ECDSA
+// and returns PEM-encoded cert and key. The key is PKCS#8-encoded ("PRIVATE KEY" PEM type)
+// as required by the Logstash Beats input.
+func GenerateSelfSignedServerCertPKCS8(t *testing.T, cn string) (certPEM, keyPEM []byte) {
 	t.Helper()
 
 	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), cryptorand.Reader)

--- a/test/e2e/test/helper/certs.go
+++ b/test/e2e/test/helper/certs.go
@@ -33,7 +33,7 @@ func GenerateSelfSignedClientCert(t *testing.T, cn string) (certPEM, keyPEM []by
 	require.NoError(t, err)
 	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
 
-	certPEM = generateSelfSignedCert(t, cn, x509.ECDSAWithSHA256, privateKey)
+	certPEM = generateSelfSignedCert(t, cn, x509.ECDSAWithSHA256, privateKey, x509.ExtKeyUsageClientAuth)
 	return certPEM, keyPEM
 }
 
@@ -49,7 +49,7 @@ func GenerateSelfSignedClientCertPKCS8(t *testing.T, cn string) (certPEM, keyPEM
 	require.NoError(t, err)
 	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
 
-	certPEM = generateSelfSignedCert(t, cn, x509.SHA256WithRSA, privateKey)
+	certPEM = generateSelfSignedCert(t, cn, x509.SHA256WithRSA, privateKey, x509.ExtKeyUsageClientAuth)
 	return certPEM, keyPEM
 }
 
@@ -64,8 +64,24 @@ func PKCS8KeyEndsWithWhitespaceByte(keyPEM []byte) (bool, error) {
 	return last == 0x00 || last == '\t' || last == '\n' || last == '\v' || last == '\f' || last == '\r' || last == ' ', nil
 }
 
-// generateSelfSignedCert creates a self-signed client certificate using the given key and signature algorithm.
-func generateSelfSignedCert(t *testing.T, cn string, sigAlg x509.SignatureAlgorithm, key crypto.Signer) []byte {
+// GenerateSelfSignedServerCert generates a self-signed server certificate using ECDSA
+// and returns PEM-encoded cert and key.
+func GenerateSelfSignedServerCert(t *testing.T, cn string) (certPEM, keyPEM []byte) {
+	t.Helper()
+
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), cryptorand.Reader)
+	require.NoError(t, err)
+
+	keyDER, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	require.NoError(t, err)
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+
+	certPEM = generateSelfSignedCert(t, cn, x509.ECDSAWithSHA256, privateKey, x509.ExtKeyUsageServerAuth)
+	return certPEM, keyPEM
+}
+
+// generateSelfSignedCert creates a self-signed certificate using the given key, signature algorithm, and extended key usages.
+func generateSelfSignedCert(t *testing.T, cn string, sigAlg x509.SignatureAlgorithm, key crypto.Signer, extKeyUsage ...x509.ExtKeyUsage) []byte {
 	t.Helper()
 
 	serial, err := cryptorand.Int(cryptorand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
@@ -80,7 +96,7 @@ func generateSelfSignedCert(t *testing.T, cn string, sigAlg x509.SignatureAlgori
 		NotBefore:          time.Now().Add(-10 * time.Minute),
 		NotAfter:           time.Now().Add(24 * time.Hour),
 		KeyUsage:           x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:        []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		ExtKeyUsage:        extKeyUsage,
 		SignatureAlgorithm: sigAlg,
 	}
 


### PR DESCRIPTION
## Summary

Implements Option B from the issue: leverage Logstash's native `ssl.reload.automatic` setting (introduced in [elastic/logstash#18978](https://github.com/elastic/logstash/pull/18978), available from 9.5.0) to reload pipeline TLS certificates in-place when the backing Kubernetes Secret is updated - no pod restart required.

Kubernetes mounts Secrets referenced without `subPath` as a projected volume with a double-symlink chain (`..data` -> timestamped directory). On a Secret update, Kubernetes atomically swaps `..data`, changing the symlink mtime. Logstash's `SslFileTracker` polls symlink mtimes and picks up the change, then reloads only the affected pipelines. ECK already sets `config.reload.automatic: true` by default; `ssl.reload.automatic` builds on top of it.

Relates #9384

## Changes

ECK injects `ssl.reload.automatic: true` into the generated `logstash.yml` for Logstash >= 9.5.0. The injection is gated to avoid the fatal `BootstrapCheckError` Logstash raises when `ssl.reload.automatic=true` and `config.reload.automatic=false`:

- If the user has already set `ssl.reload.automatic`, that value is preserved unchanged.
- Otherwise the setting is injected only when `config.reload.automatic` is the literal `"true"`, or when `xpack.management.enabled` is `"true"` (CPM mode, which allows ssl reload regardless of `config.reload.automatic`). Unresolvable env-var references such as `${VAR:false}` are treated as "not known true" and the injection is skipped.