### PR TITLE
Retry transient pod kill setup failures in E2E tests

### DIFF
--- a/test/e2e/test/run_failure.go
+++ b/test/e2e/test/run_failure.go
@@ -62,7 +62,6 @@ func runFailureScenario(t *testing.T, recoverable bool, failureSteps StepsFunc, 
 // KillNodeSteps returns failure steps that delete one matching pod and wait for that exact pod to be gone or replaced.
 func KillNodeSteps(podMatch func(p corev1.Pod) bool, opts ...client.ListOption) StepsFunc {
 	var killedPod corev1.Pod
-	//nolint:thelper
 	return func(k *K8sClient) StepList {
 		return StepList{
 			{

--- a/test/e2e/test/run_failure.go
+++ b/test/e2e/test/run_failure.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -60,6 +59,7 @@ func runFailureScenario(t *testing.T, recoverable bool, failureSteps StepsFunc, 
 	steps.RunSequential(t)
 }
 
+// KillNodeSteps returns failure steps that delete one matching pod and wait for that exact pod to be gone or replaced.
 func KillNodeSteps(podMatch func(p corev1.Pod) bool, opts ...client.ListOption) StepsFunc {
 	var killedPod corev1.Pod
 	//nolint:thelper
@@ -67,15 +67,39 @@ func KillNodeSteps(podMatch func(p corev1.Pod) bool, opts ...client.ListOption) 
 		return StepList{
 			{
 				Name: "Kill a node",
-				Test: func(t *testing.T) {
-					pods, err := k.GetPods(opts...)
-					require.NoError(t, err)
-					var found bool
-					killedPod, found = GetFirstPodMatching(pods, podMatch)
-					require.True(t, found)
-					err = k.DeletePod(killedPod)
-					require.NoError(t, err)
-				},
+				Test: Eventually(func() error {
+					if killedPod.Name == "" {
+						pods, err := k.GetPods(opts...)
+						if err != nil {
+							return err
+						}
+						var found bool
+						killedPod, found = GetFirstPodMatching(pods, podMatch)
+						if !found {
+							return fmt.Errorf("no matching pod found")
+						}
+					}
+
+					pod, err := k.GetPod(killedPod.Namespace, killedPod.Name)
+					if apierrors.IsNotFound(err) {
+						return nil
+					}
+					if err != nil {
+						return err
+					}
+					// A different UID means the original pod was already deleted and replaced.
+					if pod.UID != killedPod.UID {
+						return nil
+					}
+
+					if err := k.DeletePod(pod); err != nil {
+						if apierrors.IsNotFound(err) {
+							return nil
+						}
+						return err
+					}
+					return nil
+				}),
 			},
 			{
 				Name: "Wait for pod to be deleted",


### PR DESCRIPTION
Retry the pod selection/deletion step used by E2E failure scenarios.

This failed in one of our E2E test sessions before the failure was actually injected. `TestKillKibanaPod` hit a transient Kubernetes API error while listing the target pod:

  ```text
  === RUN   TestKillKibanaPod/Kill_a_node
      run_failure.go:72:
          Error: Received unexpected error:
              rpc error: code = Canceled desc = CANCELLED
```

The helper now wraps the kill step in Eventually, pins the selected pod by UID, and treats the original pod being gone or replaced as success