### PR TITLE
Logstash: use TCP socket readiness probe when API basic auth is enabled

### DIFF
--- a/pkg/controller/logstash/config.go
+++ b/pkg/controller/logstash/config.go
@@ -40,26 +40,26 @@ const (
 	APIKeystorePassEnv     = "API_KEYSTORE_PASS" // #nosec G101
 )
 
-func reconcileConfig(params Params, svcUseTLS bool, configHash hash.Hash) (*settings.CanonicalConfig, configs.APIServer, error) {
+func reconcileConfig(params Params, svcUseTLS bool, configHash hash.Hash) (configs.APIServer, error) {
 	defer tracing.Span(&params.Context)()
 
 	cfg, err := buildConfig(params, svcUseTLS)
 	if err != nil {
-		return nil, configs.APIServer{}, err
+		return configs.APIServer{}, err
 	}
 
 	apiServerConfig, err := resolveAPIServerConfig(cfg, params)
 	if err != nil {
-		return nil, configs.APIServer{}, err
+		return configs.APIServer{}, err
 	}
 
 	if err = checkTLSConfig(apiServerConfig, svcUseTLS); err != nil {
-		return nil, configs.APIServer{}, err
+		return configs.APIServer{}, err
 	}
 
 	cfgBytes, err := cfg.Render()
 	if err != nil {
-		return nil, configs.APIServer{}, err
+		return configs.APIServer{}, err
 	}
 
 	expected := corev1.Secret{
@@ -81,12 +81,21 @@ func reconcileConfig(params Params, svcUseTLS bool, configHash hash.Hash) (*sett
 	}
 
 	if _, err = reconciler.ReconcileSecret(params.Context, params.Client, expected, &params.Logstash); err != nil {
-		return nil, configs.APIServer{}, err
+		return configs.APIServer{}, err
 	}
 
 	_, _ = configHash.Write(cfgBytes)
 
-	return cfg, apiServerConfig, nil
+	// include resolved credentials so that pods rotate when the backing Secret or ConfigMap changes;
+	// length-prefixed to avoid boundary ambiguity (e.g. ("a","bc") vs ("ab","c"))
+	if apiServerConfig.UsesBasicAuth() {
+		_, _ = fmt.Fprintf(configHash, "%d:%s%d:%s",
+			len(apiServerConfig.Username), apiServerConfig.Username,
+			len(apiServerConfig.Password), apiServerConfig.Password,
+		)
+	}
+
+	return apiServerConfig, nil
 }
 
 func buildConfig(params Params, useTLS bool) (*settings.CanonicalConfig, error) {

--- a/pkg/controller/logstash/config.go
+++ b/pkg/controller/logstash/config.go
@@ -80,6 +80,15 @@ func reconcileConfig(params Params, svcUseTLS bool, configHash hash.Hash) (*sett
 
 	_, _ = configHash.Write(cfgBytes)
 
+	// include resolved credentials so that pods rotate when the backing Secret or ConfigMap changes;
+	// length-prefixed to avoid boundary ambiguity (e.g. ("a","bc") vs ("ab","c"))
+	if apiServerConfig.UsesBasicAuth() {
+		_, _ = fmt.Fprintf(configHash, "%d:%s%d:%s",
+			len(apiServerConfig.Username), apiServerConfig.Username,
+			len(apiServerConfig.Password), apiServerConfig.Password,
+		)
+	}
+
 	return cfg, apiServerConfig, nil
 }
 

--- a/pkg/controller/logstash/config_test.go
+++ b/pkg/controller/logstash/config_test.go
@@ -6,6 +6,7 @@ package logstash
 
 import (
 	"context"
+	"hash/fnv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -907,6 +908,90 @@ func Test_resolveAPIServerConfig(t *testing.T) {
 			assert.Equal(t, tt.want.AuthType, got.AuthType)
 			assert.Equal(t, tt.want.Username, got.Username)
 			assert.Equal(t, tt.want.Password, got.Password)
+		})
+	}
+}
+
+// Test_reconcileConfig_credentialHash verifies that reconcileConfig includes the resolved
+// credentials in the config hash so pods roll on credential rotation. Credentials are
+// injected via pod env vars so they appear as ${VAR} in cfgBytes — the hash difference
+// comes solely from the credential-hashing block, not from the raw config bytes.
+func Test_reconcileConfig_credentialHash(t *testing.T) {
+	buildHash := func(t *testing.T, username, password string) uint32 {
+		t.Helper()
+		h := fnv.New32a()
+		params := Params{
+			Context:       context.Background(),
+			Client:        k8s.NewFakeClient(),
+			EventRecorder: toolsevents.NewFakeRecorder(10),
+			Watches:       watches.NewDynamicWatches(),
+			Logstash: v1alpha1.Logstash{
+				ObjectMeta: metav1.ObjectMeta{Name: "ls", Namespace: "ns"},
+				Spec: v1alpha1.LogstashSpec{
+					Config: &commonv1.Config{Data: map[string]any{
+						"api.auth.type":           "basic",
+						"api.auth.basic.username": "${API_USERNAME}",
+						"api.auth.basic.password": "${API_PASSWORD}",
+					}},
+					PodTemplate: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name: "logstash",
+								Env: []corev1.EnvVar{
+									{Name: "API_USERNAME", Value: username},
+									{Name: "API_PASSWORD", Value: password},
+								},
+							}},
+						},
+					},
+				},
+			},
+		}
+		_, err := reconcileConfig(params, false, h)
+		require.NoError(t, err)
+		return h.Sum32()
+	}
+
+	tests := []struct {
+		name      string
+		username1 string
+		password1 string
+		username2 string
+		password2 string
+		wantEqual bool
+	}{
+		{
+			name:      "same credentials produce the same hash",
+			username1: "user", password1: "pass",
+			username2: "user", password2: "pass",
+			wantEqual: true,
+		},
+		{
+			name:      "different password changes the hash",
+			username1: "user", password1: "pass1",
+			username2: "user", password2: "pass2",
+		},
+		{
+			name:      "different username changes the hash",
+			username1: "user1", password1: "pass",
+			username2: "user2", password2: "pass",
+		},
+		{
+			name:      "boundary collision is avoided: (a,bc) vs (ab,c)",
+			username1: "a", password1: "bc",
+			username2: "ab", password2: "c",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h1 := buildHash(t, tt.username1, tt.password1)
+			h2 := buildHash(t, tt.username2, tt.password2)
+			if tt.wantEqual {
+				assert.Equal(t, h1, h2)
+			} else {
+				assert.NotEqual(t, h1, h2)
+			}
 		})
 	}
 }

--- a/pkg/controller/logstash/configs/api_server.go
+++ b/pkg/controller/logstash/configs/api_server.go
@@ -4,6 +4,8 @@
 
 package configs
 
+import "strings"
+
 // APIServer hold the resolved api.* config
 type APIServer struct {
 	SSLEnabled       string
@@ -21,4 +23,8 @@ func (server APIServer) UseTLS() bool {
 		return false
 	}
 	return false
+}
+
+func (server APIServer) UsesBasicAuth() bool {
+	return strings.EqualFold(server.AuthType, "basic")
 }

--- a/pkg/controller/logstash/configs/api_server_test.go
+++ b/pkg/controller/logstash/configs/api_server_test.go
@@ -1,0 +1,50 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package configs
+
+import "testing"
+
+func TestAPIServer_UsesBasicAuth(t *testing.T) {
+	tests := []struct {
+		name     string
+		authType string
+		want     bool
+	}{
+		{name: "lowercase basic", authType: "basic", want: true},
+		{name: "titlecase Basic", authType: "Basic", want: true},
+		{name: "uppercase BASIC", authType: "BASIC", want: true},
+		{name: "empty auth type", authType: "", want: false},
+		{name: "other auth type", authType: "none", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := APIServer{AuthType: tt.authType}
+			if got := s.UsesBasicAuth(); got != tt.want {
+				t.Errorf("UsesBasicAuth() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAPIServer_UseTLS(t *testing.T) {
+	tests := []struct {
+		name       string
+		sslEnabled string
+		want       bool
+	}{
+		{name: "empty defaults to TLS on", sslEnabled: "", want: true},
+		{name: "explicit true", sslEnabled: "true", want: true},
+		{name: "explicit false", sslEnabled: "false", want: false},
+		{name: "unrecognised value defaults to off", sslEnabled: "yes", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := APIServer{SSLEnabled: tt.sslEnabled}
+			if got := s.UseTLS(); got != tt.want {
+				t.Errorf("UseTLS() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/logstash/driver.go
+++ b/pkg/controller/logstash/driver.go
@@ -127,7 +127,7 @@ func internalReconcile(params Params) (*reconciler.Results, logstashv1alpha1.Log
 
 	configHash := fnv.New32a()
 
-	if _, params.APIServerConfig, err = reconcileConfig(params, apiSvcTLS.Enabled(), configHash); err != nil {
+	if params.APIServerConfig, err = reconcileConfig(params, apiSvcTLS.Enabled(), configHash); err != nil {
 		return results.WithError(err), params.Status
 	}
 

--- a/pkg/controller/logstash/network/ports.go
+++ b/pkg/controller/logstash/network/ports.go
@@ -6,5 +6,5 @@ package network
 
 const (
 	// HTTPPort is the (default) API port used by Logstash
-	HTTPPort = 9600
+	HTTPPort = int32(9600)
 )

--- a/pkg/controller/logstash/pod.go
+++ b/pkg/controller/logstash/pod.go
@@ -5,10 +5,8 @@
 package logstash
 
 import (
-	"encoding/base64"
 	"fmt"
 	"hash"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -138,23 +136,20 @@ func buildPodTemplate(params Params, configHash hash.Hash32) (corev1.PodTemplate
 
 func getDefaultContainerPorts() []corev1.ContainerPort {
 	return []corev1.ContainerPort{
-		{Name: "http", ContainerPort: int32(network.HTTPPort), Protocol: corev1.ProtocolTCP},
+		{Name: "http", ContainerPort: network.HTTPPort, Protocol: corev1.ProtocolTCP},
 	}
 }
 
-// readinessProbe is the readiness probe for the Logstash container
+// readinessProbe is the readiness probe for the Logstash container.
+// When basic auth is enabled a TCPSocket probe is used.
 func readinessProbe(params Params) corev1.Probe {
 	logstash := params.Logstash
+	cfg := params.APIServerConfig
 
-	var scheme = corev1.URISchemeHTTP
-	if params.APIServerConfig.UseTLS() {
-		scheme = corev1.URISchemeHTTPS
-	}
-
-	var port = network.HTTPPort
+	port := network.HTTPPort
 	for _, service := range logstash.Spec.Services {
 		if service.Name == LogstashAPIServiceName && len(service.Service.Spec.Ports) > 0 {
-			port = int(service.Service.Spec.Ports[0].Port)
+			port = service.Service.Spec.Ports[0].Port
 		}
 	}
 
@@ -164,30 +159,30 @@ func readinessProbe(params Params) corev1.Probe {
 		PeriodSeconds:       10,
 		SuccessThreshold:    1,
 		TimeoutSeconds:      5,
-		ProbeHandler: corev1.ProbeHandler{
-			HTTPGet: &corev1.HTTPGetAction{
-				Port:        intstr.FromInt(port),
-				Path:        "/",
-				Scheme:      scheme,
-				HTTPHeaders: getHTTPHeaders(params),
+	}
+
+	if cfg.UsesBasicAuth() {
+		probe.ProbeHandler = corev1.ProbeHandler{
+			TCPSocket: &corev1.TCPSocketAction{
+				Port: intstr.FromInt32(port),
 			},
+		}
+		return probe
+	}
+
+	scheme := corev1.URISchemeHTTP
+	if cfg.UseTLS() {
+		scheme = corev1.URISchemeHTTPS
+	}
+
+	probe.ProbeHandler = corev1.ProbeHandler{
+		HTTPGet: &corev1.HTTPGetAction{
+			Port:   intstr.FromInt32(port),
+			Path:   "/",
+			Scheme: scheme,
 		},
 	}
 	return probe
-}
-
-// getHTTPHeaders when api.auth.type is set, take api.auth.basic.username and api.auth.basic.password from logstash.yml
-// to build Authorization header
-func getHTTPHeaders(params Params) []corev1.HTTPHeader {
-	if strings.ToLower(params.APIServerConfig.AuthType) != "basic" {
-		return nil
-	}
-
-	usernamePassword := fmt.Sprintf("%s:%s", params.APIServerConfig.Username, params.APIServerConfig.Password)
-	encodedUsernamePassword := base64.StdEncoding.EncodeToString([]byte(usernamePassword))
-	authHeader := corev1.HTTPHeader{Name: "Authorization", Value: fmt.Sprintf("Basic %s", encodedUsernamePassword)}
-
-	return []corev1.HTTPHeader{authHeader}
 }
 
 func getEsAssociations(params Params) []commonv1.Association {

--- a/pkg/controller/logstash/pod.go
+++ b/pkg/controller/logstash/pod.go
@@ -5,10 +5,8 @@
 package logstash
 
 import (
-	"encoding/base64"
 	"fmt"
 	"hash"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -132,23 +130,21 @@ func buildPodTemplate(params Params, configHash hash.Hash32) (corev1.PodTemplate
 
 func getDefaultContainerPorts() []corev1.ContainerPort {
 	return []corev1.ContainerPort{
-		{Name: "http", ContainerPort: int32(network.HTTPPort), Protocol: corev1.ProtocolTCP},
+		{Name: "http", ContainerPort: network.HTTPPort, Protocol: corev1.ProtocolTCP},
 	}
 }
 
-// readinessProbe is the readiness probe for the Logstash container
+// readinessProbe is the readiness probe for the Logstash container.
+// When basic auth is enabled, a TCPSocket probe is used to avoid embedding credentials in the Pod spec.
+// Note that TCP probes only verify that the port accepts connections (they do not validate TLS handshakes or HTTP responses).
 func readinessProbe(params Params) corev1.Probe {
 	logstash := params.Logstash
+	cfg := params.APIServerConfig
 
-	var scheme = corev1.URISchemeHTTP
-	if params.APIServerConfig.UseTLS() {
-		scheme = corev1.URISchemeHTTPS
-	}
-
-	var port = network.HTTPPort
+	port := network.HTTPPort
 	for _, service := range logstash.Spec.Services {
 		if service.Name == LogstashAPIServiceName && len(service.Service.Spec.Ports) > 0 {
-			port = int(service.Service.Spec.Ports[0].Port)
+			port = service.Service.Spec.Ports[0].Port
 		}
 	}
 
@@ -158,30 +154,30 @@ func readinessProbe(params Params) corev1.Probe {
 		PeriodSeconds:       10,
 		SuccessThreshold:    1,
 		TimeoutSeconds:      5,
-		ProbeHandler: corev1.ProbeHandler{
-			HTTPGet: &corev1.HTTPGetAction{
-				Port:        intstr.FromInt(port),
-				Path:        "/",
-				Scheme:      scheme,
-				HTTPHeaders: getHTTPHeaders(params),
+	}
+
+	if cfg.UsesBasicAuth() {
+		probe.ProbeHandler = corev1.ProbeHandler{
+			TCPSocket: &corev1.TCPSocketAction{
+				Port: intstr.FromInt32(port),
 			},
+		}
+		return probe
+	}
+
+	scheme := corev1.URISchemeHTTP
+	if cfg.UseTLS() {
+		scheme = corev1.URISchemeHTTPS
+	}
+
+	probe.ProbeHandler = corev1.ProbeHandler{
+		HTTPGet: &corev1.HTTPGetAction{
+			Port:   intstr.FromInt32(port),
+			Path:   "/",
+			Scheme: scheme,
 		},
 	}
 	return probe
-}
-
-// getHTTPHeaders when api.auth.type is set, take api.auth.basic.username and api.auth.basic.password from logstash.yml
-// to build Authorization header
-func getHTTPHeaders(params Params) []corev1.HTTPHeader {
-	if strings.ToLower(params.APIServerConfig.AuthType) != "basic" {
-		return nil
-	}
-
-	usernamePassword := fmt.Sprintf("%s:%s", params.APIServerConfig.Username, params.APIServerConfig.Password)
-	encodedUsernamePassword := base64.StdEncoding.EncodeToString([]byte(usernamePassword))
-	authHeader := corev1.HTTPHeader{Name: "Authorization", Value: fmt.Sprintf("Basic %s", encodedUsernamePassword)}
-
-	return []corev1.HTTPHeader{authHeader}
 }
 
 func getEsAssociations(params Params) []commonv1.Association {

--- a/pkg/controller/logstash/pod_test.go
+++ b/pkg/controller/logstash/pod_test.go
@@ -6,9 +6,7 @@ package logstash
 
 import (
 	"context"
-	"encoding/base64"
 	"hash/fnv"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -251,7 +249,7 @@ func TestNewPodTemplateSpec(t *testing.T) {
 			},
 		},
 		{
-			name: "with basic auth set, readiness probe creates Authorization header",
+			name: "with basic auth set, readiness probe uses TCP socket",
 			logstash: logstashv1alpha1.Logstash{
 				ObjectMeta: meta,
 				Spec: logstashv1alpha1.LogstashSpec{
@@ -259,14 +257,14 @@ func TestNewPodTemplateSpec(t *testing.T) {
 				}},
 			apiServerConfig: GetAPIServerWithAuth(),
 			assertions: func(pod corev1.PodTemplateSpec) {
-				authHeader := GetLogstashContainer(pod.Spec).ReadinessProbe.HTTPGet.HTTPHeaders[0]
-				b, _ := base64.StdEncoding.DecodeString(strings.TrimPrefix(authHeader.Value, "Basic "))
-				assert.Equal(t, "Authorization", authHeader.Name)
-				assert.Equal(t, "logstash:whatever", string(b))
+				probe := GetLogstashContainer(pod.Spec).ReadinessProbe
+				assert.NotNil(t, probe.TCPSocket, "TCP socket probe must be set when basic auth is enabled")
+				assert.Nil(t, probe.HTTPGet, "HTTP probe must not be used when basic auth is enabled")
+				assert.Nil(t, probe.Exec, "exec probe must not be used when basic auth is enabled")
 			},
 		},
 		{
-			name: "with tls set, readiness probe use https protocol",
+			name: "with tls and basic auth set, readiness probe uses TCP socket",
 			logstash: logstashv1alpha1.Logstash{
 				ObjectMeta: meta,
 				Spec: logstashv1alpha1.LogstashSpec{
@@ -276,7 +274,9 @@ func TestNewPodTemplateSpec(t *testing.T) {
 			assertions: func(pod corev1.PodTemplateSpec) {
 				assert.NotNil(t, GetEnvByName(GetConfigInitContainer(pod.Spec).Env, UseTLSEnv))
 				assert.NotNil(t, GetEnvByName(GetConfigInitContainer(pod.Spec).Env, APIKeystorePassEnv))
-				assert.Equal(t, corev1.URISchemeHTTPS, GetLogstashContainer(pod.Spec).ReadinessProbe.HTTPGet.Scheme)
+				probe := GetLogstashContainer(pod.Spec).ReadinessProbe
+				assert.NotNil(t, probe.TCPSocket)
+				assert.Nil(t, probe.HTTPGet)
 			},
 		},
 		{

--- a/pkg/controller/logstash/pod_test.go
+++ b/pkg/controller/logstash/pod_test.go
@@ -6,9 +6,7 @@ package logstash
 
 import (
 	"context"
-	"encoding/base64"
 	"hash/fnv"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -251,22 +249,22 @@ func TestNewPodTemplateSpec(t *testing.T) {
 			},
 		},
 		{
-			name: "with basic auth set, readiness probe creates Authorization header",
+			name: "with basic auth (no TLS), readiness probe uses TCP socket",
 			logstash: logstashv1alpha1.Logstash{
 				ObjectMeta: meta,
 				Spec: logstashv1alpha1.LogstashSpec{
 					Version: "8.6.1",
 				}},
-			apiServerConfig: GetAPIServerWithAuth(),
+			apiServerConfig: GetAPIServerBasicAuthNoTLS(),
 			assertions: func(pod corev1.PodTemplateSpec) {
-				authHeader := GetLogstashContainer(pod.Spec).ReadinessProbe.HTTPGet.HTTPHeaders[0]
-				b, _ := base64.StdEncoding.DecodeString(strings.TrimPrefix(authHeader.Value, "Basic "))
-				assert.Equal(t, "Authorization", authHeader.Name)
-				assert.Equal(t, "logstash:whatever", string(b))
+				probe := GetLogstashContainer(pod.Spec).ReadinessProbe
+				assert.NotNil(t, probe.TCPSocket, "TCP socket probe must be set when basic auth is enabled")
+				assert.Nil(t, probe.HTTPGet, "HTTP probe must not be used when basic auth is enabled")
+				assert.Nil(t, probe.Exec, "exec probe must not be used when basic auth is enabled")
 			},
 		},
 		{
-			name: "with tls set, readiness probe use https protocol",
+			name: "with tls and basic auth set, readiness probe uses TCP socket",
 			logstash: logstashv1alpha1.Logstash{
 				ObjectMeta: meta,
 				Spec: logstashv1alpha1.LogstashSpec{
@@ -276,11 +274,38 @@ func TestNewPodTemplateSpec(t *testing.T) {
 			assertions: func(pod corev1.PodTemplateSpec) {
 				assert.NotNil(t, GetEnvByName(GetConfigInitContainer(pod.Spec).Env, UseTLSEnv))
 				assert.NotNil(t, GetEnvByName(GetConfigInitContainer(pod.Spec).Env, APIKeystorePassEnv))
-				assert.Equal(t, corev1.URISchemeHTTPS, GetLogstashContainer(pod.Spec).ReadinessProbe.HTTPGet.Scheme)
+				probe := GetLogstashContainer(pod.Spec).ReadinessProbe
+				assert.NotNil(t, probe.TCPSocket)
+				assert.Nil(t, probe.HTTPGet)
 			},
 		},
 		{
-			name: "with default service, readiness probe hits the correct port",
+			name: "with basic auth and custom service port, TCPSocket probe uses the custom port",
+			logstash: logstashv1alpha1.Logstash{
+				ObjectMeta: meta,
+				Spec: logstashv1alpha1.LogstashSpec{
+					Version: "8.6.1",
+					Services: []logstashv1alpha1.LogstashService{{
+						Name: LogstashAPIServiceName,
+						Service: commonv1.ServiceTemplate{
+							Spec: corev1.ServiceSpec{
+								Ports: []corev1.ServicePort{
+									{Name: "api", Protocol: "TCP", Port: 9200},
+								},
+							},
+						},
+					}},
+				}},
+			apiServerConfig: GetAPIServerWithAuth(),
+			assertions: func(pod corev1.PodTemplateSpec) {
+				probe := GetLogstashContainer(pod.Spec).ReadinessProbe
+				assert.NotNil(t, probe.TCPSocket)
+				assert.Equal(t, 9200, probe.TCPSocket.Port.IntValue())
+				assert.Nil(t, probe.HTTPGet)
+			},
+		},
+		{
+			name: "with default service, readiness probe hits the correct port with HTTPS",
 			logstash: logstashv1alpha1.Logstash{
 				ObjectMeta: meta,
 				Spec: logstashv1alpha1.LogstashSpec{
@@ -288,7 +313,9 @@ func TestNewPodTemplateSpec(t *testing.T) {
 				}},
 			apiServerConfig: GetDefaultAPIServer(),
 			assertions: func(pod corev1.PodTemplateSpec) {
-				assert.Equal(t, 9600, GetLogstashContainer(pod.Spec).ReadinessProbe.HTTPGet.Port.IntValue())
+				probe := GetLogstashContainer(pod.Spec).ReadinessProbe
+				assert.Equal(t, 9600, probe.HTTPGet.Port.IntValue())
+				assert.Equal(t, corev1.URISchemeHTTPS, probe.HTTPGet.Scheme)
 			},
 		},
 
@@ -414,5 +441,14 @@ func GetDefaultAPIServer() configs.APIServer {
 		AuthType:         "",
 		Username:         "",
 		Password:         "",
+	}
+}
+
+func GetAPIServerBasicAuthNoTLS() configs.APIServer {
+	return configs.APIServer{
+		SSLEnabled: "false",
+		AuthType:   "basic",
+		Username:   "logstash",
+		Password:   "whatever",
 	}
 }

--- a/test/e2e/test/logstash/http_client.go
+++ b/test/e2e/test/logstash/http_client.go
@@ -38,7 +38,7 @@ func DoRequest(client *http.Client, logstash v1alpha1.Logstash, method, path str
 	var port = network.HTTPPort
 	for _, service := range logstash.Spec.Services {
 		if service.Name == ls.LogstashAPIServiceName && len(service.Service.Spec.Ports) > 0 {
-			port = int(service.Service.Spec.Ports[0].Port)
+			port = service.Service.Spec.Ports[0].Port
 		}
 	}
 


### PR DESCRIPTION
## Summary

When `api.auth.type: basic` is configured, the Logstash readiness probe previously embedded the resolved API credentials as an `Authorization: Basic …` HTTP header directly in the StatefulSet spec. This PR moves to a TCPSocket probe in that case, keeping the pod spec free of credentials entirely.

## Changes

- **TCPSocket probe for basic auth.** When basic auth is enabled the readiness probe switches from an `httpGet` action to a `tcpSocket` action. Kubernetes directs TCP probes to the Pod IP directly, bypassing any Service or LoadBalancer, so the semantics are equivalent to the previous kubelet-originated HTTP probe — the kubelet verifies that Logstash is accepting connections on the API port.

- **Pod rotation on credential change.** The resolved credentials are still included in the config hash so that pods roll whenever the backing Secret or ConfigMap is updated, even though the probe itself does not read them.
