### PR TITLE
Add containerPort 8200 and secret token injection to Fleet APM integration recipe

### DIFF
--- a/config/recipes/elastic-agent/README.asciidoc
+++ b/config/recipes/elastic-agent/README.asciidoc
@@ -43,6 +43,14 @@ Deploys Elastic Agent as a DaemonSet in Fleet mode with Custom Logs integration 
 
 Deploys a single-instance Elastic Agent Deployment in Fleet mode with the APM integration enabled. The APM server listens on port 8200 inside the agent pod and is exposed to the cluster via a dedicated Kubernetes Service. A secret token is pre-configured in the Fleet agent policy to authenticate APM agents. Kibana is configured to send its own telemetry to the APM endpoint.
 
+Before deploying, replace the placeholder value `my-apm-secret-token` in the `apm-secret-token` Secret with a secret of your choice.
+
+To rotate the token: patch the Secret with the new value, then manually restart Kibana (ECK does not roll Kibana when a referenced Secret changes). On restart, Fleet force-updates the stored agent policy with the new token. Update any APM agents or clients to match.
+
+NOTE: The `frozen: true` flag is accepted by all Kibana versions that support Fleet pre-configuration. On Kibana >= 9.2.0 it additionally causes Fleet to force-update the stored policy value on every Kibana restart, keeping it in sync after a token rotation (https://github.com/elastic/kibana/pull/235306). On older versions the field has no effect: the stored policy silently retains the old token after a rotation and must be updated manually.
+
+NOTE: The APM secret token travels between Kibana and the APM endpoint over plain HTTP within the cluster network.
+
 ===== Synthetic monitoring - `synthetic-monitoring.yaml`
 
 Deploys an Fleet-enrolled Elastic Agent that can be used as for link:https://www.elastic.co/guide/en/observability/current/monitor-uptime-synthetics.html[Synthetic monitoring]. This Elastic Agent uses the `elastic-agent-complete` image. The agent policy still needs to be link:https://www.elastic.co/guide/en/observability/current/synthetics-private-location.html#synthetics-private-location-add[registered as private location] in Kibana.

--- a/config/recipes/elastic-agent/README.asciidoc
+++ b/config/recipes/elastic-agent/README.asciidoc
@@ -41,7 +41,7 @@ Deploys Elastic Agent as a DaemonSet in Fleet mode with Custom Logs integration 
 
 ===== APM integration - `fleet-apm-integration.yaml`
 
-Deploys single instance Elastic Agent Deployment in Fleet mode with APM integration enabled.
+Deploys a single-instance Elastic Agent Deployment in Fleet mode with the APM integration enabled. The APM server listens on port 8200 inside the agent pod and is exposed to the cluster via a dedicated Kubernetes Service. A secret token is pre-configured in the Fleet agent policy to authenticate APM agents. Kibana is configured to send its own telemetry to the APM endpoint.
 
 ===== Synthetic monitoring - `synthetic-monitoring.yaml`
 

--- a/config/recipes/elastic-agent/fleet-apm-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-apm-integration.yaml
@@ -1,3 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: apm-secret-token
+stringData:
+  # Change this value before deploying to production.
+  token: "my-apm-secret-token"
+---
 apiVersion: kibana.k8s.elastic.co/v1
 kind: Kibana
 metadata:
@@ -7,9 +15,30 @@ spec:
   count: 1
   elasticsearchRef:
     name: elasticsearch
+  podTemplate:
+    spec:
+      containers:
+      - name: kibana
+        env:
+        # The token is injected from the apm-secret-token Secret and interpolated
+        # into kibana.yml via ${APM_SECRET_TOKEN} for both the Kibana APM agent
+        # and the Fleet pre-configuration below.
+        - name: APM_SECRET_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: apm-secret-token
+              key: token
   config:
+    # Send Kibana's own telemetry to the Fleet-managed APM endpoint.
+    elastic.apm.active: true
+    elastic.apm.serverUrl: "http://apm.default.svc:8200"
+    elastic.apm.secretToken: "${APM_SECRET_TOKEN}"
+
+    # Fleet configuration: point agents to Elasticsearch and the Fleet Server.
     xpack.fleet.agents.elasticsearch.hosts: ["https://elasticsearch-es-http.default.svc:9200"]
     xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server-agent-http.default.svc:8220"]
+
+    # Pre-install the packages used by the agent policies below.
     xpack.fleet.packages:
     - name: system
       version: latest
@@ -46,15 +75,24 @@ spec:
         id: system-1
         package:
           name: system
-      - package:
+      # APM integration: listens on 0.0.0.0:8200 inside the agent pod.
+      - name: apm-1
+        package:
           name: apm
-        name: apm-1
         inputs:
         - type: apm
           enabled: true
           vars:
           - name: host
-            value: 0.0.0.0:8200    
+            value: 0.0.0.0:8200
+          # Fleet pre-configuration does not support Kibana keystore values, so the
+          # token is injected via the APM_SECRET_TOKEN env var instead (see podTemplate above).
+          - name: secret_token
+            value: "${APM_SECRET_TOKEN}"
+            # frozen: true causes Fleet to force-update this var on every Kibana restart,
+            # ensuring the stored policy value stays in sync after a token rotation.
+            # Requires Kibana >= 9.2.0 (https://github.com/elastic/kibana/pull/235306).
+            frozen: true
 ---
 apiVersion: elasticsearch.k8s.elastic.co/v1
 kind: Elasticsearch
@@ -63,10 +101,12 @@ metadata:
 spec:
   version: 9.4.3
   nodeSets:
-  - name: default
-    count: 3
-    config:
-      node.store.allow_mmap: false
+    - name: default
+      count: 3
+      config:
+        # This setting could have performance implications for production clusters.
+        # See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html
+        node.store.allow_mmap: false
 ---
 apiVersion: agent.k8s.elastic.co/v1alpha1
 kind: Agent
@@ -92,13 +132,13 @@ spec:
 ---
 apiVersion: agent.k8s.elastic.co/v1alpha1
 kind: Agent
-metadata: 
+metadata:
   name: elastic-agent
 spec:
   version: 9.4.3
   kibanaRef:
     name: kibana
-  fleetServerRef: 
+  fleetServerRef:
     name: fleet-server
   mode: fleet
   policyID: eck-agent
@@ -108,6 +148,13 @@ spec:
       spec:
         securityContext:
           runAsUser: 0
+        containers:
+        - name: agent
+          ports:
+          # Expose the APM port so that the Service below can route traffic to it.
+          - name: apm
+            containerPort: 8200
+            protocol: TCP
 ---
 apiVersion: v1
 kind: Service
@@ -117,8 +164,10 @@ spec:
   selector:
     agent.k8s.elastic.co/name: elastic-agent
   ports:
-  - protocol: TCP
+  - name: apm
+    protocol: TCP
     port: 8200
+    targetPort: 8200
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -136,18 +185,18 @@ rules:
   - list
 - apiGroups: ["apps"]
   resources:
-    - replicasets
+  - replicasets
   verbs:
-    - get
-    - watch
-    - list
+  - get
+  - watch
+  - list
 - apiGroups: ["batch"]
   resources:
-    - jobs
+  - jobs
   verbs:
-    - get
-    - watch
-    - list
+  - get
+  - watch
+  - list
 - apiGroups: ["coordination.k8s.io"]
   resources:
   - leases

--- a/config/recipes/elastic-agent/fleet-apm-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-apm-integration.yaml
@@ -89,9 +89,10 @@ spec:
           # token is injected via the APM_SECRET_TOKEN env var instead (see podTemplate above).
           - name: secret_token
             value: "${APM_SECRET_TOKEN}"
-            # frozen: true causes Fleet to force-update this var on every Kibana restart,
-            # ensuring the stored policy value stays in sync after a token rotation.
-            # Requires Kibana >= 9.2.0 (https://github.com/elastic/kibana/pull/235306).
+            # frozen: true is accepted by all Kibana versions that support Fleet pre-configuration.
+            # On Kibana >= 9.2.0 it additionally causes Fleet to force-update this var on every
+            # Kibana restart, keeping the stored policy in sync after a token rotation
+            # (https://github.com/elastic/kibana/pull/235306).
             frozen: true
 ---
 apiVersion: elasticsearch.k8s.elastic.co/v1
@@ -151,7 +152,6 @@ spec:
         containers:
         - name: agent
           ports:
-          # Expose the APM port so that the Service below can route traffic to it.
           - name: apm
             containerPort: 8200
             protocol: TCP

--- a/test/e2e/agent/config_test.go
+++ b/test/e2e/agent/config_test.go
@@ -188,7 +188,6 @@ func TestFleetMode(t *testing.T) {
 		WithNodeCount(1)
 
 	t.Run("Fleet in same namespace as Agent", func(t *testing.T) {
-
 		fleetServerBuilder := agent.NewBuilder(name + "-fs").
 			WithNamespace(agentNS).
 			WithRoles(agent.AgentFleetModeRoleName).
@@ -216,7 +215,6 @@ func TestFleetMode(t *testing.T) {
 	})
 
 	t.Run("Fleet in different namespace than Agent", func(t *testing.T) {
-
 		fleetServerBuilder := agent.NewBuilder(name + "-fs").
 			WithNamespace(fleetNS).
 			WithRoles(agent.AgentFleetModeRoleName).
@@ -281,7 +279,6 @@ func TestFleetModeAdvancedConfig(t *testing.T) {
 	agentBuilder = agent.ApplyYamls(t, agentBuilder, E2EAgentFleetModeAdvancedConfig, E2EAgentFleetModeHostPathPodTemplate)
 
 	test.Sequence(nil, test.EmptySteps, esBuilder, kbBuilder, fleetServerBuilder, agentBuilder).RunSequential(t)
-
 }
 
 func fleetConfigForKibana(t *testing.T, agentVersion string, esRef v1.ObjectSelector, fsRef v1.ObjectSelector, tlsEnabled bool) map[string]interface{} {

--- a/test/e2e/test/helper/yaml.go
+++ b/test/e2e/test/helper/yaml.go
@@ -402,6 +402,17 @@ func transformToE2E(namespace, fullTestName, suffix string, transformers []Build
 		case *corev1.Service:
 			decodedObj.Namespace = namespace
 			decodedObj.Name = decodedObj.Name + "-" + suffix
+			for _, labelKey := range []string{
+				"agent.k8s.elastic.co/name",
+				"beat.k8s.elastic.co/name",
+				"logstash.k8s.elastic.co/name",
+				"apm.k8s.elastic.co/name",
+				"enterprisesearch.k8s.elastic.co/name",
+			} {
+				if v, ok := decodedObj.Spec.Selector[labelKey]; ok {
+					decodedObj.Spec.Selector[labelKey] = v + "-" + suffix
+				}
+			}
 		case *appsv1.DaemonSet:
 			name := decodedObj.Name + "-" + suffix
 			decodedObj.Namespace = namespace

--- a/test/e2e/test/helper/yaml.go
+++ b/test/e2e/test/helper/yaml.go
@@ -25,6 +25,7 @@ import (
 	meta2 "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -72,6 +73,7 @@ func NewYAMLDecoder() *YAMLDecoder {
 	scheme.AddKnownTypes(rbacv1.SchemeGroupVersion, &rbacv1.ClusterRole{}, &rbacv1.ClusterRoleList{})
 	scheme.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.ServiceAccount{}, &corev1.ServiceAccountList{})
 	scheme.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.Service{}, &corev1.ServiceList{})
+	scheme.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.Secret{}, &corev1.SecretList{})
 	scheme.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.ConfigMap{}, &corev1.ConfigMapList{})
 	scheme.AddKnownTypes(appsv1.SchemeGroupVersion, &appsv1.DaemonSet{})
 	scheme.AddKnownTypes(appsv1.SchemeGroupVersion, &appsv1.Deployment{}, &appsv1.DeploymentList{})
@@ -260,6 +262,15 @@ func makeObjectSteps(
 }
 
 func transformToE2E(namespace, fullTestName, suffix string, transformers []BuilderTransform, objects []client.Object) ([]test.Builder, []client.Object) {
+	// Pre-pass: collect the names of Secrets defined in this file so that only
+	// those secretKeyRef references (not ECK-managed secrets) are suffixed.
+	secretsInFile := sets.New[string]()
+	for _, object := range objects {
+		if s, ok := object.(*corev1.Secret); ok {
+			secretsInFile.Insert(s.Name)
+		}
+	}
+
 	var builders []test.Builder
 	var otherObjects []client.Object
 	for _, object := range objects {
@@ -285,6 +296,7 @@ func transformToE2E(namespace, fullTestName, suffix string, transformers []Build
 		case *kbv1.Kibana:
 			b := kibana.NewBuilderWithoutSuffix(decodedObj.Name)
 			b.Kibana = *decodedObj
+			tweakEnvSecretRefs(&b.Kibana.Spec.PodTemplate.Spec, suffix, secretsInFile)
 			builder = b.WithNamespace(namespace).
 				WithVersion(test.Ctx().ElasticStackVersion).
 				WithSuffix(suffix).
@@ -320,6 +332,7 @@ func transformToE2E(namespace, fullTestName, suffix string, transformers []Build
 				b = b.WithPodTemplateServiceAccount(b.PodTemplate.Spec.ServiceAccountName + "-" + suffix)
 			}
 
+			tweakEnvSecretRefs(&b.PodTemplate.Spec, suffix, secretsInFile)
 			builder = b
 		case *entv1.EnterpriseSearch:
 			b := enterprisesearch.NewBuilderWithoutSuffix(decodedObj.Name)
@@ -346,6 +359,7 @@ func transformToE2E(namespace, fullTestName, suffix string, transformers []Build
 				b = b.WithPodTemplateServiceAccount(b.PodTemplate.Spec.ServiceAccountName + "-" + suffix)
 			}
 
+			tweakEnvSecretRefs(&b.PodTemplate.Spec, suffix, secretsInFile)
 			builder = b
 		case *logstashv1alpha1.Logstash:
 			b := logstash.NewBuilderWithoutSuffix(decodedObj.Name)
@@ -381,6 +395,9 @@ func transformToE2E(namespace, fullTestName, suffix string, transformers []Build
 			decodedObj.RoleRef.Name = decodedObj.RoleRef.Name + "-" + suffix
 			decodedObj.Name = decodedObj.Name + "-" + suffix
 		case *rbacv1.ClusterRole:
+			decodedObj.Name = decodedObj.Name + "-" + suffix
+		case *corev1.Secret:
+			decodedObj.Namespace = namespace
 			decodedObj.Name = decodedObj.Name + "-" + suffix
 		case *corev1.Service:
 			decodedObj.Namespace = namespace
@@ -495,6 +512,17 @@ func tweakConfigLiterals(config *commonv1.Config, suffix string, namespace strin
 
 	data := config.Data
 
+	apmServerUrlKey := "elastic.apm.serverUrl"
+	if untypedURL, ok := data[apmServerUrlKey]; ok {
+		if url, ok := untypedURL.(string); ok {
+			data[apmServerUrlKey] = strings.ReplaceAll(
+				url,
+				"apm.default",
+				fmt.Sprintf("apm-%s.%s", suffix, namespace),
+			)
+		}
+	}
+
 	elasticsearchHostsKey := "xpack.fleet.agents.elasticsearch.hosts"
 	if untypedHosts, ok := data[elasticsearchHostsKey]; ok {
 		if untypedHostsSlice, ok := untypedHosts.([]any); ok {
@@ -568,6 +596,27 @@ func tweakConfigLiterals(config *commonv1.Config, suffix string, namespace strin
 	}
 
 	return data
+}
+
+// tweakEnvSecretRefs appends suffix to env var secretKeyRef names that refer to Secrets
+// defined in the same recipe file (secretsInFileSet). Volume mounts, imagePullSecrets, and
+// other Secret references are out of scope.
+func tweakEnvSecretRefs(podSpec *corev1.PodSpec, suffix string, secretsInFileSet sets.Set[string]) {
+	applyToContainers := func(containers []corev1.Container) {
+		for i := range containers {
+			for j := range containers[i].Env {
+				ref := containers[i].Env[j].ValueFrom
+				if ref == nil || ref.SecretKeyRef == nil {
+					continue
+				}
+				if secretsInFileSet.Has(ref.SecretKeyRef.Name) {
+					ref.SecretKeyRef.Name = ref.SecretKeyRef.Name + "-" + suffix
+				}
+			}
+		}
+	}
+	applyToContainers(podSpec.InitContainers)
+	applyToContainers(podSpec.Containers)
 }
 
 func MkTestName(t *testing.T, path string) string {

--- a/test/e2e/test/helper/yaml.go
+++ b/test/e2e/test/helper/yaml.go
@@ -523,10 +523,10 @@ func tweakConfigLiterals(config *commonv1.Config, suffix string, namespace strin
 
 	data := config.Data
 
-	apmServerUrlKey := "elastic.apm.serverUrl"
-	if untypedURL, ok := data[apmServerUrlKey]; ok {
+	apmServerURLKey := "elastic.apm.serverUrl"
+	if untypedURL, ok := data[apmServerURLKey]; ok {
 		if url, ok := untypedURL.(string); ok {
-			data[apmServerUrlKey] = strings.ReplaceAll(
+			data[apmServerURLKey] = strings.ReplaceAll(
 				url,
 				"apm.default",
 				fmt.Sprintf("apm-%s.%s", suffix, namespace),

--- a/test/e2e/test/helper/yaml_test.go
+++ b/test/e2e/test/helper/yaml_test.go
@@ -1,0 +1,113 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package helper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func TestTweakEnvSecretRefs(t *testing.T) {
+	fileSecrets := sets.New("apm-secret-token", "other-secret")
+
+	envVar := func(name, secretName, secretKey string) corev1.EnvVar {
+		return corev1.EnvVar{
+			Name: name,
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
+					Key:                  secretKey,
+				},
+			},
+		}
+	}
+	plainEnvVar := func(name, value string) corev1.EnvVar {
+		return corev1.EnvVar{Name: name, Value: value}
+	}
+
+	for _, tc := range []struct {
+		name          string
+		podSpec       corev1.PodSpec
+		wantEnvs      map[string]string // container name → secretKeyRef name after tweak
+		wantUnchanged []string          // env var names whose secretKeyRef must not change
+	}{
+		{
+			name: "suffixes file-owned secret refs in containers",
+			podSpec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "kibana", Env: []corev1.EnvVar{
+						envVar("APM_SECRET_TOKEN", "apm-secret-token", "token"),
+					}},
+				},
+			},
+			wantEnvs: map[string]string{"APM_SECRET_TOKEN": "apm-secret-token-abc"},
+		},
+		{
+			name: "does not suffix ECK-managed secret refs not in fileSecrets",
+			podSpec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "metricbeat", Env: []corev1.EnvVar{
+						envVar("MONITORED_ES_PASSWORD", "elasticsearch-es-elastic-user", "elastic"),
+					}},
+				},
+			},
+			wantUnchanged: []string{"MONITORED_ES_PASSWORD"},
+		},
+		{
+			name: "handles mixed env vars: file secret suffixed, ECK secret unchanged, plain value unchanged",
+			podSpec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "c", Env: []corev1.EnvVar{
+						envVar("FILE_SECRET", "apm-secret-token", "token"),
+						envVar("ECK_SECRET", "elasticsearch-es-elastic-user", "elastic"),
+						plainEnvVar("PLAIN", "value"),
+					}},
+				},
+			},
+			wantEnvs:      map[string]string{"FILE_SECRET": "apm-secret-token-abc"},
+			wantUnchanged: []string{"ECK_SECRET"},
+		},
+		{
+			name: "suffixes file-owned secret refs in init containers",
+			podSpec: corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{Name: "init", Env: []corev1.EnvVar{
+						envVar("TOKEN", "other-secret", "key"),
+					}},
+				},
+			},
+			wantEnvs: map[string]string{"TOKEN": "other-secret-abc"},
+		},
+		{
+			name:    "no-op on empty pod spec",
+			podSpec: corev1.PodSpec{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tweakEnvSecretRefs(&tc.podSpec, "abc", fileSecrets)
+
+			allContainers := append(tc.podSpec.InitContainers, tc.podSpec.Containers...)
+
+			for _, c := range allContainers {
+				for _, env := range c.Env {
+					if want, ok := tc.wantEnvs[env.Name]; ok {
+						assert.Equal(t, want, env.ValueFrom.SecretKeyRef.Name,
+							"env var %s secretKeyRef.Name", env.Name)
+					}
+					for _, unchanged := range tc.wantUnchanged {
+						if env.Name == unchanged {
+							original := env.ValueFrom.SecretKeyRef.Name
+							assert.NotContains(t, original, "-abc",
+								"env var %s should not have been suffixed", env.Name)
+						}
+					}
+				}
+			}
+		})
+	}
+}

--- a/test/e2e/test/helper/yaml_test.go
+++ b/test/e2e/test/helper/yaml_test.go
@@ -91,7 +91,9 @@ func TestTweakEnvSecretRefs(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tweakEnvSecretRefs(&tc.podSpec, "abc", fileSecrets)
 
-			allContainers := append(tc.podSpec.InitContainers, tc.podSpec.Containers...)
+			allContainers := make([]corev1.Container, 0, len(tc.podSpec.InitContainers)+len(tc.podSpec.Containers))
+			allContainers = append(allContainers, tc.podSpec.InitContainers...)
+			allContainers = append(allContainers, tc.podSpec.Containers...)
 
 			for _, c := range allContainers {
 				for _, env := range c.Env {


### PR DESCRIPTION
## Summary

Fix the Fleet APM integration recipe by adding the missing containerPort: 8200 on the elastic-agent container and introducing proper secret token management via a Kubernetes Secret injected into Kibana as an environment variable. The token is referenced from both Kibana's own APM telemetry config and the Fleet policy var, with frozen: true ensuring the Fleet policy stays in sync on token rotation.

Closes https://github.com/elastic/cloud-on-k8s/issues/6081

## Changes

- Add apm-secret-token Kubernetes Secret as the single source of truth for the APM token
- Inject the token into the Kibana pod as APM_SECRET_TOKEN via secretKeyRef and reference it via ${APM_SECRET_TOKEN} in both elastic.apm.secretToken and the Fleet policy secret_token var
- Mark the Fleet secret_token var as frozen: true so Fleet force-updates the stored policy on Kibana restart, enabling rotation by patching the Secret and restarting Kibana (requires Kibana >= 9.2.0)