### PR TITLE
Fix duplicate volume mounts for fleet-managed and fleet-enabled agents

### DIFF
--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -17,7 +17,6 @@ import (
 
 	pkgerrors "github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -204,7 +203,7 @@ func buildPodTemplate(params Params, fleetCerts *certificates.CertificatesSecret
 	}
 
 	// all volumes with CAs of direct associations
-	caAssocVols, err := getVolumesFromAssociations(params.Agent.GetAssociations())
+	caAssocVols, err := getVolumesFromAssociations(params.Agent.GetAssociations(), spec.FleetModeEnabled())
 	if err != nil {
 		return corev1.PodTemplateSpec{}, err
 	}
@@ -488,12 +487,26 @@ func writeEsAssocToConfigHash(params Params, esAssociation commonv1.Association,
 	)
 }
 
-func getVolumesFromAssociations(associations []commonv1.Association) ([]volume.VolumeLike, error) {
+// shouldSkipVolumeMount centralises association-type skip decisions for getVolumesFromAssociations.
+// Adding a new association type that needs special-cased volume handling belongs here.
+func shouldSkipVolumeMount(assocType commonv1.AssociationType, fleetModeEnabled bool) bool {
+	switch assocType {
+	case commonv1.KibanaAssociationType:
+		// Kibana is operator-only; no cert mount needed in agent pods.
+		return true
+	case commonv1.ElasticsearchAssociationType:
+		// For fleet mode, applyRelatedEsAssoc already mounts both the CA and the client cert
+		// (CA as a plain secret volume, client cert at FleetManagedAgentClientCertDir).
+		return fleetModeEnabled
+	default:
+		return false
+	}
+}
+
+func getVolumesFromAssociations(associations []commonv1.Association, fleetModeEnabled bool) ([]volume.VolumeLike, error) {
 	var vols []volume.VolumeLike
 	for i, assoc := range associations {
-		// the Kibana association is only used by the operator to interact with the Kibana Fleet API but
-		// not by the individual Elastic Agent Pods. There is therefore no need to mount the Kibana certificate secret.
-		if assoc.AssociationType() == commonv1.KibanaAssociationType {
+		if shouldSkipVolumeMount(assoc.AssociationType(), fleetModeEnabled) {
 			continue
 		}
 		assocConf, err := assoc.AssociationConf()
@@ -733,13 +746,10 @@ func populateFleetServerESConfig(ctx context.Context, agent agentv1alpha1.Agent,
 	}
 
 	if esAssocConf.ClientCertIsConfigured() {
-		esAssoc, err := association.SingleAssociationOfType(agent.GetAssociations(), commonv1.ElasticsearchAssociationType)
-		if err != nil {
-			return err
-		}
-		clientCertDir := associationClientCertificatesDir(esAssoc)
-		fleetServerCfg[FleetServerESCert] = path.Join(clientCertDir, certificates.CertFileName)
-		fleetServerCfg[FleetServerESCertKey] = path.Join(clientCertDir, certificates.KeyFileName)
+		// FleetManagedAgentClientCertDir is mounted by applyRelatedEsAssoc; reuse
+		// the same path.
+		fleetServerCfg[FleetServerESCert] = path.Join(FleetManagedAgentClientCertDir, certificates.CertFileName)
+		fleetServerCfg[FleetServerESCertKey] = path.Join(FleetManagedAgentClientCertDir, certificates.KeyFileName)
 	}
 
 	return nil
@@ -759,18 +769,6 @@ func secretSource(name, key string) *corev1.EnvVarSource {
 }
 
 func cleanupEnvVarsSecret(params Params) error {
-	var envVarsSecret corev1.Secret
-	if err := params.Client.Get(
-		params.Context,
-		types.NamespacedName{Name: EnvVarsSecretName(params.Agent.Name), Namespace: params.Agent.Namespace},
-		&envVarsSecret,
-	); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return err
-		}
-	} else if err := params.Client.Delete(params.Context, &envVarsSecret); err != nil {
-		return err
-	}
-
-	return nil
+	return k8s.DeleteSecretIfExists(params.Context, params.Client,
+		types.NamespacedName{Name: EnvVarsSecretName(params.Agent.Name), Namespace: params.Agent.Namespace})
 }

--- a/pkg/controller/agent/pod_test.go
+++ b/pkg/controller/agent/pod_test.go
@@ -442,6 +442,117 @@ func Test_amendBuilderForFleetMode(t *testing.T) {
 			}),
 		},
 		{
+			name: "running elastic agent, with fleet server, with es CA: single CA mount",
+			params: func() Params {
+				agent := agentv1alpha1.Agent{
+					ObjectMeta: metav1.ObjectMeta{Name: "agent", Namespace: "default"},
+					Spec: agentv1alpha1.AgentSpec{
+						FleetServerEnabled: true,
+						ElasticsearchRefs: []agentv1alpha1.Output{{
+							ElasticsearchSelector: commonv1.ElasticsearchSelector{
+								ObjectSelector: commonv1.ObjectSelector{Name: "es", Namespace: "es-ns"},
+							},
+						}},
+					},
+				}
+				agent.GetAssociations()[0].SetAssociationConf(&commonv1.AssociationConf{
+					AuthSecretName: "es-auth-secret",
+					AuthSecretKey:  "user",
+					URL:            "https://es-es-http.es-ns.svc:9200",
+					CACertProvided: true,
+					CASecretName:   "es-es-ca",
+				})
+				return Params{
+					Context:      context.Background(),
+					AgentVersion: version.MinFor(9, 0, 0),
+					Agent:        agent,
+					Client: k8s.NewFakeClient(
+						&corev1.Service{
+							ObjectMeta: metav1.ObjectMeta{Name: "agent-agent-http", Namespace: "default"},
+							Spec: corev1.ServiceSpec{
+								Ports: []corev1.ServicePort{{Name: "https", Port: 8220}},
+							},
+						},
+						&corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{Name: "es-auth-secret", Namespace: "default"},
+							Data:       map[string][]byte{"user": []byte("password")},
+						},
+					),
+				}
+			}(),
+			fleetCerts: fleetCertsFixture,
+			wantPodSpec: generatePodSpec(func(ps corev1.PodSpec) corev1.PodSpec {
+				f := false
+				ps.Volumes = []corev1.Volume{
+					{
+						Name: "elasticsearch-certs",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName: "es-es-ca",
+								Optional:   &optional,
+							},
+						},
+					},
+					{
+						Name: "fleet-certs",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName: "fleet-certs-secret-name",
+								Optional:   &optional,
+							},
+						},
+					},
+				}
+				ps.Containers[0].VolumeMounts = []corev1.VolumeMount{
+					{
+						Name:      "elasticsearch-certs",
+						ReadOnly:  true,
+						MountPath: "/mnt/elastic-internal/elasticsearch-association/es-ns/es/certs",
+					},
+					{
+						Name:      "fleet-certs",
+						ReadOnly:  true,
+						MountPath: "/usr/share/fleet-server/config/http-certs",
+					},
+				}
+				ps.Containers[0].Ports = []corev1.ContainerPort{
+					{Name: "https", ContainerPort: 8220, Protocol: corev1.ProtocolTCP},
+				}
+				ps.Containers[0].Env = []corev1.EnvVar{
+					{Name: "FLEET_CA", Value: "/usr/share/fleet-server/config/http-certs/ca.crt"},
+					{Name: "FLEET_SERVER_CERT", Value: "/usr/share/fleet-server/config/http-certs/tls.crt"},
+					{Name: "FLEET_SERVER_CERT_KEY", Value: "/usr/share/fleet-server/config/http-certs/tls.key"},
+					{Name: "FLEET_SERVER_ELASTICSEARCH_CA", Value: "/mnt/elastic-internal/elasticsearch-association/es-ns/es/certs/ca.crt"},
+					{Name: "FLEET_SERVER_ELASTICSEARCH_HOST", Value: "https://es-es-http.es-ns.svc:9200"},
+					{Name: "FLEET_SERVER_ELASTICSEARCH_PASSWORD", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "agent-agent-envvars"},
+						Key:                  "FLEET_SERVER_ELASTICSEARCH_PASSWORD",
+						Optional:             &f,
+					}}},
+					{Name: "FLEET_SERVER_ELASTICSEARCH_USERNAME", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "agent-agent-envvars"},
+						Key:                  "FLEET_SERVER_ELASTICSEARCH_USERNAME",
+						Optional:             &f,
+					}}},
+					{Name: "FLEET_SERVER_ENABLE", Value: "true"},
+					{Name: "FLEET_URL", Value: "https://agent-agent-http.default.svc:8220"},
+					{Name: "STATE_PATH", Value: "/usr/share/elastic-agent/state"},
+					{Name: "CONFIG_PATH", Value: "/usr/share/elastic-agent/state"},
+				}
+				ps.Containers[0].Resources = corev1.ResourceRequirements{
+					Limits: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+					},
+					Requests: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+					},
+				}
+				return ps
+			}),
+		},
+		{
 			name: "running elastic agent, with fleet server, with client auth required",
 			params: Params{
 				AgentVersion: version.MinFor(9, 0, 0),
@@ -934,10 +1045,10 @@ func Test_applyEnvVars(t *testing.T) {
 func Test_getVolumesFromAssociations(t *testing.T) {
 	// Note: we use setAssocConfs to set the AssociationConfs which are normally set in the reconciliation loop.
 	for _, tt := range []struct {
-		name                   string
-		params                 Params
-		setAssocConfs          func(assocs []commonv1.Association)
-		wantAssociationsLength int
+		name                              string
+		params                            Params
+		setAssocConfs                     func(assocs []commonv1.Association)
+		wantVolumesFromAssociationsLength int
 	}{
 		{
 			name: "fleet mode enabled, kb ref, fleet ref",
@@ -969,7 +1080,7 @@ func Test_getVolumesFromAssociations(t *testing.T) {
 					CASecretName: "elasticsearch-es-ca",
 				})
 			},
-			wantAssociationsLength: 2,
+			wantVolumesFromAssociationsLength: 2,
 		},
 		{
 			name: "fleet mode enabled, kb no tls ref, fleet ref",
@@ -990,7 +1101,30 @@ func Test_getVolumesFromAssociations(t *testing.T) {
 					CASecretName: "fleet-agent-http-certs-public",
 				})
 			},
-			wantAssociationsLength: 1,
+			wantVolumesFromAssociationsLength: 1,
+		},
+		{
+			name: "fleet mode enabled, fleet server ref with CA and mTLS",
+			params: Params{
+				Agent: agentv1alpha1.Agent{
+					Spec: agentv1alpha1.AgentSpec{
+						Mode:           agentv1alpha1.AgentFleetMode,
+						KibanaRef:      commonv1.ObjectSelector{Name: "kibana"},
+						FleetServerRef: commonv1.FleetServerSelector{ObjectSelector: commonv1.ObjectSelector{Name: "fleet"}},
+					},
+				},
+			},
+			setAssocConfs: func(assocs []commonv1.Association) {
+				assocs[0].SetAssociationConf(&commonv1.AssociationConf{
+					// No CASecretName (Kibana)
+				})
+				assocs[1].SetAssociationConf(&commonv1.AssociationConf{
+					CASecretName:         "fleet-agent-http-certs-public",
+					ClientCertSecretName: "fleet-client-cert",
+				})
+			},
+			// Fleet Server CA (1) + Fleet Server client cert for mTLS (1) = 2
+			wantVolumesFromAssociationsLength: 2,
 		},
 		{
 			name: "fleet mode enabled, es ref with client cert",
@@ -1022,15 +1156,99 @@ func Test_getVolumesFromAssociations(t *testing.T) {
 				})
 			},
 			// 1 CA vol for ES + 1 client cert vol for ES + 1 CA vol for Fleet Server = 3
-			wantAssociationsLength: 3,
+			wantVolumesFromAssociationsLength: 3,
+		},
+		{
+			name: "fleet server enabled, es ref with CA only",
+			params: Params{
+				Agent: agentv1alpha1.Agent{
+					Spec: agentv1alpha1.AgentSpec{
+						Mode:               agentv1alpha1.AgentFleetMode,
+						FleetServerEnabled: true,
+						ElasticsearchRefs: []agentv1alpha1.Output{
+							{
+								ElasticsearchSelector: commonv1.ElasticsearchSelector{
+									ObjectSelector: commonv1.ObjectSelector{Name: "elasticsearch"},
+								},
+								OutputName: "default",
+							},
+						},
+					},
+				},
+			},
+			setAssocConfs: func(assocs []commonv1.Association) {
+				assocs[0].SetAssociationConf(&commonv1.AssociationConf{
+					CASecretName: "elasticsearch-es-ca",
+				})
+			},
+			// ES association skipped: applyRelatedEsAssoc mounts it as a plain secret volume.
+			wantVolumesFromAssociationsLength: 0,
+		},
+		{
+			name: "fleet server enabled, es ref with CA and client cert",
+			params: Params{
+				Agent: agentv1alpha1.Agent{
+					Spec: agentv1alpha1.AgentSpec{
+						Mode:               agentv1alpha1.AgentFleetMode,
+						FleetServerEnabled: true,
+						ElasticsearchRefs: []agentv1alpha1.Output{
+							{
+								ElasticsearchSelector: commonv1.ElasticsearchSelector{
+									ObjectSelector: commonv1.ObjectSelector{Name: "elasticsearch"},
+								},
+								OutputName: "default",
+							},
+						},
+					},
+				},
+			},
+			setAssocConfs: func(assocs []commonv1.Association) {
+				assocs[0].SetAssociationConf(&commonv1.AssociationConf{
+					CASecretName:         "elasticsearch-es-ca",
+					ClientCertSecretName: "es-client-cert",
+				})
+			},
+			// ES association skipped: applyRelatedEsAssoc mounts both CA and client cert.
+			wantVolumesFromAssociationsLength: 0,
+		},
+		{
+			name: "fleet server enabled, es ref with CA and client cert, kb ref",
+			params: Params{
+				Agent: agentv1alpha1.Agent{
+					Spec: agentv1alpha1.AgentSpec{
+						Mode:               agentv1alpha1.AgentFleetMode,
+						FleetServerEnabled: true,
+						KibanaRef:          commonv1.ObjectSelector{Name: "kibana"},
+						ElasticsearchRefs: []agentv1alpha1.Output{
+							{
+								ElasticsearchSelector: commonv1.ElasticsearchSelector{
+									ObjectSelector: commonv1.ObjectSelector{Name: "elasticsearch"},
+								},
+								OutputName: "default",
+							},
+						},
+					},
+				},
+			},
+			setAssocConfs: func(assocs []commonv1.Association) {
+				assocs[0].SetAssociationConf(&commonv1.AssociationConf{
+					CASecretName: "kibana-kb-http-certs-public",
+				})
+				assocs[1].SetAssociationConf(&commonv1.AssociationConf{
+					CASecretName:         "elasticsearch-es-ca",
+					ClientCertSecretName: "es-client-cert",
+				})
+			},
+			// Kibana skipped (not pod-mounted); ES skipped (applyRelatedEsAssoc handles it).
+			wantVolumesFromAssociationsLength: 0,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			assocs := tt.params.Agent.GetAssociations()
 			tt.setAssocConfs(assocs)
-			associations, err := getVolumesFromAssociations(assocs)
+			associations, err := getVolumesFromAssociations(assocs, tt.params.Agent.Spec.FleetServerEnabled)
 			require.NoError(t, err)
-			require.Equal(t, tt.wantAssociationsLength, len(associations))
+			require.Equal(t, tt.wantVolumesFromAssociationsLength, len(associations))
 		})
 	}
 }
@@ -1968,8 +2186,8 @@ func Test_getFleetSetupFleetServerEnvVars(t *testing.T) {
 				"FLEET_SERVER_ELASTICSEARCH_USERNAME": "user",
 				"FLEET_SERVER_ELASTICSEARCH_PASSWORD": "password",
 				"FLEET_SERVER_ELASTICSEARCH_CA":       "/mnt/elastic-internal/elasticsearch-association/es-ns/es/certs/ca.crt",
-				FleetServerESCert:                     path.Join("/mnt/elastic-internal/elasticsearch-association/es-ns/es/client-certs", certificates.CertFileName),
-				FleetServerESCertKey:                  path.Join("/mnt/elastic-internal/elasticsearch-association/es-ns/es/client-certs", certificates.KeyFileName),
+				FleetServerESCert:                     path.Join(FleetManagedAgentClientCertDir, certificates.CertFileName),
+				FleetServerESCertKey:                  path.Join(FleetManagedAgentClientCertDir, certificates.KeyFileName),
 			},
 			client: k8s.NewFakeClient(&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2109,6 +2327,50 @@ func Test_fleetManagedAgentESClientCertSecretName(t *testing.T) {
 			}
 			got := fleetManagedAgentESClientCertSecretName(tt.params)
 			require.Equal(t, tt.wantSecretName, got)
+		})
+	}
+}
+
+func Test_shouldSkipVolumeMount(t *testing.T) {
+	for _, tt := range []struct {
+		name               string
+		assocType          commonv1.AssociationType
+		fleetServerEnabled bool
+		want               bool
+	}{
+		{
+			name:               "kibana is always skipped",
+			assocType:          commonv1.KibanaAssociationType,
+			fleetServerEnabled: false,
+			want:               true,
+		},
+		{
+			name:               "kibana is skipped even when fleet server enabled",
+			assocType:          commonv1.KibanaAssociationType,
+			fleetServerEnabled: true,
+			want:               true,
+		},
+		{
+			name:               "elasticsearch skipped when fleet server enabled",
+			assocType:          commonv1.ElasticsearchAssociationType,
+			fleetServerEnabled: true,
+			want:               true,
+		},
+		{
+			name:               "elasticsearch mounted when fleet server disabled",
+			assocType:          commonv1.ElasticsearchAssociationType,
+			fleetServerEnabled: false,
+			want:               false,
+		},
+		{
+			name:               "fleet server association always mounted",
+			assocType:          commonv1.FleetServerAssociationType,
+			fleetServerEnabled: false,
+			want:               false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, shouldSkipVolumeMount(tt.assocType, tt.fleetServerEnabled))
 		})
 	}
 }

--- a/pkg/controller/agent/pod_test.go
+++ b/pkg/controller/agent/pod_test.go
@@ -1080,7 +1080,9 @@ func Test_getVolumesFromAssociations(t *testing.T) {
 					CASecretName: "elasticsearch-es-ca",
 				})
 			},
-			wantVolumesFromAssociationsLength: 2,
+			// Kibana skipped (not pod-mounted); ES skipped (applyRelatedEsAssoc handles it in fleet mode).
+			// 1 CA vol for Fleet Server = 1
+			wantVolumesFromAssociationsLength: 1,
 		},
 		{
 			name: "fleet mode enabled, kb no tls ref, fleet ref",
@@ -1155,8 +1157,8 @@ func Test_getVolumesFromAssociations(t *testing.T) {
 					CASecretName: "fleet-agent-http-certs-public",
 				})
 			},
-			// 1 CA vol for ES + 1 client cert vol for ES + 1 CA vol for Fleet Server = 3
-			wantVolumesFromAssociationsLength: 3,
+			// ES skipped: applyRelatedEsAssoc handles it in fleet mode. 1 CA vol for Fleet Server = 1
+			wantVolumesFromAssociationsLength: 1,
 		},
 		{
 			name: "fleet server enabled, es ref with CA only",
@@ -1246,7 +1248,7 @@ func Test_getVolumesFromAssociations(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			assocs := tt.params.Agent.GetAssociations()
 			tt.setAssocConfs(assocs)
-			associations, err := getVolumesFromAssociations(assocs, tt.params.Agent.Spec.FleetServerEnabled)
+			associations, err := getVolumesFromAssociations(assocs, tt.params.Agent.Spec.FleetModeEnabled())
 			require.NoError(t, err)
 			require.Equal(t, tt.wantVolumesFromAssociationsLength, len(associations))
 		})
@@ -2333,44 +2335,50 @@ func Test_fleetManagedAgentESClientCertSecretName(t *testing.T) {
 
 func Test_shouldSkipVolumeMount(t *testing.T) {
 	for _, tt := range []struct {
-		name               string
-		assocType          commonv1.AssociationType
-		fleetServerEnabled bool
-		want               bool
+		name             string
+		assocType        commonv1.AssociationType
+		fleetModeEnabled bool
+		want             bool
 	}{
 		{
-			name:               "kibana is always skipped",
-			assocType:          commonv1.KibanaAssociationType,
-			fleetServerEnabled: false,
-			want:               true,
+			name:             "kibana is always skipped",
+			assocType:        commonv1.KibanaAssociationType,
+			fleetModeEnabled: false,
+			want:             true,
 		},
 		{
-			name:               "kibana is skipped even when fleet server enabled",
-			assocType:          commonv1.KibanaAssociationType,
-			fleetServerEnabled: true,
-			want:               true,
+			name:             "kibana is skipped even when fleet mode enabled",
+			assocType:        commonv1.KibanaAssociationType,
+			fleetModeEnabled: true,
+			want:             true,
 		},
 		{
-			name:               "elasticsearch skipped when fleet server enabled",
-			assocType:          commonv1.ElasticsearchAssociationType,
-			fleetServerEnabled: true,
-			want:               true,
+			name:             "elasticsearch skipped when fleet mode enabled (fleet server agent)",
+			assocType:        commonv1.ElasticsearchAssociationType,
+			fleetModeEnabled: true,
+			want:             true,
 		},
 		{
-			name:               "elasticsearch mounted when fleet server disabled",
-			assocType:          commonv1.ElasticsearchAssociationType,
-			fleetServerEnabled: false,
-			want:               false,
+			name:             "elasticsearch skipped when fleet mode enabled (fleet-managed agent)",
+			assocType:        commonv1.ElasticsearchAssociationType,
+			fleetModeEnabled: true,
+			want:             true,
 		},
 		{
-			name:               "fleet server association always mounted",
-			assocType:          commonv1.FleetServerAssociationType,
-			fleetServerEnabled: false,
-			want:               false,
+			name:             "elasticsearch mounted when not in fleet mode",
+			assocType:        commonv1.ElasticsearchAssociationType,
+			fleetModeEnabled: false,
+			want:             false,
+		},
+		{
+			name:             "fleet server association always mounted",
+			assocType:        commonv1.FleetServerAssociationType,
+			fleetModeEnabled: false,
+			want:             false,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, shouldSkipVolumeMount(tt.assocType, tt.fleetServerEnabled))
+			require.Equal(t, tt.want, shouldSkipVolumeMount(tt.assocType, tt.fleetModeEnabled))
 		})
 	}
 }

--- a/pkg/controller/agent/pod_test.go
+++ b/pkg/controller/agent/pod_test.go
@@ -1070,14 +1070,15 @@ func Test_getVolumesFromAssociations(t *testing.T) {
 				},
 			},
 			setAssocConfs: func(assocs []commonv1.Association) {
+				// GetAssociations order: [ES, Kibana, FleetServer]
 				assocs[0].SetAssociationConf(&commonv1.AssociationConf{
-					CASecretName: "kibana-kb-http-certs-public",
+					CASecretName: "elasticsearch-es-ca",
 				})
 				assocs[1].SetAssociationConf(&commonv1.AssociationConf{
-					CASecretName: "fleet-agent-http-certs-public",
+					CASecretName: "kibana-kb-http-certs-public",
 				})
 				assocs[2].SetAssociationConf(&commonv1.AssociationConf{
-					CASecretName: "elasticsearch-es-ca",
+					CASecretName: "fleet-agent-http-certs-public",
 				})
 			},
 			// Kibana skipped (not pod-mounted); ES skipped (applyRelatedEsAssoc handles it in fleet mode).
@@ -1233,12 +1234,13 @@ func Test_getVolumesFromAssociations(t *testing.T) {
 				},
 			},
 			setAssocConfs: func(assocs []commonv1.Association) {
+				// GetAssociations order: [ES, Kibana]
 				assocs[0].SetAssociationConf(&commonv1.AssociationConf{
-					CASecretName: "kibana-kb-http-certs-public",
-				})
-				assocs[1].SetAssociationConf(&commonv1.AssociationConf{
 					CASecretName:         "elasticsearch-es-ca",
 					ClientCertSecretName: "es-client-cert",
+				})
+				assocs[1].SetAssociationConf(&commonv1.AssociationConf{
+					CASecretName: "kibana-kb-http-certs-public",
 				})
 			},
 			// Kibana skipped (not pod-mounted); ES skipped (applyRelatedEsAssoc handles it).


### PR DESCRIPTION
## Summary

Fleet Server agent pods end up with duplicate volume mounts when the Elasticsearch association has TLS enabled, which is the default for all ECK-managed clusters. The root cause was that `buildPodTemplate` called `getVolumesFromAssociations` for every agent regardless of mode, and for fleet-mode agents this added an ES CA volume at the same mount path that `applyRelatedEsAssoc` had already mounted - for both fleet-server agents (which mount it via their own ES association) and fleet-managed agents (which mount it transitively via the fleet server's ES association).

A related issue affected mTLS configurations: `getVolumesFromAssociations` mounted the Elasticsearch client certificate at a namespaced path while `applyRelatedEsAssoc` also mounted the same secret at the flat `FleetManagedAgentClientCertDir` path, producing two mounts for the same secret. The `FLEET_SERVER_ES_CERT` and `FLEET_SERVER_ES_CERT_KEY` env vars pointed to the namespaced path, leaving the flat-path mount unused.

Closes #9682

## Changes

- Added `shouldSkipVolumeMount` to centralise association-type skip decisions: Kibana associations are always skipped (operator-only, no pod cert needed); Elasticsearch associations are skipped when fleet mode is enabled, since `applyRelatedEsAssoc` already mounts both the CA and the client cert for all fleet-mode agents.
- Changed `getVolumesFromAssociations` to accept a `fleetModeEnabled bool` parameter (driven by `spec.FleetModeEnabled()`) so it skips Elasticsearch associations for both fleet-server and fleet-managed agents, preventing duplicate mounts in both cases.
- Fixed `populateFleetServerESConfig` to point `FLEET_SERVER_ES_CERT` and `FLEET_SERVER_ES_CERT_KEY` at `FleetManagedAgentClientCertDir`, matching the path `applyRelatedEsAssoc` actually mounts the client certificate at.
- Simplified `cleanupEnvVarsSecret` to use the shared `k8s.DeleteSecretIfExists` helper.
- Fixed pre-existing `Test_getVolumesFromAssociations` cases that assigned `AssociationConf` by slice index in an order inconsistent with `GetAssociations()` (which returns `[ElasticsearchRefs..., KibanaRef, FleetServerRef]`), causing the wrong secret names to be attached to the wrong association types.
- Corrected pre-existing test expectations for fleet-managed agents with Elasticsearch refs to reflect that `applyRelatedEsAssoc` handles ES cert mounting in all fleet-mode scenarios, not only for fleet-server agents.
