### PR TITLE
[e2e]: run TestSmoke on merge to main, in multiple providers

### DIFF
--- a/.buildkite/pipeline-e2e-tests.yml
+++ b/.buildkite/pipeline-e2e-tests.yml
@@ -12,9 +12,26 @@ steps:
           .buildkite/scripts/build/set-images.sh
           cd .buildkite/e2e/pipeline-gen && go build -o pipeline-gen
           cat <<DEF | ./pipeline-gen | buildkite-agent pipeline upload
-          - label: gke/all
+          - label: gke/TestSmoke
             fixed:
               E2E_PROVIDER: gke
+              TESTS_MATCH: TestSmoke
+          - label: kind/TestSmoke
+            fixed:
+              E2E_PROVIDER: kind
+              TESTS_MATCH: TestSmoke
+          - label: aks/TestSmoke
+            fixed:
+              E2E_PROVIDER: aks
+              TESTS_MATCH: TestSmoke
+          - label: eks/TestSmoke
+            fixed:
+              E2E_PROVIDER: eks
+              TESTS_MATCH: TestSmoke
+          - label: ocp/TestSmoke
+            fixed:
+              E2E_PROVIDER: ocp
+              TESTS_MATCH: TestSmoke
           DEF
         agents:
           image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:8aeecfdfe9b9d178a6087e5158946cc5d1ca2b3a15f24c2579a9730f30caa1bb

--- a/.buildkite/pipeline-e2e-tests.yml
+++ b/.buildkite/pipeline-e2e-tests.yml
@@ -28,10 +28,6 @@ steps:
             fixed:
               E2E_PROVIDER: eks
               TESTS_MATCH: TestSmoke
-          - label: ocp/TestSmoke
-            fixed:
-              E2E_PROVIDER: ocp
-              TESTS_MATCH: TestSmoke
           DEF
         agents:
           image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest@sha256:8aeecfdfe9b9d178a6087e5158946cc5d1ca2b3a15f24c2579a9730f30caa1bb

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -115,11 +115,11 @@ steps:
       .buildkite/scripts/build/set-images.sh
       cd .buildkite/e2e/pipeline-gen && go build -o pipeline-gen
       cat <<DEF | ./pipeline-gen | buildkite-agent pipeline upload
-      # Run TestSmokeLite on every commit.
-      - label: "kind/TestSmokeLite"
+      # Run TestSmoke_Core on every commit.
+      - label: "kind/TestSmoke_Core"
         fixed:
           E2E_PROVIDER: kind
-          TESTS_MATCH: TestSmokeLite
+          TESTS_MATCH: TestSmoke_Core
           E2E_TAGS: "e2e,mixed"
           MONITORING_SECRETS: ""
           E2E_SKIP_CLEANUP: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -116,7 +116,7 @@ steps:
       cd .buildkite/e2e/pipeline-gen && go build -o pipeline-gen
       cat <<DEF | ./pipeline-gen | buildkite-agent pipeline upload
       # Run TestSmoke_Core on every commit.
-      - label: "kind/TestSmoke_Core"
+      - label: "kind/TestSmokeCore"
         fixed:
           E2E_PROVIDER: kind
           TESTS_MATCH: TestSmoke_Core

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -105,7 +105,7 @@ steps:
   # step to run e2e-tests for PR are inlined for speed
 
   # for commits in all branches (PR, release) except main
-  - label: ":buildkite: upload e2e smoke pipeline"
+  - label: ":buildkite: upload e2e smoke lite pipeline"
     if: |
         ( build.branch != "main" )
         && build.env("GITHUB_PR_TRIGGER_COMMENT") !~ /^buildkite test this -[fm]/
@@ -115,11 +115,11 @@ steps:
       .buildkite/scripts/build/set-images.sh
       cd .buildkite/e2e/pipeline-gen && go build -o pipeline-gen
       cat <<DEF | ./pipeline-gen | buildkite-agent pipeline upload
-      # Run TestSmoke on every commit.
-      - label: "kind/TestSmoke"
+      # Run TestSmokeLite on every commit.
+      - label: "kind/TestSmokeLite"
         fixed:
           E2E_PROVIDER: kind
-          TESTS_MATCH: TestSmoke
+          TESTS_MATCH: TestSmokeLite
           E2E_TAGS: "e2e,mixed"
           MONITORING_SECRETS: ""
           E2E_SKIP_CLEANUP: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,8 @@ There are 4 test suites:
 
   A faster option is to run the operator and tests locally, with `make run` in one shell and `make e2e-local TESTS_MATCH= TestMetricbeatStackMonitoringRecipe` in another, though this does not exercise all of the same configuration (permissions etc.) that will be used in CI, so is not as thorough.
 
+  Test cases prefixed with `TestSmoke_` are part of the smoke suite and run automatically on every merge to main across all supported cloud providers.
+
 - **Helm chart tests** - allows us to test helm charts. To run helm chart tests, you can use `make helm-test` command.
 
 #### Pull Request validation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ There are 4 test suites:
 
   A faster option is to run the operator and tests locally, with `make run` in one shell and `make e2e-local TESTS_MATCH= TestMetricbeatStackMonitoringRecipe` in another, though this does not exercise all of the same configuration (permissions etc.) that will be used in CI, so is not as thorough.
 
-  Test cases prefixed with `TestSmoke_` are part of the smoke suite and run automatically on every merge to main across all supported cloud providers.
+  Test cases prefixed with `TestSmoke_` are part of the smoke suite and run automatically on every merge to main across all supported cloud providers. `TestSmokeLite` runs on every PR.
 
 - **Helm chart tests** - allows us to test helm charts. To run helm chart tests, you can use `make helm-test` command.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ There are 4 test suites:
 
   A faster option is to run the operator and tests locally, with `make run` in one shell and `make e2e-local TESTS_MATCH= TestMetricbeatStackMonitoringRecipe` in another, though this does not exercise all of the same configuration (permissions etc.) that will be used in CI, so is not as thorough.
 
-  Test cases prefixed with `TestSmoke_` are part of the smoke suite and run automatically on every merge to main across all supported cloud providers. `TestSmokeLite` runs on every PR.
+  Test cases prefixed with `TestSmoke_` are part of the smoke suite and run automatically on every merge to main across all supported cloud providers. `TestSmoke_Core` runs on every PR.
 
 - **Helm chart tests** - allows us to test helm charts. To run helm chart tests, you can use `make helm-test` command.
 

--- a/config/samples/logstash/logstash_pv.yaml
+++ b/config/samples/logstash/logstash_pv.yaml
@@ -1,7 +1,7 @@
 apiVersion: logstash.k8s.elastic.co/v1alpha1
 kind: Logstash
 metadata:
-  name: d
+  name: logstash-sample
 spec:
   count: 1
   version: 9.4.3

--- a/test/e2e/agent/recipes_test.go
+++ b/test/e2e/agent/recipes_test.go
@@ -53,7 +53,7 @@ func TestSystemIntegrationRecipe(t *testing.T) {
 	runAgentRecipe(t, "system-integration.yaml", customize)
 }
 
-func TestKubernetesIntegrationRecipe(t *testing.T) {
+func TestSmoke_KubernetesIntegrationRecipe(t *testing.T) {
 	v := version.MustParse(test.Ctx().ElasticStackVersion)
 	customize := func(builder agent.Builder) agent.Builder {
 		if !skipAgentInternalLogsValidation(v) {
@@ -114,7 +114,7 @@ func TestMultiOutputRecipe(t *testing.T) {
 	runAgentRecipe(t, "multi-output.yaml", customize)
 }
 
-func TestFleetKubernetesIntegrationRecipe(t *testing.T) {
+func TestSmoke_FleetKubernetesIntegrationRecipe(t *testing.T) {
 	customize := func(builder agent.Builder) agent.Builder {
 		if !builder.Agent.Spec.FleetServerEnabled {
 			return builder
@@ -165,7 +165,7 @@ func TestFleetKubernetesNonRootIntegrationRecipe(t *testing.T) {
 	}
 
 	if (v.GE(version.MinFor(9, 0, 1)) && v.LE(version.MinFor(9, 0, 4))) ||
-		(v.EQ(version.From(9, 1, 0))) {
+		v.EQ(version.From(9, 1, 0)) {
 		t.Skipf("Skipped as version %s is affected by https://github.com/elastic/kibana/pull/230211", v)
 	}
 

--- a/test/e2e/beat/recipes_test.go
+++ b/test/e2e/beat/recipes_test.go
@@ -88,7 +88,7 @@ func TestFilebeatAutodiscoverByMetadataRecipe(t *testing.T) {
 	runBeatRecipe(t, "filebeat_autodiscover_by_metadata.yaml", customize, podLabel, podBad)
 }
 
-func TestMetricbeatHostsRecipe(t *testing.T) {
+func TestSmoke_MetricbeatHostsRecipe(t *testing.T) {
 	customize := func(builder beat.Builder) beat.Builder {
 		return builder.
 			WithESValidations(
@@ -195,7 +195,6 @@ func TestHeartbeatEsKbHealthRecipe(t *testing.T) {
 }
 
 func TestAuditbeatHostsRecipe(t *testing.T) {
-
 	if test.Ctx().Provider == "kind" || test.Ctx().Provider == "k3d" || test.Ctx().Provider == "eks-arm" || test.Ctx().HasTag(test.ArchARMTag) {
 		// Skipping test because recipe relies on syscall audit rules unavailable on arm64
 		// Also: both kind and k3d do not support configuring required settings

--- a/test/e2e/samples_test.go
+++ b/test/e2e/samples_test.go
@@ -29,19 +29,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test/logstash"
 )
 
-func isSmokeSample(sampleFile string) bool {
-	s, _ := strings.CutPrefix("../../", sampleFile)
-	switch s {
-	case
-		"config/samples/apm/apm_es_kibana.yaml",
-		"config/samples/elasticsearch/elasticsearch.yaml",
-		"config/samples/logstash/logstash_pv.yaml",
-		"config/samples/logstash/logstash_stackmonitor.yaml":
-		return true
-	}
-	return false
-}
-
 func TestSmoke_Samples(t *testing.T) {
 	testSamples(t, isSmokeSample)
 }

--- a/test/e2e/samples_test.go
+++ b/test/e2e/samples_test.go
@@ -35,7 +35,6 @@ func isSmokeSample(sampleFile string) bool {
 	case
 		"config/samples/apm/apm_es_kibana.yaml",
 		"config/samples/elasticsearch/elasticsearch.yaml",
-		"config/samples/logstash/logstash_es.yaml",
 		"config/samples/logstash/logstash_pv.yaml",
 		"config/samples/logstash/logstash_stackmonitor.yaml":
 		return true

--- a/test/e2e/samples_test.go
+++ b/test/e2e/samples_test.go
@@ -29,12 +29,37 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test/logstash"
 )
 
+func isSmokeSample(sampleFile string) bool {
+	s, _ := strings.CutPrefix("../../", sampleFile)
+	switch s {
+	case
+		"config/samples/apm/apm_es_kibana.yaml",
+		"config/samples/elasticsearch/elasticsearch.yaml",
+		"config/samples/logstash/logstash_es.yaml",
+		"config/samples/logstash/logstash_pv.yaml",
+		"config/samples/logstash/logstash_stackmonitor.yaml":
+		return true
+	}
+	return false
+}
+
+func TestSmoke_Samples(t *testing.T) {
+	testSamples(t, isSmokeSample)
+}
+
 func TestSamples(t *testing.T) {
+	testSamples(t, func(_ string) bool { return true })
+}
+
+func testSamples(t *testing.T, shouldRun func(sampleName string) bool) {
 	sampleFiles, err := filepath.Glob("../../config/samples/*/*.yaml")
 	require.NoError(t, err, "Failed to find samples")
 
 	decoder := helper.NewYAMLDecoder()
 	for _, sample := range sampleFiles {
+		if !shouldRun(sample) {
+			continue
+		}
 		testName := helper.MkTestName(t, sample)
 		builders := createBuilders(t, decoder, sample, testName)
 		t.Run(testName, func(t *testing.T) {

--- a/test/e2e/smoke_test.go
+++ b/test/e2e/smoke_test.go
@@ -24,7 +24,7 @@ import (
 const sampleFile = "../../config/samples/apm/apm_es_kibana.yaml"
 
 // TestSmoke runs a test suite using the ApmServer + Kibana + ES + Beat sample.
-func TestSmoke(t *testing.T) {
+func TestSmokeLite(t *testing.T) {
 	runStatefulSmoke(t)
 }
 

--- a/test/e2e/smoke_test.go
+++ b/test/e2e/smoke_test.go
@@ -9,6 +9,7 @@ package e2e
 import (
 	"bufio"
 	"os"
+	"strings"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -74,4 +75,17 @@ func runStatefulSmoke(t *testing.T) {
 
 	test.Sequence(nil, test.EmptySteps, esBuilder, kbBuilder, apmBuilder).
 		RunSequential(t)
+}
+
+func isSmokeSample(sampleFile string) bool {
+	s, _ := strings.CutPrefix(sampleFile, "../../")
+	switch s {
+	case
+		"config/samples/apm/apm_es_kibana.yaml",
+		"config/samples/elasticsearch/elasticsearch.yaml",
+		"config/samples/logstash/logstash_pv.yaml",
+		"config/samples/logstash/logstash_stackmonitor.yaml":
+		return true
+	}
+	return false
 }

--- a/test/e2e/smoke_test.go
+++ b/test/e2e/smoke_test.go
@@ -25,7 +25,7 @@ import (
 const sampleFile = "../../config/samples/apm/apm_es_kibana.yaml"
 
 // TestSmoke runs a test suite using the ApmServer + Kibana + ES + Beat sample.
-func TestSmokeLite(t *testing.T) {
+func TestSmoke_Core(t *testing.T) {
 	runStatefulSmoke(t)
 }
 

--- a/test/e2e/smoke_unit_test.go
+++ b/test/e2e/smoke_unit_test.go
@@ -1,0 +1,40 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+//go:build mixed || e2e
+
+package e2e
+
+import (
+	"flag"
+	"testing"
+)
+
+func TestIsSmokeSample(t *testing.T) {
+	if flag.Lookup("testContextPath").Value.String() != "" {
+		t.Skip("skipping unit test in e2e run")
+	}
+
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"../../config/samples/apm/apm_es_kibana.yaml", true},
+		{"../../config/samples/elasticsearch/elasticsearch.yaml", true},
+		{"../../config/samples/logstash/logstash_pv.yaml", true},
+		{"../../config/samples/logstash/logstash_stackmonitor.yaml", true},
+		{"../../config/samples/logstash/logstash_es.yaml", false},
+		{"../../config/samples/kibana/kibana_es.yaml", false},
+		{"../../config/samples/agent/fleet_es_kibana.yaml", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := isSmokeSample(tt.input); got != tt.want {
+				t.Errorf("isSmokeSample(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/test/e2e/stack_test.go
+++ b/test/e2e/stack_test.go
@@ -33,9 +33,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test/logstash"
 )
 
-var (
-	updatedVersion = test.LatestReleasedVersion8x
-)
+var updatedVersion = test.LatestReleasedVersion8x
 
 func initialBuildersToUpgrade(t *testing.T, initialVersion string) ([]test.Builder, []test.Builder, StackResourceVersions) {
 	// Single-node ES clusters cannot be green with APM indices (see https://github.com/elastic/apm-server/issues/414).
@@ -134,7 +132,6 @@ func TestVersionUpgradeOrderingWithLogstash(t *testing.T) {
 // runVersionUpgradeOrdering deploys the entire stack, with resources associated together.
 // Then, it updates their version, and ensures a strict ordering is respected during the version upgrade.
 func runVersionUpgradeOrdering(t *testing.T, initialBuilders []test.Builder, updatedBuilders []test.Builder, stackVersions StackResourceVersions) {
-
 	// upgrading the entire stack can take some time, since we need to account for (in order):
 	// - Elasticsearch rolling upgrade
 	// - Kibana + Enterprise Search deployments upgrade
@@ -214,7 +211,6 @@ func (s StackResourceVersions) IsValid() bool {
 		// ES >= EnterpriseSearch
 		s.Elasticsearch.GTE(s.EnterpriseSearch) &&
 		isLogstashValid
-
 }
 
 func (s StackResourceVersions) AllSetTo(version string) bool {


### PR DESCRIPTION
## Summary

Reduces the main pipeline by replacing the single `gke/all` job (full test suite) with a targeted `TestSmoke_` run across all five providers (gke, kind, aks, eks) on every merge to main.

> ocp was left out because it takes ~48m to create the cluster.

## Changes

**Pipeline (`.buildkite/pipeline-e2e-tests.yml`):** replaced `gke/all` with five provider jobs each filtered to `TESTS_MATCH: TestSmoke`.

**Test cases (`TestSmoke_` prefix) and samples added to the smoke suite :**
 - `TestSmoke_KubernetesIntegrationRecipe` — standalone Elastic Agent with Kubernetes integration
 - `TestSmoke_FleetKubernetesIntegrationRecipe` — Fleet Server + managed Elastic Agent with Kubernetes integration
 - `TestSmoke_MetricbeatHostsRecipe` — standalone Metricbeat collecting system metrics
 - `TestSmoke_Samples` — curated subset of sample YAMLs: APM+ES+Kibana, Elasticsearch, Logstash+ES output, Logstash with persistent queue, and Logstash stack monitoring
 - `config/samples/apm/apm_es_kibana.yaml`
 - `config/samples/elasticsearch/elasticsearch.yaml`
 - `config/samples/logstash/logstash_pv.yaml`
 - `config/samples/logstash/logstash_stackmonitor.yaml`

**`TestSmoke` → `TestSmoke_Core`:** the existing APM+ES+Kibana smoke test is renamed to `TestSmokeLite'.

`TestSamples` intentionally still runs all samples (including those in the smoke subset), so that anyone triggering it via a PR comment gets the full picture, excluding smoke samples from `TestSamples` would make the name misleading and produce surprising gaps in coverage.
___

The generated pipeline yaml can me verified with this:

```shell
cat <<DEF | ./pipeline-gen
- label: gke/TestSmoke
  fixed:
    E2E_PROVIDER: gke
    TESTS_MATCH: TestSmoke
- label: kind/TestSmoke
  fixed:
    E2E_PROVIDER: kind
    TESTS_MATCH: TestSmoke
- label: aks/TestSmoke
  fixed:
    E2E_PROVIDER: aks
    TESTS_MATCH: TestSmoke
- label: eks/TestSmoke
  fixed:
    E2E_PROVIDER: eks
    TESTS_MATCH: TestSmoke
- label: ocp/TestSmoke
  fixed:
    E2E_PROVIDER: ocp
    TESTS_MATCH: TestSmoke
DEF
```