### PR TITLE
Use scoped annotation/field patches to respect SSA ownerships

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -587,6 +587,7 @@ func startOperator(ctx context.Context) error {
 		LeaderElectionID:           LeaderElectionLeaseName,
 		LeaderElectionNamespace:    operatorNamespace,
 		Logger:                     log.WithName("eck-operator"),
+		Client:                     client.Options{FieldOwner: about.FieldOwner},
 	}
 
 	// configure the manager cache based on the number of managed namespaces

--- a/pkg/about/info.go
+++ b/pkg/about/info.go
@@ -24,6 +24,11 @@ const (
 	UUIDCfgMapName = "elastic-operator-uuid"
 	// UUIDCfgMapName is used for the operator UUID inside a config map.
 	UUIDCfgMapKey = "uuid"
+
+	// FieldOwner is the field manager name used by the operator for all Kubernetes write operations.
+	// It matches the binary name so it is consistent with the User-Agent-derived name the API server
+	// would assign when no explicit field manager is provided.
+	FieldOwner = "elastic-operator"
 )
 
 // lookup of valid distribution channels

--- a/pkg/about/info.go
+++ b/pkg/about/info.go
@@ -26,8 +26,8 @@ const (
 	UUIDCfgMapKey = "uuid"
 
 	// FieldOwner is the field manager name used by the operator for all Kubernetes write operations.
-	// It matches the binary name so it is consistent with the User-Agent-derived name the API server
-	// would assign when no explicit field manager is provided.
+	// The value matches the historical User-Agent-derived name ("elastic-operator") so that existing
+	// managedFields records attributed to that name are not abandoned on upgrade.
 	FieldOwner = "elastic-operator"
 )
 

--- a/pkg/controller/agent/fleet.go
+++ b/pkg/controller/agent/fleet.go
@@ -370,12 +370,7 @@ FindOrCreate:
 		return EnrollmentAPIKey{}, err
 	}
 
-	err = k8s.PatchObjectAnnotations(ctx, params.Client, &agent, func() {
-		if agent.Annotations == nil {
-			agent.Annotations = map[string]string{}
-		}
-		agent.Annotations[FleetTokenAnnotation] = key.ID
-	})
+	err = k8s.PatchAnnotations(ctx, params.Client, &agent, map[string]string{FleetTokenAnnotation: key.ID})
 	if err != nil {
 		return EnrollmentAPIKey{}, err
 	}

--- a/pkg/controller/agent/fleet.go
+++ b/pkg/controller/agent/fleet.go
@@ -370,12 +370,12 @@ FindOrCreate:
 		return EnrollmentAPIKey{}, err
 	}
 
-	// this potentially creates conflicts we could introduce reconciler state similar to the ES controller and handle it  on the top level
-	if agent.Annotations == nil {
-		agent.Annotations = map[string]string{}
-	}
-	agent.Annotations[FleetTokenAnnotation] = key.ID
-	err = params.Client.Update(ctx, &agent)
+	err = k8s.PatchObjectAnnotations(ctx, params.Client, &agent, func() {
+		if agent.Annotations == nil {
+			agent.Annotations = map[string]string{}
+		}
+		agent.Annotations[FleetTokenAnnotation] = key.ID
+	})
 	if err != nil {
 		return EnrollmentAPIKey{}, err
 	}

--- a/pkg/controller/association/conf.go
+++ b/pkg/controller/association/conf.go
@@ -218,13 +218,7 @@ func RemoveObsoleteAssociationConfs(
 		return nil
 	}
 
-	return k8s.PatchObjectAnnotations(ctx, client, associated, func() {
-		annotations := associated.GetAnnotations()
-		for _, key := range toDelete {
-			delete(annotations, key)
-		}
-		associated.SetAnnotations(annotations)
-	})
+	return k8s.PatchAnnotations(ctx, client, associated, nil, toDelete...)
 }
 
 // RemoveAssociationConf removes the association configuration annotation.
@@ -241,11 +235,7 @@ func RemoveAssociationConf(ctx context.Context, client k8s.Client, association c
 		return nil
 	}
 
-	return k8s.PatchObjectAnnotations(ctx, client, associated, func() {
-		annotations := associated.GetAnnotations()
-		delete(annotations, annotationName)
-		associated.SetAnnotations(annotations)
-	})
+	return k8s.PatchAnnotations(ctx, client, associated, nil, annotationName)
 }
 
 // UpdateAssociationConf updates the association configuration annotation.
@@ -262,14 +252,7 @@ func UpdateAssociationConf(
 	}
 
 	obj := association.Associated()
-	return k8s.PatchObjectAnnotations(ctx, client, obj, func() {
-		annotations := obj.GetAnnotations()
-		if annotations == nil {
-			annotations = make(map[string]string)
-		}
-		annotations[association.AssociationConfAnnotationName()] = unsafeBytesToString(serializedConf)
-		obj.SetAnnotations(annotations)
-	})
+	return k8s.PatchAnnotations(ctx, client, obj, map[string]string{association.AssociationConfAnnotationName(): unsafeBytesToString(serializedConf)})
 }
 
 // unsafeBytesToString converts a byte array to string without making extra allocations.

--- a/pkg/controller/association/conf.go
+++ b/pkg/controller/association/conf.go
@@ -14,7 +14,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 	toolsevents "k8s.io/client-go/tools/events"
 
@@ -201,44 +200,37 @@ func RemoveObsoleteAssociationConfs(
 	associated commonv1.Associated,
 	associationConfAnnotationNameBase string,
 ) error {
-	accessor := meta.NewAccessor()
-	annotations, err := accessor.Annotations(associated)
-	if err != nil {
-		return err
-	}
+	annotations := associated.GetAnnotations()
 
 	expected := make(map[string]bool)
 	for _, association := range associated.GetAssociations() {
 		expected[association.AssociationConfAnnotationName()] = true
 	}
 
-	modified := false
+	var toDelete []string
 	for key := range annotations {
 		if strings.HasPrefix(key, associationConfAnnotationNameBase) && !expected[key] {
-			delete(annotations, key)
-			modified = true
+			toDelete = append(toDelete, key)
 		}
 	}
 
-	if !modified {
+	if len(toDelete) == 0 {
 		return nil
 	}
 
-	if err := accessor.SetAnnotations(associated, annotations); err != nil {
-		return err
-	}
-
-	return client.Update(ctx, associated)
+	return k8s.PatchObjectAnnotations(ctx, client, associated, func() {
+		annotations := associated.GetAnnotations()
+		for _, key := range toDelete {
+			delete(annotations, key)
+		}
+		associated.SetAnnotations(annotations)
+	})
 }
 
 // RemoveAssociationConf removes the association configuration annotation.
 func RemoveAssociationConf(ctx context.Context, client k8s.Client, association commonv1.Association) error {
 	associated := association.Associated()
-	accessor := meta.NewAccessor()
-	annotations, err := accessor.Annotations(associated)
-	if err != nil {
-		return err
-	}
+	annotations := associated.GetAnnotations()
 
 	if len(annotations) == 0 {
 		return nil
@@ -249,12 +241,11 @@ func RemoveAssociationConf(ctx context.Context, client k8s.Client, association c
 		return nil
 	}
 
-	delete(annotations, annotationName)
-	if err := accessor.SetAnnotations(associated, annotations); err != nil {
-		return err
-	}
-
-	return client.Update(ctx, associated)
+	return k8s.PatchObjectAnnotations(ctx, client, associated, func() {
+		annotations := associated.GetAnnotations()
+		delete(annotations, annotationName)
+		associated.SetAnnotations(annotations)
+	})
 }
 
 // UpdateAssociationConf updates the association configuration annotation.
@@ -264,32 +255,21 @@ func UpdateAssociationConf(
 	association commonv1.Association,
 	wantConf *commonv1.AssociationConf,
 ) error {
-	accessor := meta.NewAccessor()
-
-	obj := association.Associated()
-	annotations, err := accessor.Annotations(obj)
-	if err != nil {
-		return err
-	}
-
-	// serialize the config and update the object
+	// serialize the config
 	serializedConf, err := json.Marshal(wantConf)
 	if err != nil {
 		return errors.Wrapf(err, "failed to serialize configuration")
 	}
 
-	if annotations == nil {
-		annotations = make(map[string]string)
-	}
-
-	annotationName := association.AssociationConfAnnotationName()
-	annotations[annotationName] = unsafeBytesToString(serializedConf)
-	if err := accessor.SetAnnotations(obj, annotations); err != nil {
-		return err
-	}
-
-	// persist the changes
-	return client.Update(ctx, obj)
+	obj := association.Associated()
+	return k8s.PatchObjectAnnotations(ctx, client, obj, func() {
+		annotations := obj.GetAnnotations()
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		annotations[association.AssociationConfAnnotationName()] = unsafeBytesToString(serializedConf)
+		obj.SetAnnotations(annotations)
+	})
 }
 
 // unsafeBytesToString converts a byte array to string without making extra allocations.

--- a/pkg/controller/common/annotation/client_cert.go
+++ b/pkg/controller/common/annotation/client_cert.go
@@ -29,14 +29,7 @@ func SetClientAuthenticationRequiredAnnotation(ctx context.Context, k8sClient k8
 
 	ulog.FromContext(ctx).Info("Setting client-authentication-required annotation")
 
-	return k8s.PatchObjectAnnotations(ctx, k8sClient, obj, func() {
-		existingAnnotations := obj.GetAnnotations()
-		if existingAnnotations == nil {
-			existingAnnotations = make(map[string]string)
-		}
-		existingAnnotations[ClientAuthenticationRequiredAnnotation] = "true"
-		obj.SetAnnotations(existingAnnotations)
-	})
+	return k8s.PatchAnnotations(ctx, k8sClient, obj, map[string]string{ClientAuthenticationRequiredAnnotation: "true"})
 }
 
 // RemoveClientAuthenticationRequiredAnnotation removes the client-authentication-required annotation from the given resource.
@@ -48,9 +41,5 @@ func RemoveClientAuthenticationRequiredAnnotation(ctx context.Context, k8sClient
 
 	ulog.FromContext(ctx).Info("Removing client-authentication-required annotation")
 
-	return k8s.PatchObjectAnnotations(ctx, k8sClient, obj, func() {
-		existingAnnotations := obj.GetAnnotations()
-		delete(existingAnnotations, ClientAuthenticationRequiredAnnotation)
-		obj.SetAnnotations(existingAnnotations)
-	})
+	return k8s.PatchAnnotations(ctx, k8sClient, obj, nil, ClientAuthenticationRequiredAnnotation)
 }

--- a/pkg/controller/common/annotation/client_cert.go
+++ b/pkg/controller/common/annotation/client_cert.go
@@ -29,13 +29,14 @@ func SetClientAuthenticationRequiredAnnotation(ctx context.Context, k8sClient k8
 
 	ulog.FromContext(ctx).Info("Setting client-authentication-required annotation")
 
-	existingAnnotations := obj.GetAnnotations()
-	if existingAnnotations == nil {
-		existingAnnotations = make(map[string]string)
-	}
-	existingAnnotations[ClientAuthenticationRequiredAnnotation] = "true"
-	obj.SetAnnotations(existingAnnotations)
-	return k8sClient.Update(ctx, obj)
+	return k8s.PatchObjectAnnotations(ctx, k8sClient, obj, func() {
+		existingAnnotations := obj.GetAnnotations()
+		if existingAnnotations == nil {
+			existingAnnotations = make(map[string]string)
+		}
+		existingAnnotations[ClientAuthenticationRequiredAnnotation] = "true"
+		obj.SetAnnotations(existingAnnotations)
+	})
 }
 
 // RemoveClientAuthenticationRequiredAnnotation removes the client-authentication-required annotation from the given resource.
@@ -47,7 +48,9 @@ func RemoveClientAuthenticationRequiredAnnotation(ctx context.Context, k8sClient
 
 	ulog.FromContext(ctx).Info("Removing client-authentication-required annotation")
 
-	existingAnnotations := obj.GetAnnotations()
-	delete(existingAnnotations, ClientAuthenticationRequiredAnnotation)
-	return k8sClient.Update(ctx, obj)
+	return k8s.PatchObjectAnnotations(ctx, k8sClient, obj, func() {
+		existingAnnotations := obj.GetAnnotations()
+		delete(existingAnnotations, ClientAuthenticationRequiredAnnotation)
+		obj.SetAnnotations(existingAnnotations)
+	})
 }

--- a/pkg/controller/common/annotation/pod.go
+++ b/pkg/controller/common/annotation/pod.go
@@ -51,12 +51,13 @@ func MarkPodAsUpdated(
 		"namespace", pod.Namespace,
 		"pod_name", pod.Name,
 	)
-	if pod.Annotations == nil {
-		pod.Annotations = map[string]string{}
-	}
-	pod.Annotations[UpdateAnnotation] =
-		time.Now().Format(time.RFC3339Nano) // nano should be enough to avoid collisions and keep it readable by a human.
-	if err := c.Update(ctx, &pod); err != nil {
+	ts := time.Now().Format(time.RFC3339Nano) // nano should be enough to avoid collisions and keep it readable by a human.
+	if err := k8s.PatchObjectAnnotations(ctx, c, &pod, func() {
+		if pod.Annotations == nil {
+			pod.Annotations = map[string]string{}
+		}
+		pod.Annotations[UpdateAnnotation] = ts
+	}); err != nil {
 		if errors.IsConflict(err) {
 			// Conflicts are expected and will be handled on the next reconcile loop, no need to error out here
 			log.V(1).Info("Conflict while updating pod annotation", "namespace", pod.Namespace, "pod_name", pod.Name)

--- a/pkg/controller/common/annotation/pod.go
+++ b/pkg/controller/common/annotation/pod.go
@@ -52,12 +52,7 @@ func MarkPodAsUpdated(
 		"pod_name", pod.Name,
 	)
 	ts := time.Now().Format(time.RFC3339Nano) // nano should be enough to avoid collisions and keep it readable by a human.
-	if err := k8s.PatchObjectAnnotations(ctx, c, &pod, func() {
-		if pod.Annotations == nil {
-			pod.Annotations = map[string]string{}
-		}
-		pod.Annotations[UpdateAnnotation] = ts
-	}); err != nil {
+	if err := k8s.PatchAnnotations(ctx, c, &pod, map[string]string{UpdateAnnotation: ts}); err != nil {
 		if errors.IsConflict(err) {
 			// Conflicts are expected and will be handled on the next reconcile loop, no need to error out here
 			log.V(1).Info("Conflict while updating pod annotation", "namespace", pod.Namespace, "pod_name", pod.Name)

--- a/pkg/controller/common/finalizer/finalizers.go
+++ b/pkg/controller/common/finalizer/finalizers.go
@@ -6,7 +6,6 @@ package finalizer
 
 import (
 	"context"
-	"errors"
 	"regexp"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -21,16 +20,7 @@ func RemoveAll(ctx context.Context, c k8s.Client, obj client.Object) error {
 	if len(obj.GetFinalizers()) == 0 {
 		return nil
 	}
-	filtered := filterFinalizers(obj.GetFinalizers())
-	if len(filtered) == len(obj.GetFinalizers()) {
-		return nil
-	}
-	base, ok := obj.DeepCopyObject().(client.Object)
-	if !ok {
-		return errors.New("failed to convert deep copy to client.Object")
-	}
-	obj.SetFinalizers(filtered)
-	return c.Patch(ctx, obj, client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{}))
+	return k8s.PatchObjectFinalizers(ctx, c, obj, filterFinalizers(obj.GetFinalizers()))
 }
 
 // filterFinalizers removes Elastic finalizers

--- a/pkg/controller/common/finalizer/finalizers.go
+++ b/pkg/controller/common/finalizer/finalizers.go
@@ -6,9 +6,9 @@ package finalizer
 
 import (
 	"context"
+	"errors"
 	"regexp"
 
-	"k8s.io/apimachinery/pkg/api/meta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
@@ -18,16 +18,19 @@ var finalizersRegExp = regexp.MustCompile(`^finalizer\.(.*)\.k8s.elastic.co\/(.*
 
 // RemoveAll removes all existing Elastic Finalizers on an Object
 func RemoveAll(ctx context.Context, c k8s.Client, obj client.Object) error {
-	accessor, err := meta.Accessor(obj)
-	if err != nil {
-		return err
-	}
-	if len(accessor.GetFinalizers()) == 0 {
+	if len(obj.GetFinalizers()) == 0 {
 		return nil
 	}
-	filterFinalizers := filterFinalizers(accessor.GetFinalizers())
-	accessor.SetFinalizers(filterFinalizers)
-	return c.Update(ctx, obj)
+	filtered := filterFinalizers(obj.GetFinalizers())
+	if len(filtered) == len(obj.GetFinalizers()) {
+		return nil
+	}
+	base, ok := obj.DeepCopyObject().(client.Object)
+	if !ok {
+		return errors.New("failed to convert deep copy to client.Object")
+	}
+	obj.SetFinalizers(filtered)
+	return c.Patch(ctx, obj, client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{}))
 }
 
 // filterFinalizers removes Elastic finalizers

--- a/pkg/controller/common/volume/pvc_expansion.go
+++ b/pkg/controller/common/volume/pvc_expansion.go
@@ -136,12 +136,14 @@ func annotateForRecreation(
 	}
 	ownerKind := gvk.Kind
 
-	err = setAnnotation(owner, getRecreateStatefulSetAnnotationKey(ownerKind, actualSset.Name), string(asJSON))
-	if err != nil {
-		return err
-	}
-
-	return k8sClient.Update(ctx, owner)
+	return k8s.PatchObjectAnnotations(ctx, k8sClient, owner, func() {
+		annotations := owner.GetAnnotations()
+		if annotations == nil {
+			annotations = make(map[string]string, 1)
+		}
+		annotations[getRecreateStatefulSetAnnotationKey(ownerKind, actualSset.Name)] = string(asJSON)
+		owner.SetAnnotations(annotations)
+	})
 }
 
 // needsRecreate returns true if the StatefulSet needs to be re-created to account for volume expansion.
@@ -222,12 +224,12 @@ func RecreateStatefulSets(ctx context.Context, k8sClient k8s.Client, owner clien
 				return recreations, err
 			}
 			// remove the annotation
-			err := deleteAnnotation(owner, annotation)
+			err := k8s.PatchObjectAnnotations(ctx, k8sClient, owner, func() {
+				annotations := owner.GetAnnotations()
+				delete(annotations, annotation)
+				owner.SetAnnotations(annotations)
+			})
 			if err != nil {
-				return recreations, err
-			}
-
-			if err := k8sClient.Update(ctx, owner); err != nil {
 				return recreations, err
 			}
 			// one less recreation
@@ -335,44 +337,6 @@ func namespacedNameFromObject(owner client.Object) types.NamespacedName {
 		namespace = "-"
 	}
 	return types.NamespacedName{Name: name, Namespace: namespace}
-}
-
-func setAnnotation(owner client.Object, annotationKey string, annotationValue string) error {
-	accessor := meta.NewAccessor()
-	annotations, err := accessor.Annotations(owner)
-
-	if err != nil {
-		return err
-	}
-	if annotations == nil {
-		annotations = make(map[string]string, 1)
-	}
-	annotations[annotationKey] = annotationValue
-	err = accessor.SetAnnotations(owner, annotations)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func deleteAnnotation(owner client.Object, annotation string) error {
-	accessor := meta.NewAccessor()
-	annotations, err := accessor.Annotations(owner)
-
-	if err != nil {
-		return err
-	}
-
-	if annotations == nil {
-		annotations = make(map[string]string, 1)
-	}
-	delete(annotations, annotation)
-	err = accessor.SetAnnotations(owner, annotations)
-
-	if err != nil {
-		return err
-	}
-	return nil
 }
 
 // ssetsToRecreate returns the list of StatefulSet that should be recreated, based on annotations

--- a/pkg/controller/common/volume/pvc_expansion.go
+++ b/pkg/controller/common/volume/pvc_expansion.go
@@ -136,14 +136,7 @@ func annotateForRecreation(
 	}
 	ownerKind := gvk.Kind
 
-	return k8s.PatchObjectAnnotations(ctx, k8sClient, owner, func() {
-		annotations := owner.GetAnnotations()
-		if annotations == nil {
-			annotations = make(map[string]string, 1)
-		}
-		annotations[getRecreateStatefulSetAnnotationKey(ownerKind, actualSset.Name)] = string(asJSON)
-		owner.SetAnnotations(annotations)
-	})
+	return k8s.PatchAnnotations(ctx, k8sClient, owner, map[string]string{getRecreateStatefulSetAnnotationKey(ownerKind, actualSset.Name): string(asJSON)})
 }
 
 // needsRecreate returns true if the StatefulSet needs to be re-created to account for volume expansion.
@@ -224,11 +217,7 @@ func RecreateStatefulSets(ctx context.Context, k8sClient k8s.Client, owner clien
 				return recreations, err
 			}
 			// remove the annotation
-			err := k8s.PatchObjectAnnotations(ctx, k8sClient, owner, func() {
-				annotations := owner.GetAnnotations()
-				delete(annotations, annotation)
-				owner.SetAnnotations(annotations)
-			})
+			err := k8s.PatchAnnotations(ctx, k8sClient, owner, nil, annotation)
 			if err != nil {
 				return recreations, err
 			}

--- a/pkg/controller/elasticsearch/bootstrap/bootstrap.go
+++ b/pkg/controller/elasticsearch/bootstrap/bootstrap.go
@@ -86,10 +86,5 @@ func annotateWithUUID(ctx context.Context, k8sClient k8s.Client, cluster *esv1.E
 		"es_name", cluster.Name,
 		"uuid", uuid,
 	)
-	return k8s.PatchObjectAnnotations(ctx, k8sClient, cluster, func() {
-		if cluster.Annotations == nil {
-			cluster.Annotations = make(map[string]string)
-		}
-		cluster.Annotations[ClusterUUIDAnnotationName] = uuid
-	})
+	return k8s.PatchAnnotations(ctx, k8sClient, cluster, map[string]string{ClusterUUIDAnnotationName: uuid})
 }

--- a/pkg/controller/elasticsearch/bootstrap/bootstrap.go
+++ b/pkg/controller/elasticsearch/bootstrap/bootstrap.go
@@ -86,9 +86,10 @@ func annotateWithUUID(ctx context.Context, k8sClient k8s.Client, cluster *esv1.E
 		"es_name", cluster.Name,
 		"uuid", uuid,
 	)
-	if cluster.Annotations == nil {
-		cluster.Annotations = make(map[string]string)
-	}
-	cluster.Annotations[ClusterUUIDAnnotationName] = uuid
-	return k8sClient.Update(ctx, cluster)
+	return k8s.PatchObjectAnnotations(ctx, k8sClient, cluster, func() {
+		if cluster.Annotations == nil {
+			cluster.Annotations = make(map[string]string)
+		}
+		cluster.Annotations[ClusterUUIDAnnotationName] = uuid
+	})
 }

--- a/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -365,8 +365,9 @@ func (r *ReconcileElasticsearch) annotateResource(
 		log.V(1).Info("Skipping annotation update", "es_name", es.Name, "namespace", es.Namespace)
 		return nil
 	}
-	es.SetAnnotations(expected)
-	return r.Update(ctx, &es)
+	return k8s.PatchObjectAnnotations(ctx, r.Client, &es, func() {
+		es.SetAnnotations(expected)
+	})
 }
 
 // OnNamespaceOutOfScope releases all controller-local state associated with the given Elasticsearch resource

--- a/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -365,9 +365,7 @@ func (r *ReconcileElasticsearch) annotateResource(
 		log.V(1).Info("Skipping annotation update", "es_name", es.Name, "namespace", es.Namespace)
 		return nil
 	}
-	return k8s.PatchObjectAnnotations(ctx, r.Client, &es, func() {
-		es.SetAnnotations(expected)
-	})
+	return k8s.PatchAnnotations(ctx, r.Client, &es, newAnnotations)
 }
 
 // OnNamespaceOutOfScope releases all controller-local state associated with the given Elasticsearch resource

--- a/pkg/controller/elasticsearch/remotecluster/annotations.go
+++ b/pkg/controller/elasticsearch/remotecluster/annotations.go
@@ -42,9 +42,7 @@ func annotateWithCreatedRemoteClusters(ctx context.Context, c k8s.Client, es esv
 
 		// if the annotation exists, delete it
 		if _, ok := es.Annotations[ManagedRemoteClustersAnnotationName]; ok {
-			return k8s.PatchObjectAnnotations(ctx, c, &es, func() {
-				delete(es.Annotations, ManagedRemoteClustersAnnotationName)
-			})
+			return k8s.PatchAnnotations(ctx, c, &es, nil, ManagedRemoteClustersAnnotationName)
 		}
 
 		return nil
@@ -64,9 +62,7 @@ func annotateWithCreatedRemoteClusters(ctx context.Context, c k8s.Client, es esv
 	current, ok := es.Annotations[ManagedRemoteClustersAnnotationName]
 
 	if !ok || current != expected {
-		return k8s.PatchObjectAnnotations(ctx, c, &es, func() {
-			es.Annotations[ManagedRemoteClustersAnnotationName] = expected
-		})
+		return k8s.PatchAnnotations(ctx, c, &es, map[string]string{ManagedRemoteClustersAnnotationName: expected})
 	}
 	return nil
 }

--- a/pkg/controller/elasticsearch/remotecluster/annotations.go
+++ b/pkg/controller/elasticsearch/remotecluster/annotations.go
@@ -42,8 +42,9 @@ func annotateWithCreatedRemoteClusters(ctx context.Context, c k8s.Client, es esv
 
 		// if the annotation exists, delete it
 		if _, ok := es.Annotations[ManagedRemoteClustersAnnotationName]; ok {
-			delete(es.Annotations, ManagedRemoteClustersAnnotationName)
-			return c.Update(ctx, &es)
+			return k8s.PatchObjectAnnotations(ctx, c, &es, func() {
+				delete(es.Annotations, ManagedRemoteClustersAnnotationName)
+			})
 		}
 
 		return nil
@@ -63,8 +64,9 @@ func annotateWithCreatedRemoteClusters(ctx context.Context, c k8s.Client, es esv
 	current, ok := es.Annotations[ManagedRemoteClustersAnnotationName]
 
 	if !ok || current != expected {
-		es.Annotations[ManagedRemoteClustersAnnotationName] = expected
-		return c.Update(ctx, &es)
+		return k8s.PatchObjectAnnotations(ctx, c, &es, func() {
+			es.Annotations[ManagedRemoteClustersAnnotationName] = expected
+		})
 	}
 	return nil
 }

--- a/pkg/controller/elasticsearch/remotecluster/elasticsearch_test.go
+++ b/pkg/controller/elasticsearch/remotecluster/elasticsearch_test.go
@@ -122,7 +122,7 @@ func TestUpdateSettings(t *testing.T) {
 		name                                  string
 		args                                  args
 		wantAnnotation                        string
-		wantKubernetesAPIUpdateCalled         int
+		wantKubernetesAPIPatchCalled          int
 		wantRequeue                           bool
 		wantErr                               bool
 		wantGetRemoteClusterSettingsCalled    bool
@@ -141,7 +141,7 @@ func TestUpdateSettings(t *testing.T) {
 				),
 			},
 			wantRequeue:                           false,
-			wantKubernetesAPIUpdateCalled:         0,
+			wantKubernetesAPIPatchCalled:          0,
 			wantGetRemoteClusterSettingsCalled:    false,
 			wantUpdateRemoteClusterSettingsCalled: false,
 		},
@@ -156,7 +156,7 @@ func TestUpdateSettings(t *testing.T) {
 					map[string]string{"foo": "bar", ManagedRemoteClustersAnnotationName: ""},
 				),
 			},
-			wantKubernetesAPIUpdateCalled:         1, // Annotation should be removed
+			wantKubernetesAPIPatchCalled:          1, // Annotation should be removed
 			wantRequeue:                           false,
 			wantGetRemoteClusterSettingsCalled:    true,
 			wantUpdateRemoteClusterSettingsCalled: false,
@@ -172,7 +172,7 @@ func TestUpdateSettings(t *testing.T) {
 					map[string]string{ManagedRemoteClustersAnnotationName: "ns2-es2"},
 				),
 			},
-			wantKubernetesAPIUpdateCalled:         1,
+			wantKubernetesAPIPatchCalled:          1,
 			wantRequeue:                           false,
 			wantGetRemoteClusterSettingsCalled:    true,
 			wantUpdateRemoteClusterSettingsCalled: false,
@@ -193,7 +193,7 @@ func TestUpdateSettings(t *testing.T) {
 				),
 			},
 			wantAnnotation:                        "ns2-es2",
-			wantKubernetesAPIUpdateCalled:         1,
+			wantKubernetesAPIPatchCalled:          1,
 			wantGetRemoteClusterSettingsCalled:    true,
 			wantUpdateRemoteClusterSettingsCalled: true,
 			wantSettings: esclient.RemoteClustersSettings{
@@ -225,7 +225,7 @@ func TestUpdateSettings(t *testing.T) {
 			wantGetRemoteClusterSettingsCalled:    true,
 			wantUpdateRemoteClusterSettingsCalled: true,
 			wantAnnotation:                        "ns1-es2",
-			wantKubernetesAPIUpdateCalled:         1,
+			wantKubernetesAPIPatchCalled:          1,
 			wantSettings: esclient.RemoteClustersSettings{
 				PersistentSettings: &esclient.SettingsGroup{
 					Cluster: esclient.RemoteClusters{
@@ -266,7 +266,7 @@ func TestUpdateSettings(t *testing.T) {
 			wantGetRemoteClusterSettingsCalled:    true,
 			wantUpdateRemoteClusterSettingsCalled: true,
 			wantAnnotation:                        "ns2-es2",
-			wantKubernetesAPIUpdateCalled:         0,
+			wantKubernetesAPIPatchCalled:          0,
 			wantSettings: esclient.RemoteClustersSettings{
 				PersistentSettings: &esclient.SettingsGroup{
 					Cluster: esclient.RemoteClusters{
@@ -306,7 +306,7 @@ func TestUpdateSettings(t *testing.T) {
 			},
 			wantRequeue:                           false,
 			wantAnnotation:                        "ns2-es2",
-			wantKubernetesAPIUpdateCalled:         1,
+			wantKubernetesAPIPatchCalled:          1,
 			wantGetRemoteClusterSettingsCalled:    true,
 			wantUpdateRemoteClusterSettingsCalled: true,
 			wantSettings: esclient.RemoteClustersSettings{
@@ -352,7 +352,7 @@ func TestUpdateSettings(t *testing.T) {
 			wantGetRemoteClusterSettingsCalled:    true,
 			wantUpdateRemoteClusterSettingsCalled: true,
 			wantAnnotation:                        "ns1-es2,ns1-es3",
-			wantKubernetesAPIUpdateCalled:         1, // Add ns1-es3
+			wantKubernetesAPIPatchCalled:          1, // Add ns1-es3
 			wantSettings: esclient.RemoteClustersSettings{
 				PersistentSettings: &esclient.SettingsGroup{
 					Cluster: esclient.RemoteClusters{
@@ -476,7 +476,7 @@ func TestUpdateSettings(t *testing.T) {
 			wantGetRemoteClusterSettingsCalled:    true,
 			wantUpdateRemoteClusterSettingsCalled: true,
 			wantAnnotation:                        "ns1-es2,ns1-es4,ns1-es5",
-			wantKubernetesAPIUpdateCalled:         1,
+			wantKubernetesAPIPatchCalled:          1,
 			wantSettings: esclient.RemoteClustersSettings{
 				PersistentSettings: &esclient.SettingsGroup{
 					Cluster: esclient.RemoteClusters{
@@ -492,7 +492,7 @@ func TestUpdateSettings(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client := trackUpdateCalls(k8s.NewFakeClient(tt.args.es))
+			client := trackPatchCalls(k8s.NewFakeClient(tt.args.es))
 			shouldRequeue, err := UpdateSettings(
 				context.Background(),
 				client,
@@ -515,7 +515,7 @@ func TestUpdateSettings(t *testing.T) {
 				assert.False(t, annotationExists)
 			}
 
-			assert.Equal(t, tt.wantKubernetesAPIUpdateCalled, client.updateCallCount, "Kubernetes API Update call count mismatch")
+			assert.Equal(t, tt.wantKubernetesAPIPatchCalled, client.patchCallCount, "Kubernetes API Patch call count mismatch")
 
 			// Check the requeue result
 			assert.Equal(t, tt.wantRequeue, shouldRequeue)
@@ -529,16 +529,16 @@ func TestUpdateSettings(t *testing.T) {
 	}
 }
 
-func trackUpdateCalls(c client.Client) *trackUpdateCallsClient {
-	return &trackUpdateCallsClient{Client: c}
+func trackPatchCalls(c client.Client) *trackPatchCallsClient {
+	return &trackPatchCallsClient{Client: c}
 }
 
-type trackUpdateCallsClient struct {
+type trackPatchCallsClient struct {
 	client.Client
-	updateCallCount int
+	patchCallCount int
 }
 
-func (t *trackUpdateCallsClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
-	t.updateCallCount++
-	return t.Client.Update(ctx, obj, opts...)
+func (t *trackPatchCallsClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	t.patchCallCount++
+	return t.Client.Patch(ctx, obj, patch, opts...)
 }

--- a/pkg/controller/elasticsearch/version/zen2/initial_master_nodes.go
+++ b/pkg/controller/elasticsearch/version/zen2/initial_master_nodes.go
@@ -86,9 +86,7 @@ func RemoveZen2BootstrapAnnotation(ctx context.Context, k8sClient k8s.Client, es
 		"es_name", es.Name,
 	)
 	// remove the annotation to indicate we're done with zen2 bootstrapping
-	return false, k8s.PatchObjectAnnotations(ctx, k8sClient, &es, func() {
-		delete(es.Annotations, InitialMasterNodesAnnotation)
-	})
+	return false, k8s.PatchAnnotations(ctx, k8sClient, &es, nil, InitialMasterNodesAnnotation)
 }
 
 // patchInitialMasterNodesConfig mutates the configuration of master nodes
@@ -122,10 +120,5 @@ func getInitialMasterNodesAnnotation(es esv1.Elasticsearch) []string {
 // setInitialMasterNodesAnnotation sets initialMasterNodesAnnotation on the given es resource to initialMasterNodes,
 // and updates the es resource in the apiserver.
 func setInitialMasterNodesAnnotation(ctx context.Context, k8sClient k8s.Client, es esv1.Elasticsearch, initialMasterNodes []string) error {
-	return k8s.PatchObjectAnnotations(ctx, k8sClient, &es, func() {
-		if es.Annotations == nil {
-			es.Annotations = map[string]string{}
-		}
-		es.Annotations[InitialMasterNodesAnnotation] = strings.Join(initialMasterNodes, ",")
-	})
+	return k8s.PatchAnnotations(ctx, k8sClient, &es, map[string]string{InitialMasterNodesAnnotation: strings.Join(initialMasterNodes, ",")})
 }

--- a/pkg/controller/elasticsearch/version/zen2/initial_master_nodes.go
+++ b/pkg/controller/elasticsearch/version/zen2/initial_master_nodes.go
@@ -86,8 +86,9 @@ func RemoveZen2BootstrapAnnotation(ctx context.Context, k8sClient k8s.Client, es
 		"es_name", es.Name,
 	)
 	// remove the annotation to indicate we're done with zen2 bootstrapping
-	delete(es.Annotations, InitialMasterNodesAnnotation)
-	return false, k8sClient.Update(ctx, &es)
+	return false, k8s.PatchObjectAnnotations(ctx, k8sClient, &es, func() {
+		delete(es.Annotations, InitialMasterNodesAnnotation)
+	})
 }
 
 // patchInitialMasterNodesConfig mutates the configuration of master nodes
@@ -121,9 +122,10 @@ func getInitialMasterNodesAnnotation(es esv1.Elasticsearch) []string {
 // setInitialMasterNodesAnnotation sets initialMasterNodesAnnotation on the given es resource to initialMasterNodes,
 // and updates the es resource in the apiserver.
 func setInitialMasterNodesAnnotation(ctx context.Context, k8sClient k8s.Client, es esv1.Elasticsearch, initialMasterNodes []string) error {
-	if es.Annotations == nil {
-		es.Annotations = map[string]string{}
-	}
-	es.Annotations[InitialMasterNodesAnnotation] = strings.Join(initialMasterNodes, ",")
-	return k8sClient.Update(ctx, &es)
+	return k8s.PatchObjectAnnotations(ctx, k8sClient, &es, func() {
+		if es.Annotations == nil {
+			es.Annotations = map[string]string{}
+		}
+		es.Annotations[InitialMasterNodesAnnotation] = strings.Join(initialMasterNodes, ",")
+	})
 }

--- a/pkg/controller/enterprisesearch/version_upgrade.go
+++ b/pkg/controller/enterprisesearch/version_upgrade.go
@@ -127,11 +127,12 @@ func (r *VersionUpgrade) enableReadOnlyMode(ctx context.Context) error {
 
 	// annotate the resource to avoid doing the same API call over and over again
 	// (in practice, it may happen again if the next reconciliation does not have an up-to-date cache)
-	if r.ent.Annotations == nil {
-		r.ent.Annotations = map[string]string{}
-	}
-	r.ent.Annotations[ReadOnlyModeAnnotationName] = "true"
-	return r.k8sClient.Update(ctx, &r.ent)
+	return k8s.PatchObjectAnnotations(ctx, r.k8sClient, &r.ent, func() {
+		if r.ent.Annotations == nil {
+			r.ent.Annotations = map[string]string{}
+		}
+		r.ent.Annotations[ReadOnlyModeAnnotationName] = "true"
+	})
 }
 
 // disableReadOnlyMode disables read-only mode through an API call, if enabled previously,
@@ -152,8 +153,9 @@ func (r *VersionUpgrade) disableReadOnlyMode(ctx context.Context) error {
 
 	// remove the annotation to avoid doing the same API call over and over again
 	// (in practice, it may happen again if the next reconciliation does not have an up-to-date cache)
-	delete(r.ent.Annotations, ReadOnlyModeAnnotationName)
-	return r.k8sClient.Update(ctx, &r.ent)
+	return k8s.PatchObjectAnnotations(ctx, r.k8sClient, &r.ent, func() {
+		delete(r.ent.Annotations, ReadOnlyModeAnnotationName)
+	})
 }
 
 // hasReadOnlyAnnotationTrue returns true if the read-only mode annotation is set to true,

--- a/pkg/controller/enterprisesearch/version_upgrade.go
+++ b/pkg/controller/enterprisesearch/version_upgrade.go
@@ -127,12 +127,7 @@ func (r *VersionUpgrade) enableReadOnlyMode(ctx context.Context) error {
 
 	// annotate the resource to avoid doing the same API call over and over again
 	// (in practice, it may happen again if the next reconciliation does not have an up-to-date cache)
-	return k8s.PatchObjectAnnotations(ctx, r.k8sClient, &r.ent, func() {
-		if r.ent.Annotations == nil {
-			r.ent.Annotations = map[string]string{}
-		}
-		r.ent.Annotations[ReadOnlyModeAnnotationName] = "true"
-	})
+	return k8s.PatchAnnotations(ctx, r.k8sClient, &r.ent, map[string]string{ReadOnlyModeAnnotationName: "true"})
 }
 
 // disableReadOnlyMode disables read-only mode through an API call, if enabled previously,
@@ -153,9 +148,7 @@ func (r *VersionUpgrade) disableReadOnlyMode(ctx context.Context) error {
 
 	// remove the annotation to avoid doing the same API call over and over again
 	// (in practice, it may happen again if the next reconciliation does not have an up-to-date cache)
-	return k8s.PatchObjectAnnotations(ctx, r.k8sClient, &r.ent, func() {
-		delete(r.ent.Annotations, ReadOnlyModeAnnotationName)
-	})
+	return k8s.PatchAnnotations(ctx, r.k8sClient, &r.ent, nil, ReadOnlyModeAnnotationName)
 }
 
 // hasReadOnlyAnnotationTrue returns true if the read-only mode annotation is set to true,

--- a/pkg/controller/webhook/admission_registration.go
+++ b/pkg/controller/webhook/admission_registration.go
@@ -6,6 +6,7 @@ package webhook
 
 import (
 	"context"
+	"encoding/json"
 
 	v1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -82,13 +83,32 @@ func (v1w *v1webhookHandler) services() Services {
 	return services
 }
 
+// updateCABundle patches only the clientConfig.caBundle of each webhook entry, matched by name,
+// instead of replacing the whole object. The webhooks list is a Kubernetes-native associative list
+// keyed by name (+patchStrategy=merge +patchMergeKey=name), so a strategic merge patch here leaves
+// every other field of the ValidatingWebhookConfiguration (rules, failurePolicy, selectors, etc.),
+// which is managed by the Helm chart, untouched. The resourceVersion read at Get time is embedded
+// in the patch to preserve the optimistic-concurrency guarantee.
 func (v1w *v1webhookHandler) updateCABundle(caCert []byte) error {
-	for i := range v1w.webhookConfiguration.Webhooks {
-		v1w.webhookConfiguration.Webhooks[i].ClientConfig.CABundle = caCert
+	webhooks := make([]map[string]any, 0, len(v1w.webhookConfiguration.Webhooks))
+	for _, wh := range v1w.webhookConfiguration.Webhooks {
+		webhooks = append(webhooks, map[string]any{
+			"name":         wh.Name,
+			"clientConfig": map[string]any{"caBundle": caCert},
+		})
 	}
-	_, err := v1w.clientset.
+	patch, err := json.Marshal(map[string]any{
+		"metadata": map[string]any{
+			"resourceVersion": v1w.webhookConfiguration.ResourceVersion,
+		},
+		"webhooks": webhooks,
+	})
+	if err != nil {
+		return err
+	}
+	_, err = v1w.clientset.
 		AdmissionregistrationV1().
 		ValidatingWebhookConfigurations().
-		Update(v1w.ctx, v1w.webhookConfiguration, metav1.UpdateOptions{})
+		Patch(v1w.ctx, v1w.webhookConfiguration.Name, types.StrategicMergePatchType, patch, metav1.PatchOptions{})
 	return err
 }

--- a/pkg/controller/webhook/admission_registration.go
+++ b/pkg/controller/webhook/admission_registration.go
@@ -13,6 +13,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/elastic/cloud-on-k8s/v3/pkg/about"
 )
 
 type webhook struct {
@@ -109,6 +111,7 @@ func (v1w *v1webhookHandler) updateCABundle(caCert []byte) error {
 	_, err = v1w.clientset.
 		AdmissionregistrationV1().
 		ValidatingWebhookConfigurations().
-		Patch(v1w.ctx, v1w.webhookConfiguration.Name, types.StrategicMergePatchType, patch, metav1.PatchOptions{})
+		Patch(v1w.ctx, v1w.webhookConfiguration.Name, types.StrategicMergePatchType, patch,
+			metav1.PatchOptions{FieldManager: about.FieldOwner})
 	return err
 }

--- a/pkg/controller/webhook/reconcile.go
+++ b/pkg/controller/webhook/reconcile.go
@@ -6,11 +6,13 @@ package webhook
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
 	"go.elastic.co/apm/v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
 
@@ -61,17 +63,28 @@ func (w *Params) ReconcileResources(ctx context.Context, clientset kubernetes.In
 			return err
 		}
 
-		// update server secret
-		webhookServerSecret.Data = map[string][]byte{
-			certificates.CertFileName: newCertificates.serverCert,
-			certificates.KeyFileName:  newCertificates.serverKey,
+		// patch only the cert data and the single ECK-owned label, leaving everything else
+		// on the Secret (Helm-managed labels, annotations, etc.) untouched. The resourceVersion
+		// is embedded so the patch is rejected on conflict. JSON Merge Patch merges nested
+		// maps, so unlisted Helm-owned labels are preserved server-side; omitting them from
+		// the patch body prevents the API server from attributing their field ownership to
+		// the operator's field manager, which would cause Helm SSA Apply conflicts on upgrade.
+		patch, err := json.Marshal(map[string]any{
+			"data": map[string][]byte{
+				certificates.CertFileName: newCertificates.serverCert,
+				certificates.KeyFileName:  newCertificates.serverKey,
+			},
+			"metadata": map[string]any{
+				"resourceVersion": webhookServerSecret.ResourceVersion,
+				"labels": map[string]string{
+					commonv1.RestrictWatchedResourcesLabelName: commonv1.RestrictWatchedResourcesLabelValue,
+				},
+			},
+		})
+		if err != nil {
+			return err
 		}
-		if webhookServerSecret.Labels == nil {
-			webhookServerSecret.Labels = make(map[string]string)
-		}
-		webhookServerSecret.Labels[commonv1.RestrictWatchedResourcesLabelName] = commonv1.RestrictWatchedResourcesLabelValue
-
-		if _, err := clientset.CoreV1().Secrets(w.Namespace).Update(ctx, webhookServerSecret, metav1.UpdateOptions{}); err != nil {
+		if _, err := clientset.CoreV1().Secrets(w.Namespace).Patch(ctx, w.SecretName, types.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
 			return err
 		}
 		updateOperatorPods(ctx, clientset, w.Namespace)
@@ -98,17 +111,25 @@ func updateOperatorPods(ctx context.Context, clientset kubernetes.Interface, ope
 // updateOperatorPod updates a specific annotation on a single pod to speed up secret propagation.
 func updateOperatorPod(ctx context.Context, pod corev1.Pod, clientset kubernetes.Interface) {
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		// Fetch the last the version of the Pod
+		// Fetch the latest version of the Pod for its resourceVersion.
 		pod, err := clientset.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
-		// Update the annotation
-		if pod.Annotations == nil {
-			pod.Annotations = map[string]string{}
+		// Patch only the annotation, leaving all other fields (spec, labels, etc.) that
+		// are owned by the Deployment/ReplicaSet controller or by Helm untouched.
+		patch, err := json.Marshal(map[string]any{
+			"metadata": map[string]any{
+				"resourceVersion": pod.ResourceVersion,
+				"annotations": map[string]any{
+					annotation.UpdateAnnotation: time.Now().Format(time.RFC3339Nano),
+				},
+			},
+		})
+		if err != nil {
+			return err
 		}
-		pod.Annotations[annotation.UpdateAnnotation] = time.Now().Format(time.RFC3339Nano)
-		_, err = clientset.CoreV1().Pods(pod.Namespace).Update(ctx, pod, metav1.UpdateOptions{})
+		_, err = clientset.CoreV1().Pods(pod.Namespace).Patch(ctx, pod.Name, types.MergePatchType, patch, metav1.PatchOptions{})
 		return err
 	})
 	if err != nil {

--- a/pkg/controller/webhook/reconcile.go
+++ b/pkg/controller/webhook/reconcile.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
 
+	"github.com/elastic/cloud-on-k8s/v3/pkg/about"
 	commonv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/common/v1"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/annotation"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/certificates"
@@ -84,7 +85,8 @@ func (w *Params) ReconcileResources(ctx context.Context, clientset kubernetes.In
 		if err != nil {
 			return err
 		}
-		if _, err := clientset.CoreV1().Secrets(w.Namespace).Patch(ctx, w.SecretName, types.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
+		if _, err := clientset.CoreV1().Secrets(w.Namespace).Patch(ctx, w.SecretName, types.MergePatchType, patch,
+			metav1.PatchOptions{FieldManager: about.FieldOwner}); err != nil {
 			return err
 		}
 		updateOperatorPods(ctx, clientset, w.Namespace)
@@ -129,7 +131,8 @@ func updateOperatorPod(ctx context.Context, pod corev1.Pod, clientset kubernetes
 		if err != nil {
 			return err
 		}
-		_, err = clientset.CoreV1().Pods(pod.Namespace).Patch(ctx, pod.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+		_, err = clientset.CoreV1().Pods(pod.Namespace).Patch(ctx, pod.Name, types.MergePatchType, patch,
+			metav1.PatchOptions{FieldManager: about.FieldOwner})
 		return err
 	})
 	if err != nil {

--- a/pkg/controller/webhook/reconcile_test.go
+++ b/pkg/controller/webhook/reconcile_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -115,6 +116,78 @@ func TestParams_ReconcileResources(t *testing.T) {
 	caBundle = webhookConfiguration.Webhooks[0].ClientConfig.CABundle
 	// Check again that the cert in the secret has been signed by the caBundle
 	verifyCertificates(t, caBundle, webhookServerSecret.Data["tls.crt"])
+}
+
+// TestReconcileResources_PreservesHelmOwnedFields verifies that cert rotation uses scoped patches
+// and does not overwrite fields on the Secret or ValidatingWebhookConfiguration that are managed
+// by the Helm chart (e.g. labels on the Secret, FailurePolicy/Rules on webhook entries).
+func TestReconcileResources_PreservesHelmOwnedFields(t *testing.T) {
+	const helmLabel = "helm.sh/chart"
+	failurePolicy := v1.Fail
+	rules := []v1.RuleWithOperations{
+		{
+			Operations: []v1.OperationType{v1.OperationAll},
+			Rule: v1.Rule{
+				APIGroups:   []string{"elasticsearch.k8s.elastic.co"},
+				APIVersions: []string{"v1"},
+				Resources:   []string{"elasticsearches"},
+			},
+		},
+	}
+
+	w := Params{
+		Name:       "elastic-webhook.k8s.elastic.co",
+		Namespace:  "elastic-system",
+		SecretName: "elastic-webhook-server-cert",
+		Rotation: certificates.RotationParams{
+			Validity:     certificates.DefaultCertValidity,
+			RotateBefore: certificates.DefaultRotateBefore,
+		},
+	}
+
+	clientset := fake.NewClientset(
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "elastic-system",
+				Name:      "elastic-webhook-server-cert",
+				Labels:    map[string]string{helmLabel: "eck-stack-1.0.0"},
+			},
+		},
+		&v1.ValidatingWebhookConfiguration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "elastic-webhook.k8s.elastic.co",
+			},
+			Webhooks: []v1.ValidatingWebhook{
+				{
+					Name:          "elastic-es-validation-v1.k8s.elastic.co",
+					FailurePolicy: &failurePolicy,
+					Rules:         rules,
+					ClientConfig: v1.WebhookClientConfig{
+						Service: &v1.ServiceReference{Name: "elastic-webhook-server", Namespace: "elastic-system"},
+					},
+				},
+			},
+		},
+	)
+
+	wh, err := w.NewAdmissionControllerInterface(context.Background(), clientset)
+	require.NoError(t, err)
+	require.NoError(t, w.ReconcileResources(context.Background(), clientset, wh))
+
+	ctx := context.Background()
+
+	secret, err := clientset.CoreV1().Secrets(w.Namespace).Get(ctx, w.SecretName, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "eck-stack-1.0.0", secret.Labels[helmLabel], "Helm-managed label must survive cert rotation")
+	assert.Equal(t, commonv1.RestrictWatchedResourcesLabelValue, secret.Labels[commonv1.RestrictWatchedResourcesLabelName], "ECK label must be set")
+
+	webhookCfg, err := clientset.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(ctx, w.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Len(t, webhookCfg.Webhooks, 1)
+	wh0 := webhookCfg.Webhooks[0]
+	assert.Equal(t, v1.Fail, *wh0.FailurePolicy, "Helm-managed FailurePolicy must survive caBundle patch")
+	assert.Equal(t, rules, wh0.Rules, "Helm-managed Rules must survive caBundle patch")
+	assert.NotEmpty(t, wh0.ClientConfig.CABundle, "caBundle must be set by cert rotation")
 }
 
 func verifyCertificates(t *testing.T, rootCert []byte, serverCert []byte) {

--- a/pkg/utils/k8s/k8sutils.go
+++ b/pkg/utils/k8s/k8sutils.go
@@ -8,8 +8,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"maps"
 	"net"
+	"slices"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -345,54 +345,50 @@ func NamespaceFilterFunc(
 	return namespaces.Has, nil // Return the Has method directly
 }
 
-// PatchObjectAnnotations applies mutateAnnotationsFn to obj, then sends a JSON merge patch containing
-// only the resulting annotations diff (additions, changes and removals), instead of diffing the whole
-// object. mutateAnnotationsFn is expected to mutate obj's annotations in place (e.g. via obj.GetAnnotations()
-// and obj.SetAnnotations()); it is a no-op to mutate any other field of obj, since only the annotations are
-// compared before and after. If the resulting annotations are unchanged, no patch request is sent.
-// The resourceVersion read from obj before mutation is embedded in the patch so that
-// the optimistic-concurrency guarantee is maintained. Callers must ensure obj has been fetched from
-// the API server (i.e. has a populated ResourceVersion) before calling this function; passing an
-// object that was only constructed locally will embed an empty resourceVersion and the
-// optimistic-concurrency guarantee will not hold.
-func PatchObjectAnnotations(ctx context.Context, k8sClient Client, obj client.Object, mutateAnnotationsFn func()) error {
-	if mutateAnnotationsFn == nil {
-		return nil
-	}
-
-	resourceVersion := obj.GetResourceVersion()
-
-	var origAnnotations map[string]string
-	if objAnnotation := obj.GetAnnotations(); objAnnotation != nil {
-		origAnnotations = maps.Clone(objAnnotation)
-	} else {
-		origAnnotations = map[string]string{}
-	}
-
-	mutateAnnotationsFn()
-
-	mutatedAnnotations := obj.GetAnnotations()
+// PatchAnnotations sends a JSON merge patch that upserts the keys in upsert and sets the keys
+// in remove to null (which deletes them). Only keys whose values actually differ from obj's
+// current annotations are included in the patch; if there is no diff, no request is sent.
+// The resourceVersion read from obj is embedded in the patch to maintain the
+// optimistic-concurrency guarantee.
+func PatchAnnotations(ctx context.Context, c Client, obj client.Object, upsert map[string]string, remove ...string) error {
+	orig := obj.GetAnnotations()
 	diff := make(map[string]any)
-	for k := range origAnnotations {
-		if _, ok := mutatedAnnotations[k]; !ok {
-			diff[k] = nil
+	for k, v := range upsert {
+		if ov, ok := orig[k]; !ok || ov != v {
+			diff[k] = v
 		}
 	}
-	for k, v := range mutatedAnnotations {
-		if ov, ok := origAnnotations[k]; !ok || ov != v {
-			diff[k] = v
+	for _, k := range remove {
+		if _, ok := orig[k]; ok {
+			diff[k] = nil
 		}
 	}
 	if len(diff) == 0 {
 		return nil
 	}
-
 	data, err := json.Marshal(map[string]any{"metadata": map[string]any{
-		"resourceVersion": resourceVersion,
+		"resourceVersion": obj.GetResourceVersion(),
 		"annotations":     diff,
 	}})
 	if err != nil {
 		return err
 	}
-	return k8sClient.Patch(ctx, obj, client.RawPatch(types.MergePatchType, data))
+	return c.Patch(ctx, obj, client.RawPatch(types.MergePatchType, data))
+}
+
+// PatchObjectFinalizers sends a JSON merge patch replacing the finalizers list with finalizers.
+// If the list is unchanged, no request is sent. The resourceVersion read from obj is embedded
+// in the patch to maintain the optimistic-concurrency guarantee.
+func PatchObjectFinalizers(ctx context.Context, c Client, obj client.Object, finalizers []string) error {
+	if slices.Equal(obj.GetFinalizers(), finalizers) {
+		return nil
+	}
+	data, err := json.Marshal(map[string]any{"metadata": map[string]any{
+		"resourceVersion": obj.GetResourceVersion(),
+		"finalizers":      finalizers,
+	}})
+	if err != nil {
+		return err
+	}
+	return c.Patch(ctx, obj, client.RawPatch(types.MergePatchType, data))
 }

--- a/pkg/utils/k8s/k8sutils.go
+++ b/pkg/utils/k8s/k8sutils.go
@@ -6,7 +6,9 @@ package k8s
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"maps"
 	"net"
 
 	corev1 "k8s.io/api/core/v1"
@@ -341,4 +343,56 @@ func NamespaceFilterFunc(
 	}
 
 	return namespaces.Has, nil // Return the Has method directly
+}
+
+// PatchObjectAnnotations applies mutateAnnotationsFn to obj, then sends a JSON merge patch containing
+// only the resulting annotations diff (additions, changes and removals), instead of diffing the whole
+// object. mutateAnnotationsFn is expected to mutate obj's annotations in place (e.g. via obj.GetAnnotations()
+// and obj.SetAnnotations()); it is a no-op to mutate any other field of obj, since only the annotations are
+// compared before and after. If the resulting annotations are unchanged, no patch request is sent.
+// The resourceVersion read from obj before mutation is embedded in the patch so that
+// the optimistic-concurrency guarantee is maintained. Callers must ensure obj has been fetched from
+// the API server (i.e. has a populated ResourceVersion) before calling this function; passing an
+// object that was only constructed locally will embed an empty resourceVersion and the
+// optimistic-concurrency guarantee will not hold.
+func PatchObjectAnnotations(ctx context.Context, k8sClient Client, obj client.Object, mutateAnnotationsFn func()) error {
+	if mutateAnnotationsFn == nil {
+		return nil
+	}
+
+	resourceVersion := obj.GetResourceVersion()
+
+	var origAnnotations map[string]string
+	if objAnnotation := obj.GetAnnotations(); objAnnotation != nil {
+		origAnnotations = maps.Clone(objAnnotation)
+	} else {
+		origAnnotations = map[string]string{}
+	}
+
+	mutateAnnotationsFn()
+
+	mutatedAnnotations := obj.GetAnnotations()
+	diff := make(map[string]any)
+	for k := range origAnnotations {
+		if _, ok := mutatedAnnotations[k]; !ok {
+			diff[k] = nil
+		}
+	}
+	for k, v := range mutatedAnnotations {
+		if ov, ok := origAnnotations[k]; !ok || ov != v {
+			diff[k] = v
+		}
+	}
+	if len(diff) == 0 {
+		return nil
+	}
+
+	data, err := json.Marshal(map[string]any{"metadata": map[string]any{
+		"resourceVersion": resourceVersion,
+		"annotations":     diff,
+	}})
+	if err != nil {
+		return err
+	}
+	return k8sClient.Patch(ctx, obj, client.RawPatch(types.MergePatchType, data))
 }

--- a/pkg/utils/k8s/k8sutils_test.go
+++ b/pkg/utils/k8s/k8sutils_test.go
@@ -6,6 +6,7 @@ package k8s
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net"
 	"reflect"
@@ -15,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -22,6 +24,21 @@ import (
 
 	netutil "github.com/elastic/cloud-on-k8s/v3/pkg/utils/net"
 )
+
+// patchRecordingClient wraps a Client and records the raw bytes of the most recent Patch call.
+type patchRecordingClient struct {
+	Client
+	lastPatchBody []byte
+}
+
+func (c *patchRecordingClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	data, err := patch.Data(obj)
+	if err != nil {
+		return err
+	}
+	c.lastPatchBody = data
+	return c.Client.Patch(ctx, obj, patch, opts...)
+}
 
 func TestDeepCopyObject(t *testing.T) {
 	testCases := []struct {
@@ -579,7 +596,7 @@ func TestNamespaceFilterFunc(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			filterFunc, err := NamespaceFilterFunc(context.Background(), tt.args.c, tt.args.selector)
+			filterFunc, err := NamespaceFilterFunc(t.Context(), tt.args.c, tt.args.selector)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NamespaceFilterFunc() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -597,112 +614,96 @@ func TestNamespaceFilterFunc(t *testing.T) {
 	}
 }
 
-func TestPatchObjectAnnotations(t *testing.T) {
+func TestPatchAnnotations(t *testing.T) {
 	tests := []struct {
-		name               string
-		initialAnnotations map[string]string
-		mutateFn           func(obj *corev1.ConfigMap)
-		failingClientErr   error
-		wantErr            bool
-		wantAnnotations    map[string]string
-		wantNoPatchCall    bool
+		name                 string
+		initialAnnotations   map[string]string
+		upsert               map[string]string
+		remove               []string
+		failingClientErr     error
+		wantErr              bool
+		wantAnnotations      map[string]string
+		wantNoPatchCall      bool
+		wantPatchAnnotations map[string]any
 	}{
 		{
-			name:               "add annotation to object with no annotations",
-			initialAnnotations: nil,
-			mutateFn: func(obj *corev1.ConfigMap) {
-				if obj.Annotations == nil {
-					obj.Annotations = map[string]string{}
-				}
-				obj.Annotations["new"] = "value"
-			},
-			wantAnnotations: map[string]string{"new": "value"},
+			name:                 "add annotation to object with no annotations",
+			initialAnnotations:   nil,
+			upsert:               map[string]string{"new": "value"},
+			wantAnnotations:      map[string]string{"new": "value"},
+			wantPatchAnnotations: map[string]any{"new": "value"},
 		},
 		{
-			name:               "add annotation to object with existing annotations",
-			initialAnnotations: map[string]string{"keep": "same"},
-			mutateFn: func(obj *corev1.ConfigMap) {
-				obj.Annotations["new"] = "value"
-			},
-			wantAnnotations: map[string]string{"keep": "same", "new": "value"},
+			name:                 "add annotation to object with existing annotations",
+			initialAnnotations:   map[string]string{"keep": "same"},
+			upsert:               map[string]string{"new": "value"},
+			wantAnnotations:      map[string]string{"keep": "same", "new": "value"},
+			wantPatchAnnotations: map[string]any{"new": "value"}, // "keep" must not appear in the patch
 		},
 		{
-			name:               "change value of an existing annotation",
-			initialAnnotations: map[string]string{"key": "old"},
-			mutateFn: func(obj *corev1.ConfigMap) {
-				obj.Annotations["key"] = "new"
-			},
-			wantAnnotations: map[string]string{"key": "new"},
+			name:                 "change value of an existing annotation",
+			initialAnnotations:   map[string]string{"key": "old"},
+			upsert:               map[string]string{"key": "new"},
+			wantAnnotations:      map[string]string{"key": "new"},
+			wantPatchAnnotations: map[string]any{"key": "new"},
 		},
 		{
-			name:               "remove one annotation, keep the others",
-			initialAnnotations: map[string]string{"keep": "same", "remove": "gone"},
-			mutateFn: func(obj *corev1.ConfigMap) {
-				delete(obj.Annotations, "remove")
-			},
-			wantAnnotations: map[string]string{"keep": "same"},
+			name:                 "remove one annotation, keep the others",
+			initialAnnotations:   map[string]string{"keep": "same", "remove": "gone"},
+			remove:               []string{"remove"},
+			wantAnnotations:      map[string]string{"keep": "same"},
+			wantPatchAnnotations: map[string]any{"remove": nil}, // "keep" must not appear in the patch
 		},
 		{
-			name:               "remove all annotations",
-			initialAnnotations: map[string]string{"a": "1", "b": "2"},
-			mutateFn: func(obj *corev1.ConfigMap) {
-				delete(obj.Annotations, "a")
-				delete(obj.Annotations, "b")
-			},
-			wantAnnotations: nil, // an emptied annotations map round-trips as nil due to the omitempty json tag
+			name:                 "remove all annotations",
+			initialAnnotations:   map[string]string{"a": "1", "b": "2"},
+			remove:               []string{"a", "b"},
+			wantAnnotations:      nil, // an emptied annotations map round-trips as nil due to the omitempty json tag
+			wantPatchAnnotations: map[string]any{"a": nil, "b": nil},
 		},
 		{
-			name:               "add, change and remove combined in a single call",
-			initialAnnotations: map[string]string{"unchanged": "1", "changed": "old", "removed": "x"},
-			mutateFn: func(obj *corev1.ConfigMap) {
-				obj.Annotations["changed"] = "new"
-				delete(obj.Annotations, "removed")
-				obj.Annotations["added"] = "y"
-			},
-			wantAnnotations: map[string]string{"unchanged": "1", "changed": "new", "added": "y"},
+			name:                 "add, change and remove combined in a single call",
+			initialAnnotations:   map[string]string{"unchanged": "1", "changed": "old", "removed": "x"},
+			upsert:               map[string]string{"changed": "new", "added": "y"},
+			remove:               []string{"removed"},
+			wantAnnotations:      map[string]string{"unchanged": "1", "changed": "new", "added": "y"},
+			wantPatchAnnotations: map[string]any{"changed": "new", "removed": nil, "added": "y"}, // "unchanged" must not appear
 		},
 		{
-			name:               "adding a key with an empty string value is treated as a change",
-			initialAnnotations: nil,
-			mutateFn: func(obj *corev1.ConfigMap) {
-				if obj.Annotations == nil {
-					obj.Annotations = map[string]string{}
-				}
-				obj.Annotations["blank"] = ""
-			},
-			wantAnnotations: map[string]string{"blank": ""},
+			name:                 "adding a key with an empty string value is treated as a change",
+			initialAnnotations:   nil,
+			upsert:               map[string]string{"blank": ""},
+			wantAnnotations:      map[string]string{"blank": ""},
+			wantPatchAnnotations: map[string]any{"blank": ""},
 		},
 		{
-			name:               "mutateAnnotationsFn that changes nothing does not issue a patch",
+			name:               "upserting the same value does not issue a patch",
 			initialAnnotations: map[string]string{"key": "value"},
-			mutateFn:           func(*corev1.ConfigMap) {},
+			upsert:             map[string]string{"key": "value"},
 			wantAnnotations:    map[string]string{"key": "value"},
 			wantNoPatchCall:    true,
 		},
 		{
-			name:               "re-setting an annotation to its current value does not issue a patch",
+			name:               "removing a key that does not exist does not issue a patch",
 			initialAnnotations: map[string]string{"key": "value"},
-			mutateFn: func(obj *corev1.ConfigMap) {
-				obj.Annotations["key"] = "value"
-			},
-			wantAnnotations: map[string]string{"key": "value"},
+			remove:             []string{"nonexistent"},
+			wantAnnotations:    map[string]string{"key": "value"},
+			wantNoPatchCall:    true,
+		},
+		{
+			name:               "nil upsert and no removes does not issue a patch",
+			initialAnnotations: map[string]string{"key": "value"},
+			wantAnnotations:    map[string]string{"key": "value"},
+			wantNoPatchCall:    true,
+		},
+		{
+			name:            "remove non-existent key from nil annotations does not issue a patch",
+			remove:          []string{"nonexistent"},
 			wantNoPatchCall: true,
 		},
 		{
-			name:               "nil mutateAnnotationsFn does not issue a patch",
-			initialAnnotations: map[string]string{"key": "value"},
-			wantAnnotations:    map[string]string{"key": "value"},
-			wantNoPatchCall:    true,
-		},
-		{
-			name:               "client error is propagated",
-			initialAnnotations: nil,
-			mutateFn: func(obj *corev1.ConfigMap) {
-				if obj.Annotations == nil {
-					obj.Annotations = map[string]string{}
-				}
-				obj.Annotations["new"] = "value"
-			},
+			name:             "client error is propagated",
+			upsert:           map[string]string{"new": "value"},
 			failingClientErr: errors.New("boom"),
 			wantErr:          true,
 		},
@@ -714,26 +715,21 @@ func TestPatchObjectAnnotations(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test", Annotations: tc.initialAnnotations},
 			}
 
-			var c Client
+			var inner Client
 			if tc.failingClientErr != nil {
-				c = NewFailingClient(tc.failingClientErr)
+				inner = NewFailingClient(tc.failingClientErr)
 			} else {
-				c = NewFakeClient(obj)
+				inner = NewFakeClient(obj)
 			}
+			recorder := &patchRecordingClient{Client: inner}
 
-			var beforeResourceVersion string
-			if tc.wantNoPatchCall {
-				fetched := &corev1.ConfigMap{}
-				require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: obj.Name, Namespace: obj.Namespace}, fetched))
-				beforeResourceVersion = fetched.ResourceVersion
+			// Fetch obj so its ResourceVersion is populated; PatchAnnotations embeds it in the patch body.
+			if tc.failingClientErr == nil {
+				require.NoError(t, recorder.Get(t.Context(), types.NamespacedName{Name: obj.Name, Namespace: obj.Namespace}, obj))
 			}
+			prePatchResourceVersion := obj.GetResourceVersion()
 
-			var mutateAnnotationsFn func()
-			if tc.mutateFn != nil {
-				mutateAnnotationsFn = func() { tc.mutateFn(obj) }
-			}
-
-			err := PatchObjectAnnotations(context.Background(), c, obj, mutateAnnotationsFn)
+			err := PatchAnnotations(t.Context(), recorder, obj, tc.upsert, tc.remove...)
 
 			if tc.wantErr {
 				require.Error(t, err)
@@ -742,36 +738,180 @@ func TestPatchObjectAnnotations(t *testing.T) {
 			require.NoError(t, err)
 
 			fetched := &corev1.ConfigMap{}
-			require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: obj.Name, Namespace: obj.Namespace}, fetched))
+			require.NoError(t, recorder.Get(t.Context(), types.NamespacedName{Name: obj.Name, Namespace: obj.Namespace}, fetched))
 			assert.Equal(t, tc.wantAnnotations, fetched.Annotations)
 
 			if tc.wantNoPatchCall {
-				assert.Equal(t, beforeResourceVersion, fetched.ResourceVersion, "expected no patch request to be issued")
+				assert.Equal(t, prePatchResourceVersion, fetched.ResourceVersion, "expected no patch request to be issued")
+				assert.Nil(t, recorder.lastPatchBody, "expected no patch request to be issued")
+				return
 			}
+
+			wantBody := map[string]any{
+				"metadata": map[string]any{
+					"resourceVersion": prePatchResourceVersion,
+					"annotations":     tc.wantPatchAnnotations,
+				},
+			}
+			var gotBody map[string]any
+			require.NoError(t, json.Unmarshal(recorder.lastPatchBody, &gotBody))
+			assert.Equal(t, wantBody, gotBody)
 		})
 	}
 }
 
-func TestPatchObjectAnnotationsOptimisticLock(t *testing.T) {
+func TestPatchAnnotationsOptimisticLock(t *testing.T) {
 	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"}}
 	c := NewFakeClient(cm)
 
 	stale := &corev1.ConfigMap{}
-	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "ns"}, stale))
+	require.NoError(t, c.Get(t.Context(), types.NamespacedName{Name: "test", Namespace: "ns"}, stale))
 
 	// Someone else changes the object first, bumping its resourceVersion.
 	live := &corev1.ConfigMap{}
-	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "ns"}, live))
+	require.NoError(t, c.Get(t.Context(), types.NamespacedName{Name: "test", Namespace: "ns"}, live))
 	live.Labels = map[string]string{"someone-else": "true"}
-	require.NoError(t, c.Update(context.Background(), live))
+	require.NoError(t, c.Update(t.Context(), live))
 
 	// Patching using the object fetched before that change must be rejected, since the
-	// resourceVersion PatchObjectAnnotations embeds no longer matches what's stored.
-	err := PatchObjectAnnotations(context.Background(), c, stale, func() {
-		if stale.Annotations == nil {
-			stale.Annotations = map[string]string{}
-		}
-		stale.Annotations["foo"] = "bar"
-	})
-	require.Error(t, err)
+	// resourceVersion PatchAnnotations embeds no longer matches what's stored.
+	err := PatchAnnotations(t.Context(), c, stale, map[string]string{"foo": "bar"})
+	require.True(t, apierrors.IsConflict(err))
+}
+
+func TestPatchObjectFinalizers(t *testing.T) {
+	tests := []struct {
+		name                string
+		initialFinalizers   []string
+		finalizers          []string
+		failingClientErr    error
+		wantErr             bool
+		wantFinalizers      []string
+		wantNoPatchCall     bool
+		wantPatchFinalizers []any
+	}{
+		{
+			name:                "remove one finalizer, keep the others",
+			initialFinalizers:   []string{"keep", "remove"},
+			finalizers:          []string{"keep"},
+			wantFinalizers:      []string{"keep"},
+			wantPatchFinalizers: []any{"keep"},
+		},
+		{
+			name:                "remove all finalizers",
+			initialFinalizers:   []string{"a", "b"},
+			finalizers:          nil,
+			wantFinalizers:      nil,
+			wantPatchFinalizers: nil, // patch sends "finalizers":null which removes all
+		},
+		{
+			name:                "add a finalizer to object with existing finalizers",
+			initialFinalizers:   []string{"existing"},
+			finalizers:          []string{"existing", "new"},
+			wantFinalizers:      []string{"existing", "new"},
+			wantPatchFinalizers: []any{"existing", "new"},
+		},
+		{
+			name:                "add a finalizer to object with no finalizers",
+			initialFinalizers:   nil,
+			finalizers:          []string{"new"},
+			wantFinalizers:      []string{"new"},
+			wantPatchFinalizers: []any{"new"},
+		},
+		{
+			name:              "same finalizers list does not issue a patch",
+			initialFinalizers: []string{"keep"},
+			finalizers:        []string{"keep"},
+			wantFinalizers:    []string{"keep"},
+			wantNoPatchCall:   true,
+		},
+		{
+			name:            "nil finalizers on empty object does not issue a patch",
+			wantNoPatchCall: true,
+		},
+		{
+			name:              "client error is propagated",
+			initialFinalizers: []string{"finalizer"},
+			finalizers:        nil,
+			failingClientErr:  errors.New("boom"),
+			wantErr:           true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test", Finalizers: tc.initialFinalizers},
+			}
+
+			var inner Client
+			if tc.failingClientErr != nil {
+				inner = NewFailingClient(tc.failingClientErr)
+			} else {
+				inner = NewFakeClient(obj)
+			}
+			recorder := &patchRecordingClient{Client: inner}
+
+			// Fetch obj so its ResourceVersion is populated; PatchObjectFinalizers embeds it in the patch body.
+			if tc.failingClientErr == nil {
+				require.NoError(t, recorder.Get(t.Context(), types.NamespacedName{Name: obj.Name, Namespace: obj.Namespace}, obj))
+			}
+			preCallResourceVersion := obj.GetResourceVersion()
+
+			err := PatchObjectFinalizers(t.Context(), recorder, obj, tc.finalizers)
+
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			fetched := &corev1.ConfigMap{}
+			require.NoError(t, recorder.Get(t.Context(), types.NamespacedName{Name: obj.Name, Namespace: obj.Namespace}, fetched))
+			assert.Equal(t, tc.wantFinalizers, fetched.Finalizers)
+
+			if tc.wantNoPatchCall {
+				assert.Equal(t, preCallResourceVersion, fetched.ResourceVersion, "expected no patch request to be issued")
+				assert.Nil(t, recorder.lastPatchBody, "expected no patch request to be issued")
+				return
+			}
+
+			// JSON unmarshal produces interface-nil for "finalizers":null, not []any(nil),
+			// so coerce the typed nil to bare nil for a consistent comparison.
+			var finalizersVal any
+			if tc.wantPatchFinalizers != nil {
+				finalizersVal = tc.wantPatchFinalizers
+			}
+			wantBody := map[string]any{
+				"metadata": map[string]any{
+					"resourceVersion": preCallResourceVersion,
+					"finalizers":      finalizersVal,
+				},
+			}
+			var gotBody map[string]any
+			require.NoError(t, json.Unmarshal(recorder.lastPatchBody, &gotBody))
+			assert.Equal(t, wantBody, gotBody)
+		})
+	}
+}
+
+func TestPatchObjectFinalizersOptimisticLock(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns", Finalizers: []string{"existing"}},
+	}
+	c := NewFakeClient(cm)
+
+	stale := &corev1.ConfigMap{}
+	require.NoError(t, c.Get(t.Context(), types.NamespacedName{Name: "test", Namespace: "ns"}, stale))
+
+	// Someone else changes the object first, bumping its resourceVersion.
+	live := &corev1.ConfigMap{}
+	require.NoError(t, c.Get(t.Context(), types.NamespacedName{Name: "test", Namespace: "ns"}, live))
+	live.Labels = map[string]string{"someone-else": "true"}
+	require.NoError(t, c.Update(t.Context(), live))
+
+	// Patching using the object fetched before that change must be rejected, since the
+	// resourceVersion PatchObjectFinalizers embeds no longer matches what's stored.
+	err := PatchObjectFinalizers(t.Context(), c, stale, nil)
+	require.True(t, apierrors.IsConflict(err))
 }

--- a/pkg/utils/k8s/k8sutils_test.go
+++ b/pkg/utils/k8s/k8sutils_test.go
@@ -6,6 +6,7 @@ package k8s
 
 import (
 	"context"
+	"errors"
 	"net"
 	"reflect"
 	"testing"
@@ -594,4 +595,183 @@ func TestNamespaceFilterFunc(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPatchObjectAnnotations(t *testing.T) {
+	tests := []struct {
+		name               string
+		initialAnnotations map[string]string
+		mutateFn           func(obj *corev1.ConfigMap)
+		failingClientErr   error
+		wantErr            bool
+		wantAnnotations    map[string]string
+		wantNoPatchCall    bool
+	}{
+		{
+			name:               "add annotation to object with no annotations",
+			initialAnnotations: nil,
+			mutateFn: func(obj *corev1.ConfigMap) {
+				if obj.Annotations == nil {
+					obj.Annotations = map[string]string{}
+				}
+				obj.Annotations["new"] = "value"
+			},
+			wantAnnotations: map[string]string{"new": "value"},
+		},
+		{
+			name:               "add annotation to object with existing annotations",
+			initialAnnotations: map[string]string{"keep": "same"},
+			mutateFn: func(obj *corev1.ConfigMap) {
+				obj.Annotations["new"] = "value"
+			},
+			wantAnnotations: map[string]string{"keep": "same", "new": "value"},
+		},
+		{
+			name:               "change value of an existing annotation",
+			initialAnnotations: map[string]string{"key": "old"},
+			mutateFn: func(obj *corev1.ConfigMap) {
+				obj.Annotations["key"] = "new"
+			},
+			wantAnnotations: map[string]string{"key": "new"},
+		},
+		{
+			name:               "remove one annotation, keep the others",
+			initialAnnotations: map[string]string{"keep": "same", "remove": "gone"},
+			mutateFn: func(obj *corev1.ConfigMap) {
+				delete(obj.Annotations, "remove")
+			},
+			wantAnnotations: map[string]string{"keep": "same"},
+		},
+		{
+			name:               "remove all annotations",
+			initialAnnotations: map[string]string{"a": "1", "b": "2"},
+			mutateFn: func(obj *corev1.ConfigMap) {
+				delete(obj.Annotations, "a")
+				delete(obj.Annotations, "b")
+			},
+			wantAnnotations: nil, // an emptied annotations map round-trips as nil due to the omitempty json tag
+		},
+		{
+			name:               "add, change and remove combined in a single call",
+			initialAnnotations: map[string]string{"unchanged": "1", "changed": "old", "removed": "x"},
+			mutateFn: func(obj *corev1.ConfigMap) {
+				obj.Annotations["changed"] = "new"
+				delete(obj.Annotations, "removed")
+				obj.Annotations["added"] = "y"
+			},
+			wantAnnotations: map[string]string{"unchanged": "1", "changed": "new", "added": "y"},
+		},
+		{
+			name:               "adding a key with an empty string value is treated as a change",
+			initialAnnotations: nil,
+			mutateFn: func(obj *corev1.ConfigMap) {
+				if obj.Annotations == nil {
+					obj.Annotations = map[string]string{}
+				}
+				obj.Annotations["blank"] = ""
+			},
+			wantAnnotations: map[string]string{"blank": ""},
+		},
+		{
+			name:               "mutateAnnotationsFn that changes nothing does not issue a patch",
+			initialAnnotations: map[string]string{"key": "value"},
+			mutateFn:           func(*corev1.ConfigMap) {},
+			wantAnnotations:    map[string]string{"key": "value"},
+			wantNoPatchCall:    true,
+		},
+		{
+			name:               "re-setting an annotation to its current value does not issue a patch",
+			initialAnnotations: map[string]string{"key": "value"},
+			mutateFn: func(obj *corev1.ConfigMap) {
+				obj.Annotations["key"] = "value"
+			},
+			wantAnnotations: map[string]string{"key": "value"},
+			wantNoPatchCall: true,
+		},
+		{
+			name:               "nil mutateAnnotationsFn does not issue a patch",
+			initialAnnotations: map[string]string{"key": "value"},
+			wantAnnotations:    map[string]string{"key": "value"},
+			wantNoPatchCall:    true,
+		},
+		{
+			name:               "client error is propagated",
+			initialAnnotations: nil,
+			mutateFn: func(obj *corev1.ConfigMap) {
+				if obj.Annotations == nil {
+					obj.Annotations = map[string]string{}
+				}
+				obj.Annotations["new"] = "value"
+			},
+			failingClientErr: errors.New("boom"),
+			wantErr:          true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test", Annotations: tc.initialAnnotations},
+			}
+
+			var c Client
+			if tc.failingClientErr != nil {
+				c = NewFailingClient(tc.failingClientErr)
+			} else {
+				c = NewFakeClient(obj)
+			}
+
+			var beforeResourceVersion string
+			if tc.wantNoPatchCall {
+				fetched := &corev1.ConfigMap{}
+				require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: obj.Name, Namespace: obj.Namespace}, fetched))
+				beforeResourceVersion = fetched.ResourceVersion
+			}
+
+			var mutateAnnotationsFn func()
+			if tc.mutateFn != nil {
+				mutateAnnotationsFn = func() { tc.mutateFn(obj) }
+			}
+
+			err := PatchObjectAnnotations(context.Background(), c, obj, mutateAnnotationsFn)
+
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			fetched := &corev1.ConfigMap{}
+			require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: obj.Name, Namespace: obj.Namespace}, fetched))
+			assert.Equal(t, tc.wantAnnotations, fetched.Annotations)
+
+			if tc.wantNoPatchCall {
+				assert.Equal(t, beforeResourceVersion, fetched.ResourceVersion, "expected no patch request to be issued")
+			}
+		})
+	}
+}
+
+func TestPatchObjectAnnotationsOptimisticLock(t *testing.T) {
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"}}
+	c := NewFakeClient(cm)
+
+	stale := &corev1.ConfigMap{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "ns"}, stale))
+
+	// Someone else changes the object first, bumping its resourceVersion.
+	live := &corev1.ConfigMap{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "ns"}, live))
+	live.Labels = map[string]string{"someone-else": "true"}
+	require.NoError(t, c.Update(context.Background(), live))
+
+	// Patching using the object fetched before that change must be rejected, since the
+	// resourceVersion PatchObjectAnnotations embeds no longer matches what's stored.
+	err := PatchObjectAnnotations(context.Background(), c, stale, func() {
+		if stale.Annotations == nil {
+			stale.Annotations = map[string]string{}
+		}
+		stale.Annotations["foo"] = "bar"
+	})
+	require.Error(t, err)
 }

--- a/test/e2e/es/autoscaling_test.go
+++ b/test/e2e/es/autoscaling_test.go
@@ -67,6 +67,7 @@ func TestAutoscaling(t *testing.T) {
 		// Add a ml tier, node count is initially set to 0, it will be updated by the autoscaling controller.
 		WithNodeSet(newNodeSet("ml", []string{"ml"}, 0, corev1.ResourceList{}, initialPVC)).
 		WithRestrictedSecurityContext().
+		WithSkipSpecOwnership().
 		WithExpectedNodeSets(
 			// master has no autoscaling policy — NodeSet.Resources is not managed by the autoscaler and stays empty.
 			newNodeSet("master", []string{"master"}, 1, corev1.ResourceList{}, initialPVC),

--- a/test/e2e/test/agent/steps.go
+++ b/test/e2e/test/agent/steps.go
@@ -202,6 +202,7 @@ func (b Builder) CheckK8sTestSteps(k *test.K8sClient) test.StepList {
 				return nil
 			}),
 		},
+		test.CheckSpecNotOwnedByOperator(&b.Agent, k),
 	}
 }
 

--- a/test/e2e/test/apmserver/checks_k8s.go
+++ b/test/e2e/test/apmserver/checks_k8s.go
@@ -25,6 +25,7 @@ func (b Builder) CheckK8sTestSteps(k *test.K8sClient) test.StepList {
 		checks.CheckServicesEndpoints(b, k),
 		CheckSecrets(b, k),
 		CheckStatus(b, k),
+		test.CheckSpecNotOwnedByOperator(&b.ApmServer, k),
 	}
 }
 

--- a/test/e2e/test/autoops/steps.go
+++ b/test/e2e/test/autoops/steps.go
@@ -196,7 +196,8 @@ func (b Builder) CheckK8sTestSteps(k *test.K8sClient) test.StepList {
 					return nil
 				})
 			}),
-		})
+		}).
+		WithStep(test.CheckSpecNotOwnedByOperator(&b.AutoOpsAgentPolicy, k))
 }
 
 func (b Builder) CheckStackTestSteps(k *test.K8sClient) test.StepList {

--- a/test/e2e/test/beat/steps.go
+++ b/test/e2e/test/beat/steps.go
@@ -143,6 +143,7 @@ func (b Builder) CheckK8sTestSteps(k *test.K8sClient) test.StepList {
 				return nil
 			}),
 		},
+		test.CheckSpecNotOwnedByOperator(&b.Beat, k),
 	}
 }
 

--- a/test/e2e/test/checks.go
+++ b/test/e2e/test/checks.go
@@ -6,6 +6,7 @@ package test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -14,6 +15,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/elastic/cloud-on-k8s/v3/pkg/about"
 )
 
 // CheckTestSteps returns all test steps to verify a given resource in K8s is the expected one
@@ -72,6 +76,40 @@ func CheckSecretsContent(k *K8sClient, namespace string, expected func() []Expec
 			for _, e := range expected() {
 				if err := e.MatchesActualSecret(k, namespace); err != nil {
 					return err
+				}
+			}
+			return nil
+		}),
+	}
+}
+
+// CheckSpecNotOwnedByOperator verifies that the ECK operator has not claimed ownership of the
+// resource spec in managed fields.
+func CheckSpecNotOwnedByOperator(obj k8sclient.Object, k *K8sClient) Step {
+	return Step{
+		Name: "Spec should not be owned by the operator in managed fields",
+		Test: Eventually(func() error {
+			// Do not mutate the caller's object.
+			live, ok := obj.DeepCopyObject().(k8sclient.Object)
+			if !ok {
+				return fmt.Errorf("expected object to be of type client.Object, got %T", live)
+			}
+			if err := k.Client.Get(context.Background(), types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, live); err != nil {
+				return err
+			}
+			for _, entry := range live.GetManagedFields() {
+				if entry.Subresource != "" || entry.FieldsV1 == nil {
+					continue
+				}
+				if entry.Manager != about.FieldOwner {
+					continue
+				}
+				var fields map[string]json.RawMessage
+				if err := json.Unmarshal(entry.FieldsV1.GetRawBytes(), &fields); err != nil {
+					return fmt.Errorf("parsing managed fields for manager %q: %w", entry.Manager, err)
+				}
+				if _, ownsSpec := fields["f:spec"]; ownsSpec {
+					return fmt.Errorf("field manager %q owns f:spec: the operator should not claim spec ownership", entry.Manager)
 				}
 			}
 			return nil

--- a/test/e2e/test/elasticsearch/builder.go
+++ b/test/e2e/test/elasticsearch/builder.go
@@ -57,6 +57,8 @@ type Builder struct {
 	GlobalCA bool
 
 	mutationToleratedChecksFailureCount int
+
+	skipSpecOwnership bool
 }
 
 func (b Builder) ResourceName() string {
@@ -76,6 +78,7 @@ func (b Builder) DeepCopy() *Builder {
 	}
 	builderCopy.GlobalCA = b.GlobalCA
 	builderCopy.mutationToleratedChecksFailureCount = b.mutationToleratedChecksFailureCount
+	builderCopy.skipSpecOwnership = b.skipSpecOwnership
 	return &builderCopy
 }
 
@@ -228,6 +231,11 @@ func (b Builder) WithCustomHTTPCerts(name string) Builder {
 
 func (b Builder) WithClientAuthenticationRequired() Builder {
 	b.Elasticsearch.Spec.HTTP.TLS.Client.Authentication = true
+	return b
+}
+
+func (b Builder) WithSkipSpecOwnership() Builder {
+	b.skipSpecOwnership = true
 	return b
 }
 

--- a/test/e2e/test/elasticsearch/checks_k8s.go
+++ b/test/e2e/test/elasticsearch/checks_k8s.go
@@ -40,7 +40,7 @@ const (
 )
 
 func (b Builder) CheckK8sTestSteps(k *test.K8sClient) test.StepList {
-	return test.StepList{
+	steps := test.StepList{
 		CheckHTTPCertificateAuthority(b, k),
 		CheckTransportCertificateAuthority(b, k),
 		CheckExpectedPodsEventuallyReady(b, k),
@@ -55,6 +55,10 @@ func (b Builder) CheckK8sTestSteps(k *test.K8sClient) test.StepList {
 		CheckContainerSecurityContext(b.Elasticsearch, k),
 		CheckClusterUUIDAnnotation(b.Elasticsearch, k),
 	}
+	if !b.skipSpecOwnership {
+		steps = append(steps, test.CheckSpecNotOwnedByOperator(&b.Elasticsearch, k))
+	}
+	return steps
 }
 
 // CheckHTTPCertificateAuthority checks that the CA is fully setup (CA cert + private key)

--- a/test/e2e/test/enterprisesearch/checks_k8s.go
+++ b/test/e2e/test/enterprisesearch/checks_k8s.go
@@ -25,6 +25,7 @@ func (b Builder) CheckK8sTestSteps(k *test.K8sClient) test.StepList {
 		checks.CheckServicesEndpoints(b, k),
 		CheckSecrets(b, k),
 		CheckStatus(b, k),
+		test.CheckSpecNotOwnedByOperator(&b.EnterpriseSearch, k),
 	}
 }
 

--- a/test/e2e/test/epr/steps.go
+++ b/test/e2e/test/epr/steps.go
@@ -91,6 +91,7 @@ func (b Builder) CheckK8sTestSteps(k *test.K8sClient) test.StepList {
 		checks.CheckServicesEndpoints(b, k),
 		CheckSecrets(b, k),
 		CheckStatus(b, k),
+		test.CheckSpecNotOwnedByOperator(&b.EPR, k),
 	}
 }
 

--- a/test/e2e/test/kibana/checks_k8s.go
+++ b/test/e2e/test/kibana/checks_k8s.go
@@ -26,6 +26,7 @@ func (b Builder) CheckK8sTestSteps(k *test.K8sClient) test.StepList {
 		checks.CheckServicesEndpoints(b, k),
 		CheckSecrets(b, k),
 		CheckStatus(b, k),
+		test.CheckSpecNotOwnedByOperator(&b.Kibana, k),
 	}
 }
 

--- a/test/e2e/test/logstash/steps.go
+++ b/test/e2e/test/logstash/steps.go
@@ -90,6 +90,7 @@ func (b Builder) CheckK8sTestSteps(k *test.K8sClient) test.StepList {
 		CheckServices(b, k),
 		CheckServicesEndpoints(b, k),
 		checks.CheckPods(b, k),
+		test.CheckSpecNotOwnedByOperator(&b.Logstash, k),
 	}
 }
 

--- a/test/e2e/test/maps/steps.go
+++ b/test/e2e/test/maps/steps.go
@@ -92,6 +92,7 @@ func (b Builder) CheckK8sTestSteps(k *test.K8sClient) test.StepList {
 		checks.CheckServicesEndpoints(b, k),
 		CheckSecrets(b, k),
 		CheckStatus(b, k),
+		test.CheckSpecNotOwnedByOperator(&b.EMS, k),
 	}
 }
 


### PR DESCRIPTION
## Summary

Whenever ECK persists internal state (association configuration, cluster UUID, enrollment keys, finalizer removal, etc.) it has historically used a full-object `client.Update()`. Under Kubernetes Server-Side Apply (SSA), which Helm 4 enables by default, a full `Update()` claims ownership of every field in the submitted object on behalf of the `elastic-operator` field manager — including `spec` fields the operator never intended to own and that Helm manages. When Helm 4 subsequently applies the chart, the API server sees conflicting ownership and rejects the operation (`UPGRADE FAILED: conflict with "elastic-operator" using elasticsearch.k8s.elastic.co/v1: .spec.nodeSets`).

This PR replaces all annotation-only and finalizer-only write paths with targeted patches that include only the fields that actually need to change, so the operator never claims `spec` ownership through these code paths and Helm 4 can freely own and apply `spec` without conflicts.

Closes https://github.com/elastic/cloud-on-k8s/issues/9631

## Changes

### `PatchObjectAnnotations` helper (`pkg/utils/k8s/k8sutils.go`)

New utility function that computes the diff between an object's annotation map before and after a caller-supplied mutation, then sends a JSON merge patch (`application/merge-patch+json`) containing only the changed keys (additions, modifications, and explicit `null` removals). The `resourceVersion` read from the object before mutation is embedded in the patch body to preserve the optimistic-concurrency guarantee. If the resulting diff is empty, no patch request is sent. All annotation-only write sites across the codebase are migrated to this helper.

### Controller write-path migrations

Every site that was doing a full-object `Update()` solely to persist an annotation or remove a finalizer is converted to a scoped patch:

- **`pkg/controller/agent/fleet.go`** - Fleet enrollment-token annotation on `Agent`
- **`pkg/controller/association/conf.go`** - `UpdateAssociationConf`, `RemoveAssociationConf`, and `RemoveObsoleteAssociationConfs` for all associated resource types
- **`pkg/controller/common/annotation/client_cert.go`** - set/remove of the client-authentication-required annotation on `Agent`
- **`pkg/controller/common/annotation/pod.go`** - pod update annotation write
- **`pkg/controller/common/finalizer/finalizers.go`** - Elastic finalizer removal uses `client.MergeFrom` with a deep-copied base (object-level merge patch) instead of `Update`, so only `metadata.finalizers` is patched; an early-exit is added for the case where no Elastic finalizers are present to avoid unnecessary API calls
- **`pkg/controller/common/volume/pvc_expansion.go`** - StatefulSet-recreation annotation set/remove; dead `setAnnotation`/`deleteAnnotation` helpers are removed
- **`pkg/controller/elasticsearch/bootstrap/bootstrap.go`** - cluster UUID annotation
- **`pkg/controller/elasticsearch/elasticsearch_controller.go`** - managed remote clusters annotation reconciliation
- **`pkg/controller/elasticsearch/remotecluster/annotations.go`** - managed remote clusters annotation write/remove
- **`pkg/controller/elasticsearch/version/zen2/initial_master_nodes.go`** - initial master nodes bootstrap annotation set/remove
- **`pkg/controller/enterprisesearch/version_upgrade.go`** - read-only-mode annotation set/remove

### Webhook patches (`pkg/controller/webhook/`)

Two webhook write paths required a different patch strategy:

- **`ValidatingWebhookConfiguration` caBundle** (`admission_registration.go`) - migrated from a full `Update()` to a **strategic merge patch** (`application/strategic-merge-patch+json`). The `webhooks` field is a Kubernetes associative list keyed by `name`, so a strategic merge patch updates individual webhook entries by name without replacing the entire list and stripping Helm-owned fields (rules, failure policy, selectors).
- **Webhook server Secret** (`reconcile.go`) - cert rotation now uses a **JSON merge patch** carrying only `data` (the new cert/key) and the commonv1.RestrictWatchedResourcesLabelName in the `labels`, leaving all other Secret fields managed by the Helm chart untouched. Operator pod annotation updates in the same file are also converted to targeted merge patches.

### Field owner registration (`cmd/manager/main.go`, `pkg/about/info.go`)

A `FieldOwner = "elastic-operator"` constant is introduced in `pkg/about` and registered as the controller-manager's default field owner via `client.Options{FieldOwner}`. This makes the field manager name explicit and consistent across all write operations rather than relying on the API server's User-Agent-derived default which is the binary name.

### E2E regression guard (`test/e2e/test/checks.go`)

A new `CheckSpecNotOwnedByOperator` step is added and wired into the post-creation check steps of every stack resource type (Elasticsearch, Kibana, APM Server, Beats, Agent, Logstash, Maps, Enterprise Search, AutoOps). It inspects the live `managedFields` on the resource after the operator has reconciled it and fails if the `elastic-operator` field manager appears as the owner of `f:spec`. Autoscaler e2e tests opt out via a `WithSkipSpecOwnership()` flag, as SSA compatibility for the autoscaler flow is tracked separately.
