### PR TITLE
Restrict fleet-server CA secret copy to ca.crt only

### DIFF
--- a/pkg/controller/association/controller/agent_fleetserver.go
+++ b/pkg/controller/association/controller/agent_fleetserver.go
@@ -20,6 +20,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/agent"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/association"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/annotation"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/hash"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/metadata"
@@ -62,7 +63,7 @@ func AddAgentFleetServer(mgr manager.Manager, accessReviewer rbac.AccessReviewer
 // additionalSecrets returns secrets from the Fleet Server's Elasticsearch association that
 // need to be copied into the fleet-managed agent's namespace: the CA secret (when present)
 // and the client certificate secret (when the user has provided one on the Fleet Server's ES ref).
-func additionalSecrets(ctx context.Context, c k8s.Client, assoc commonv1.Association) ([]types.NamespacedName, error) {
+func additionalSecrets(ctx context.Context, c k8s.Client, assoc commonv1.Association) ([]association.AdditionalSecret, error) {
 	log := ulog.FromContext(ctx)
 	associated := assoc.Associated()
 	var agent agentv1alpha1.Agent
@@ -100,19 +101,29 @@ func additionalSecrets(ctx context.Context, c k8s.Client, assoc commonv1.Associa
 		return nil, nil
 	}
 
-	secrets := make([]types.NamespacedName, 0, 2)
+	secrets := make([]association.AdditionalSecret, 0, 2)
 	if conf.CACertProvided {
 		log.V(1).Info("additional secret because CA provided")
-		secrets = append(secrets, types.NamespacedName{
-			Namespace: fleetServer.Namespace,
-			Name:      conf.CASecretName,
+		// Always restrict the copy to ca.crt. For external ES references, CASecretName ==
+		// AuthSecretName, so the source secret also contains url/username/password — filtering
+		// to ca.crt prevents credential leakage. For managed refs the CA secret also contains
+		// tls.crt; agents only need ca.crt for TLS verification, so the narrower copy is correct
+		// in both cases.
+		secrets = append(secrets, association.AdditionalSecret{
+			SourceNamespacedName: types.NamespacedName{
+				Namespace: fleetServer.Namespace,
+				Name:      conf.CASecretName,
+			},
+			Keys: []string{certificates.CAFileName},
 		})
 	}
 	if conf.ClientCertIsConfigured() && esRef.GetClientCertificateSecretName() != "" {
 		log.V(1).Info("additional secret because user client certificate is provided")
-		secrets = append(secrets, types.NamespacedName{
-			Namespace: fleetServer.Namespace,
-			Name:      conf.GetClientCertSecretName(),
+		secrets = append(secrets, association.AdditionalSecret{
+			SourceNamespacedName: types.NamespacedName{
+				Namespace: fleetServer.Namespace,
+				Name:      conf.GetClientCertSecretName(),
+			},
 		})
 	}
 	return secrets, nil

--- a/pkg/controller/association/controller/agent_fleetserver.go
+++ b/pkg/controller/association/controller/agent_fleetserver.go
@@ -110,7 +110,7 @@ func additionalSecrets(ctx context.Context, c k8s.Client, assoc commonv1.Associa
 		// tls.crt; agents only need ca.crt for TLS verification, so the narrower copy is correct
 		// in both cases.
 		secrets = append(secrets, association.AdditionalSecret{
-			SourceNamespacedName: types.NamespacedName{
+			Source: types.NamespacedName{
 				Namespace: fleetServer.Namespace,
 				Name:      conf.CASecretName,
 			},
@@ -120,7 +120,7 @@ func additionalSecrets(ctx context.Context, c k8s.Client, assoc commonv1.Associa
 	if conf.ClientCertIsConfigured() && esRef.GetClientCertificateSecretName() != "" {
 		log.V(1).Info("additional secret because user client certificate is provided")
 		secrets = append(secrets, association.AdditionalSecret{
-			SourceNamespacedName: types.NamespacedName{
+			Source: types.NamespacedName{
 				Namespace: fleetServer.Namespace,
 				Name:      conf.GetClientCertSecretName(),
 			},

--- a/pkg/controller/association/controller/agent_fleetserver_test.go
+++ b/pkg/controller/association/controller/agent_fleetserver_test.go
@@ -153,7 +153,7 @@ func TestAdditionalSecrets(t *testing.T) {
 				},
 			},
 			wantSecrets: []association.AdditionalSecret{
-				{SourceNamespacedName: types.NamespacedName{Namespace: "fs-ns", Name: "fleet1-es-ca"}, Keys: []string{"ca.crt"}},
+				{Source: types.NamespacedName{Namespace: "fs-ns", Name: "fleet1-es-ca"}, Keys: []string{"ca.crt"}},
 			},
 		},
 		{
@@ -190,8 +190,8 @@ func TestAdditionalSecrets(t *testing.T) {
 				},
 			},
 			wantSecrets: []association.AdditionalSecret{
-				{SourceNamespacedName: types.NamespacedName{Namespace: "fs-ns", Name: "fleet1-es-ca"}, Keys: []string{"ca.crt"}},
-				{SourceNamespacedName: types.NamespacedName{Namespace: "fs-ns", Name: "copied-user-cert"}},
+				{Source: types.NamespacedName{Namespace: "fs-ns", Name: "fleet1-es-ca"}, Keys: []string{"ca.crt"}},
+				{Source: types.NamespacedName{Namespace: "fs-ns", Name: "copied-user-cert"}},
 			},
 		},
 		{
@@ -225,7 +225,7 @@ func TestAdditionalSecrets(t *testing.T) {
 				},
 			},
 			wantSecrets: []association.AdditionalSecret{
-				{SourceNamespacedName: types.NamespacedName{Namespace: "fs-ns", Name: "fleet1-es-ca"}, Keys: []string{"ca.crt"}},
+				{Source: types.NamespacedName{Namespace: "fs-ns", Name: "fleet1-es-ca"}, Keys: []string{"ca.crt"}},
 			},
 		},
 	} {

--- a/pkg/controller/association/controller/agent_fleetserver_test.go
+++ b/pkg/controller/association/controller/agent_fleetserver_test.go
@@ -18,6 +18,7 @@ import (
 	agentv1alpha1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/agent/v1alpha1"
 	commonv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/association"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/annotation"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/hash"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/labels"
@@ -93,7 +94,7 @@ func TestAdditionalSecrets(t *testing.T) {
 		agent       *agentv1alpha1.Agent
 		fleetServer *agentv1alpha1.Agent
 		assoc       commonv1.Association
-		wantSecrets []types.NamespacedName
+		wantSecrets []association.AdditionalSecret
 		wantErr     bool
 	}{
 		{
@@ -151,8 +152,8 @@ func TestAdditionalSecrets(t *testing.T) {
 					},
 				},
 			},
-			wantSecrets: []types.NamespacedName{
-				{Namespace: "fs-ns", Name: "fleet1-es-ca"},
+			wantSecrets: []association.AdditionalSecret{
+				{SourceNamespacedName: types.NamespacedName{Namespace: "fs-ns", Name: "fleet1-es-ca"}, Keys: []string{"ca.crt"}},
 			},
 		},
 		{
@@ -188,9 +189,9 @@ func TestAdditionalSecrets(t *testing.T) {
 					},
 				},
 			},
-			wantSecrets: []types.NamespacedName{
-				{Namespace: "fs-ns", Name: "fleet1-es-ca"},
-				{Namespace: "fs-ns", Name: "copied-user-cert"},
+			wantSecrets: []association.AdditionalSecret{
+				{SourceNamespacedName: types.NamespacedName{Namespace: "fs-ns", Name: "fleet1-es-ca"}, Keys: []string{"ca.crt"}},
+				{SourceNamespacedName: types.NamespacedName{Namespace: "fs-ns", Name: "copied-user-cert"}},
 			},
 		},
 		{
@@ -223,8 +224,8 @@ func TestAdditionalSecrets(t *testing.T) {
 					},
 				},
 			},
-			wantSecrets: []types.NamespacedName{
-				{Namespace: "fs-ns", Name: "fleet1-es-ca"},
+			wantSecrets: []association.AdditionalSecret{
+				{SourceNamespacedName: types.NamespacedName{Namespace: "fs-ns", Name: "fleet1-es-ca"}, Keys: []string{"ca.crt"}},
 			},
 		},
 	} {

--- a/pkg/controller/association/dynamic_watches.go
+++ b/pkg/controller/association/dynamic_watches.go
@@ -124,16 +124,13 @@ func (r *Reconciler) reconcileWatches(ctx context.Context, associated types.Name
 				if err != nil {
 					return nil, err
 				}
-				// Watch the source secrets
+				// Watch both the source secret and the copy in the association namespace
+				// so that changes on either side trigger reconciliation.
 				for _, sec := range secs {
-					toWatch = append(toWatch, sec.Source)
-				}
-				// Also watch the target secrets
-				for _, sec := range secs {
-					toWatch = append(toWatch, types.NamespacedName{
-						Name:      sec.Source.Name,
-						Namespace: association.GetNamespace(),
-					})
+					toWatch = append(toWatch,
+						sec.Source,
+						types.NamespacedName{Name: sec.Source.Name, Namespace: association.GetNamespace()},
+					)
 				}
 			}
 			return toWatch, nil

--- a/pkg/controller/association/dynamic_watches.go
+++ b/pkg/controller/association/dynamic_watches.go
@@ -125,11 +125,13 @@ func (r *Reconciler) reconcileWatches(ctx context.Context, associated types.Name
 					return nil, err
 				}
 				// Watch the source secrets
-				toWatch = append(toWatch, secs...)
+				for _, sec := range secs {
+					toWatch = append(toWatch, sec.SourceNamespacedName)
+				}
 				// Also watch the target secrets
 				for _, sec := range secs {
 					toWatch = append(toWatch, types.NamespacedName{
-						Name:      sec.Name,
+						Name:      sec.SourceNamespacedName.Name,
 						Namespace: association.GetNamespace(),
 					})
 				}

--- a/pkg/controller/association/dynamic_watches.go
+++ b/pkg/controller/association/dynamic_watches.go
@@ -126,12 +126,12 @@ func (r *Reconciler) reconcileWatches(ctx context.Context, associated types.Name
 				}
 				// Watch the source secrets
 				for _, sec := range secs {
-					toWatch = append(toWatch, sec.SourceNamespacedName)
+					toWatch = append(toWatch, sec.Source)
 				}
 				// Also watch the target secrets
 				for _, sec := range secs {
 					toWatch = append(toWatch, types.NamespacedName{
-						Name:      sec.SourceNamespacedName.Name,
+						Name:      sec.Source.Name,
 						Namespace: association.GetNamespace(),
 					})
 				}

--- a/pkg/controller/association/reconciler.go
+++ b/pkg/controller/association/reconciler.go
@@ -42,6 +42,14 @@ import (
 
 var defaultRequeue = reconcile.Result{RequeueAfter: reconciler.DefaultRequeue}
 
+// AdditionalSecret is a secret to be copied into an associated resource's namespace.
+type AdditionalSecret struct {
+	// SourceNamespacedName is the namespace/name of the secret to copy from (in the referenced resource's namespace).
+	SourceNamespacedName types.NamespacedName
+	// Keys is an optional list of data keys to include in the copy; all keys are copied when empty.
+	Keys []string
+}
+
 // AssociationInfo contains information specific to a particular associated resource (eg. Kibana, APMServer, etc.).
 type AssociationInfo struct { //nolint:revive
 	// AssociationType identifies the type of the resource for association (eg. kibana for APM to Kibana association,
@@ -66,8 +74,8 @@ type AssociationInfo struct { //nolint:revive
 
 	// AdditionalSecrets are additional secrets to copy from an association's namespace to the associated resource namespace.
 	// Currently this is only used for copying the CA from an Elasticsearch association to the same namespace as
-	// an Agent referencing a Fleet Server.
-	AdditionalSecrets func(context.Context, k8s.Client, commonv1.Association) ([]types.NamespacedName, error)
+	// an Agent referencing a Fleet Server. See AdditionalSecret.Keys for per-secret key filtering.
+	AdditionalSecrets func(context.Context, k8s.Client, commonv1.Association) ([]AdditionalSecret, error)
 	// Labels are labels set on all resources created for association purpose. Note that some resources will be also
 	// labelled with AssociationResourceNameLabelName and AssociationResourceNamespaceLabelName in addition to any
 	// labels provided here.
@@ -297,7 +305,7 @@ func (r *Reconciler) reconcileAssociation(ctx context.Context, association commo
 			return commonv1.AssociationPending, results.WithError(err) // maybe not created yet
 		}
 		for _, sec := range additionalSecrets {
-			if err := copySecret(ctx, r.Client, secretsHash, association.GetNamespace(), sec); err != nil {
+			if err := copySecret(ctx, r.Client, secretsHash, association.GetNamespace(), sec.SourceNamespacedName, sec.Keys); err != nil {
 				return commonv1.AssociationPending, results.WithError(err)
 			}
 		}

--- a/pkg/controller/association/reconciler.go
+++ b/pkg/controller/association/reconciler.go
@@ -44,8 +44,8 @@ var defaultRequeue = reconcile.Result{RequeueAfter: reconciler.DefaultRequeue}
 
 // AdditionalSecret is a secret to be copied into an associated resource's namespace.
 type AdditionalSecret struct {
-	// SourceNamespacedName is the namespace/name of the secret to copy from (in the referenced resource's namespace).
-	SourceNamespacedName types.NamespacedName
+	// Source is the namespace/name of the secret to copy from (in the referenced resource's namespace).
+	Source types.NamespacedName
 	// Keys is an optional list of data keys to include in the copy; all keys are copied when empty.
 	Keys []string
 }
@@ -305,7 +305,7 @@ func (r *Reconciler) reconcileAssociation(ctx context.Context, association commo
 			return commonv1.AssociationPending, results.WithError(err) // maybe not created yet
 		}
 		for _, sec := range additionalSecrets {
-			if err := copySecret(ctx, r.Client, secretsHash, association.GetNamespace(), sec.SourceNamespacedName, sec.Keys); err != nil {
+			if err := copySecret(ctx, r.Client, secretsHash, association.GetNamespace(), sec.Source, sec.Keys); err != nil {
 				return commonv1.AssociationPending, results.WithError(err)
 			}
 		}

--- a/pkg/controller/association/reconciler_test.go
+++ b/pkg/controller/association/reconciler_test.go
@@ -1175,7 +1175,7 @@ func TestReconciler_Reconcile_Transitive_Associations(t *testing.T) {
 				return nil, nil
 			}
 			return []AdditionalSecret{{
-				SourceNamespacedName: types.NamespacedName{
+				Source: types.NamespacedName{
 					Namespace: fleetServer.Namespace,
 					Name:      conf.CASecretName,
 				},

--- a/pkg/controller/association/reconciler_test.go
+++ b/pkg/controller/association/reconciler_test.go
@@ -1141,7 +1141,7 @@ func TestReconciler_Reconcile_Transitive_Associations(t *testing.T) {
 		AssociationResourceNameLabelName:      "agent.k8s.elastic.co/name",
 		AssociationResourceNamespaceLabelName: "agent.k8s.elastic.co/namespace",
 		ElasticsearchUserCreation:             nil,
-		AdditionalSecrets: func(ctx context.Context, c k8s.Client, assoc commonv1.Association) ([]types.NamespacedName, error) {
+		AdditionalSecrets: func(ctx context.Context, c k8s.Client, assoc commonv1.Association) ([]AdditionalSecret, error) {
 			associated := assoc.Associated()
 			var agent agentv1alpha1.Agent
 			nsn := types.NamespacedName{Namespace: associated.GetNamespace(), Name: associated.GetName()}
@@ -1174,9 +1174,12 @@ func TestReconciler_Reconcile_Transitive_Associations(t *testing.T) {
 			if conf == nil || !conf.CACertProvided {
 				return nil, nil
 			}
-			return []types.NamespacedName{{
-				Namespace: fleetServer.Namespace,
-				Name:      conf.CASecretName,
+			return []AdditionalSecret{{
+				SourceNamespacedName: types.NamespacedName{
+					Namespace: fleetServer.Namespace,
+					Name:      conf.CASecretName,
+				},
+				Keys: []string{"ca.crt"},
 			}}, nil
 		},
 	}
@@ -1346,7 +1349,7 @@ func TestReconciler_Reconcile_Transitive_Associations(t *testing.T) {
 			false,
 			false,
 			true,
-			"ca.crt", "tls.crt",
+			"ca.crt",
 		),
 	}
 

--- a/pkg/controller/association/secret.go
+++ b/pkg/controller/association/secret.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash"
-	"maps"
 	"net/http"
 
 	corev1 "k8s.io/api/core/v1"
@@ -255,23 +254,20 @@ func copySecret(ctx context.Context, client k8s.Client, secHash hash.Hash, targe
 		return nil
 	}
 
-	// kubectl.kubernetes.io/last-applied-configuration embeds the full original Secret
-	// manifest as base64, which would re-expose any credential fields that were filtered
-	// out of Data. Drop it from the copy unconditionally.
-	annotations := maps.Clone(original.Annotations)
-	delete(annotations, corev1.LastAppliedConfigAnnotation)
-
 	expected := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        original.Name,
 			Namespace:   targetNamespace,
 			Labels:      original.Labels,
-			Annotations: annotations,
+			Annotations: original.Annotations,
 		},
 		Data: data,
 		Type: original.Type,
 	}
 
-	_, err := reconciler.ReconcileSecret(ctx, client, expected, nil)
+	// kubectl.kubernetes.io/last-applied-configuration embeds the full original Secret
+	// manifest as base64, which would re-expose any credential fields that were filtered
+	// out of Data. Always drop it unconditionally.
+	_, err := reconciler.ReconcileSecret(ctx, client, expected, nil, reconciler.WithAnnotationsToRemove(corev1.LastAppliedConfigAnnotation))
 	return err
 }

--- a/pkg/controller/association/secret.go
+++ b/pkg/controller/association/secret.go
@@ -24,6 +24,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/client"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
+	ulog "github.com/elastic/cloud-on-k8s/v3/pkg/utils/log"
 )
 
 const (
@@ -240,6 +241,8 @@ func copySecret(ctx context.Context, client k8s.Client, secHash hash.Hash, targe
 		for _, k := range keys {
 			if v, ok := original.Data[k]; ok {
 				data[k] = v
+			} else {
+				ulog.FromContext(ctx).V(1).Info("requested key not found in source secret", "key", k, "secret_name", source.Name, "secret_namespace", source.Namespace)
 			}
 		}
 	}

--- a/pkg/controller/association/secret.go
+++ b/pkg/controller/association/secret.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash"
+	"maps"
 	"net/http"
 
 	corev1 "k8s.io/api/core/v1"
@@ -223,28 +224,48 @@ func filterManagedElasticRef(associations []commonv1.Association) []commonv1.Ass
 	return r
 }
 
-// copySecret will copy the source secret to the target namespace adding labels from the associated object to ensure garbage collection happens.
-func copySecret(ctx context.Context, client k8s.Client, secHash hash.Hash, targetNamespace string, source types.NamespacedName) error {
+// copySecret hashes the source secret data (restricted to keys when non-empty) and, when
+// targetNamespace differs from the source namespace, reconciles a copy of the secret there.
+// The hash is always written so that AdditionalSecretsHash reflects CA cert changes even
+// when source and target share a namespace.
+func copySecret(ctx context.Context, client k8s.Client, secHash hash.Hash, targetNamespace string, source types.NamespacedName, keys []string) error {
 	var original corev1.Secret
 	if err := client.Get(ctx, source, &original); err != nil {
 		return err
 	}
-	// update the hash if there are additional secrets event if
-	// they are in the same namespace to ensure that the pods are
-	// rotated when the original CA secret is updated.
-	commonhash.WriteHashObject(secHash, original.Data)
+
+	data := original.Data
+	if len(keys) > 0 {
+		data = make(map[string][]byte, len(keys))
+		for _, k := range keys {
+			if v, ok := original.Data[k]; ok {
+				data[k] = v
+			}
+		}
+	}
+
+	// Hash only the data that will be copied. Hashing original.Data when keys is set
+	// would cause AdditionalSecretsHash to change on credential rotations even though
+	// the CA cert (the only field that actually reaches pods) has not changed.
+	commonhash.WriteHashObject(secHash, data)
 	if targetNamespace == original.Namespace {
 		return nil
 	}
+
+	// kubectl.kubernetes.io/last-applied-configuration embeds the full original Secret
+	// manifest as base64, which would re-expose any credential fields that were filtered
+	// out of Data. Drop it from the copy unconditionally.
+	annotations := maps.Clone(original.Annotations)
+	delete(annotations, corev1.LastAppliedConfigAnnotation)
 
 	expected := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        original.Name,
 			Namespace:   targetNamespace,
 			Labels:      original.Labels,
-			Annotations: original.Annotations,
+			Annotations: annotations,
 		},
-		Data: original.Data,
+		Data: data,
 		Type: original.Type,
 	}
 

--- a/pkg/controller/association/secret_test.go
+++ b/pkg/controller/association/secret_test.go
@@ -231,6 +231,7 @@ func TestCopySecret(t *testing.T) {
 	for _, tt := range []struct {
 		name                string
 		srcSecret           *corev1.Secret
+		existingTarget      *corev1.Secret
 		keys                []string
 		wantKeys            []string
 		wantMissKeys        []string
@@ -244,6 +245,14 @@ func TestCopySecret(t *testing.T) {
 			srcSecret: externalESSecret,
 			keys:      nil,
 			wantKeys:  []string{"ca.crt", "url", "username", "password"},
+		},
+		{
+			name:                "no filter: last-applied-configuration stripped",
+			srcSecret:           secretWithLastApplied,
+			keys:                nil,
+			wantKeys:            []string{"ca.crt", "url", "username", "password"},
+			wantMissAnnotations: []string{corev1.LastAppliedConfigAnnotation},
+			wantAnnotations:     map[string]string{"other-annotation": "keep-me"},
 		},
 		{
 			name:         "ca.crt filter: only ca.crt copied, credentials absent",
@@ -264,7 +273,7 @@ func TestCopySecret(t *testing.T) {
 			wantHash:     &hashCAFilter,
 		},
 		{
-			name:         "absent key in filter is silently skipped",
+			name:         "absent key in filter is skipped with a debug log",
 			srcSecret:    externalESSecret,
 			keys:         []string{"ca.crt", "nonexistent-key"},
 			wantKeys:     []string{"ca.crt"},
@@ -280,9 +289,31 @@ func TestCopySecret(t *testing.T) {
 			wantMissAnnotations: []string{corev1.LastAppliedConfigAnnotation},
 			wantAnnotations:     map[string]string{"other-annotation": "keep-me"},
 		},
+		{
+			name:      "last-applied-configuration removed from pre-existing copy on upgrade",
+			srcSecret: externalESSecret,
+			existingTarget: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "dst-ns",
+					Name:      srcNSN.Name,
+					Annotations: map[string]string{
+						corev1.LastAppliedConfigAnnotation: `{"data":{"password":"czNjcjN0","username":"ZWxhc3RpYw=="}}`,
+					},
+				},
+				Data: map[string][]byte{"ca.crt": []byte("CACERT")},
+			},
+			keys:                []string{"ca.crt"},
+			wantKeys:            []string{"ca.crt"},
+			wantMissAnnotations: []string{corev1.LastAppliedConfigAnnotation},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			fakeClient := k8s.NewFakeClient(tt.srcSecret)
+			var fakeClient k8s.Client
+			if tt.existingTarget != nil {
+				fakeClient = k8s.NewFakeClient(tt.srcSecret, tt.existingTarget)
+			} else {
+				fakeClient = k8s.NewFakeClient(tt.srcSecret)
+			}
 			h := fnv.New32a()
 			require.NoError(t, copySecret(context.Background(), fakeClient, h, "dst-ns", srcNSN, tt.keys))
 

--- a/pkg/controller/association/secret_test.go
+++ b/pkg/controller/association/secret_test.go
@@ -5,10 +5,15 @@
 package association
 
 import (
+	"context"
+	"hash/fnv"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/common/v1"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
@@ -187,6 +192,120 @@ func TestGetUnmanagedAssociationConnexionInfoFromSecret(t *testing.T) {
 			}
 			if got != nil && *got != tt.want() {
 				t.Errorf("GetUnmanagedAssociationConnectionInfoFromSecret() got = %v, want %v", *got, tt.want())
+			}
+		})
+	}
+}
+
+func TestCopySecret(t *testing.T) {
+	srcNSN := types.NamespacedName{Namespace: "src-ns", Name: "external-es"}
+	externalESSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: srcNSN.Namespace, Name: srcNSN.Name},
+		Data: map[string][]byte{
+			"ca.crt":   []byte("CACERT"),
+			"url":      []byte("https://es.example.com:9200"),
+			"username": []byte("elastic"),
+			"password": []byte("s3cr3t"),
+		},
+	}
+
+	hashOf := func(t *testing.T, secret *corev1.Secret, keys []string) uint32 {
+		t.Helper()
+		h := fnv.New32a()
+		require.NoError(t, copySecret(context.Background(), k8s.NewFakeClient(secret), h, "dst-ns", srcNSN, keys))
+		return h.Sum32()
+	}
+
+	hashNoFilter := hashOf(t, externalESSecret, nil)
+	hashCAFilter := hashOf(t, externalESSecret, []string{"ca.crt"})
+
+	rotated := externalESSecret.DeepCopy()
+	rotated.Data["password"] = []byte("new-password")
+
+	secretWithLastApplied := externalESSecret.DeepCopy()
+	secretWithLastApplied.Annotations = map[string]string{
+		corev1.LastAppliedConfigAnnotation: `{"data":{"password":"czNjcjN0"}}`,
+		"other-annotation":                 "keep-me",
+	}
+
+	for _, tt := range []struct {
+		name                string
+		srcSecret           *corev1.Secret
+		keys                []string
+		wantKeys            []string
+		wantMissKeys        []string
+		wantMissAnnotations []string
+		wantAnnotations     map[string]string
+		wantHash            *uint32
+		wantHashNot         *uint32
+	}{
+		{
+			name:      "no filter: all keys copied",
+			srcSecret: externalESSecret,
+			keys:      nil,
+			wantKeys:  []string{"ca.crt", "url", "username", "password"},
+		},
+		{
+			name:         "ca.crt filter: only ca.crt copied, credentials absent",
+			srcSecret:    externalESSecret,
+			keys:         []string{"ca.crt"},
+			wantKeys:     []string{"ca.crt"},
+			wantMissKeys: []string{"url", "username", "password"},
+			wantHashNot:  &hashNoFilter,
+		},
+		{
+			// Password rotation must not change the hash when only ca.crt is filtered in,
+			// so that credential rotations don't trigger unnecessary fleet-agent pod restarts.
+			name:         "password rotation does not change hash when ca.crt filter is active",
+			srcSecret:    rotated,
+			keys:         []string{"ca.crt"},
+			wantKeys:     []string{"ca.crt"},
+			wantMissKeys: []string{"url", "username", "password"},
+			wantHash:     &hashCAFilter,
+		},
+		{
+			name:         "absent key in filter is silently skipped",
+			srcSecret:    externalESSecret,
+			keys:         []string{"ca.crt", "nonexistent-key"},
+			wantKeys:     []string{"ca.crt"},
+			wantMissKeys: []string{"nonexistent-key", "url", "username", "password"},
+		},
+		{
+			// kubectl.kubernetes.io/last-applied-configuration embeds the full original
+			// Secret manifest as base64; it must not appear in the cross-namespace copy.
+			name:                "last-applied-configuration annotation stripped, other annotations kept",
+			srcSecret:           secretWithLastApplied,
+			keys:                []string{"ca.crt"},
+			wantKeys:            []string{"ca.crt"},
+			wantMissAnnotations: []string{corev1.LastAppliedConfigAnnotation},
+			wantAnnotations:     map[string]string{"other-annotation": "keep-me"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := k8s.NewFakeClient(tt.srcSecret)
+			h := fnv.New32a()
+			require.NoError(t, copySecret(context.Background(), fakeClient, h, "dst-ns", srcNSN, tt.keys))
+
+			var copied corev1.Secret
+			require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "dst-ns", Name: srcNSN.Name}, &copied))
+
+			for _, key := range tt.wantKeys {
+				assert.Contains(t, copied.Data, key, "expected key %q in copied secret", key)
+			}
+			for _, key := range tt.wantMissKeys {
+				assert.NotContains(t, copied.Data, key, "credential key %q must not appear in copied secret", key)
+			}
+			for _, ann := range tt.wantMissAnnotations {
+				assert.NotContains(t, copied.Annotations, ann, "annotation %q must not appear in copied secret", ann)
+			}
+			for k, v := range tt.wantAnnotations {
+				assert.Equal(t, v, copied.Annotations[k], "annotation %q must be preserved in copied secret", k)
+			}
+			if tt.wantHash != nil {
+				assert.Equal(t, *tt.wantHash, h.Sum32())
+			}
+			if tt.wantHashNot != nil {
+				assert.NotEqual(t, *tt.wantHashNot, h.Sum32())
 			}
 		})
 	}

--- a/pkg/controller/common/reconciler/secret.go
+++ b/pkg/controller/common/reconciler/secret.go
@@ -45,7 +45,10 @@ func WithPostUpdate(f func()) func(p *Params) {
 // keys from both newly created and pre-existing secrets:
 //   - PreCreate strips the keys from expected.Annotations before the object is written, so a
 //     brand-new secret never contains them even when the source carries them.
-//   - NeedsUpdate triggers an update when any listed key is present on an already-existing secret.
+//   - NeedsUpdate strips the keys from expected.Annotations before any update check so that
+//     their presence in the source does not cause update churn (the base check treats a key
+//     present in expected but absent from reconciled as a diff). It also triggers an update when
+//     any listed key is found on an already-existing secret.
 //   - UpdateReconciled deletes the keys from the reconciled object after the annotation merge, so
 //     that pre-existing copies (created before this safeguard) are cleaned up on the next
 //     reconciliation. Simply omitting a key from expected.Annotations is insufficient because
@@ -61,7 +64,6 @@ func WithAnnotationsToRemove(keys ...string) func(p *Params) {
 					return err
 				}
 			}
-
 			expectedAnnotations := p.Expected.GetAnnotations()
 			for _, k := range keys {
 				delete(expectedAnnotations, k)
@@ -70,6 +72,11 @@ func WithAnnotationsToRemove(keys ...string) func(p *Params) {
 			return nil
 		}
 		p.NeedsUpdate = func() bool {
+			expectedAnnotations := p.Expected.GetAnnotations()
+			for _, k := range keys {
+				delete(expectedAnnotations, k)
+			}
+			p.Expected.SetAnnotations(expectedAnnotations)
 			if prevNeedsUpdate != nil && prevNeedsUpdate() {
 				return true
 			}

--- a/pkg/controller/common/reconciler/secret.go
+++ b/pkg/controller/common/reconciler/secret.go
@@ -41,6 +41,59 @@ func WithPostUpdate(f func()) func(p *Params) {
 	}
 }
 
+// WithAnnotationsToRemove returns a ReconcileSecret option that actively removes the listed annotation
+// keys from both newly created and pre-existing secrets:
+//   - PreCreate strips the keys from expected.Annotations before the object is written, so a
+//     brand-new secret never contains them even when the source carries them.
+//   - NeedsUpdate triggers an update when any listed key is present on an already-existing secret.
+//   - UpdateReconciled deletes the keys from the reconciled object after the annotation merge, so
+//     that pre-existing copies (created before this safeguard) are cleaned up on the next
+//     reconciliation. Simply omitting a key from expected.Annotations is insufficient because
+//     ReconcileSecret merges rather than replaces existing annotations.
+func WithAnnotationsToRemove(keys ...string) func(p *Params) {
+	return func(p *Params) {
+		prevNeedsUpdate := p.NeedsUpdate
+		prevUpdateReconciled := p.UpdateReconciled
+		prevPreCreate := p.PreCreate
+		p.PreCreate = func() error {
+			if prevPreCreate != nil {
+				if err := prevPreCreate(); err != nil {
+					return err
+				}
+			}
+
+			expectedAnnotations := p.Expected.GetAnnotations()
+			for _, k := range keys {
+				delete(expectedAnnotations, k)
+			}
+			p.Expected.SetAnnotations(expectedAnnotations)
+			return nil
+		}
+		p.NeedsUpdate = func() bool {
+			if prevNeedsUpdate != nil && prevNeedsUpdate() {
+				return true
+			}
+			annotations := p.Reconciled.GetAnnotations()
+			for _, k := range keys {
+				if _, found := annotations[k]; found {
+					return true
+				}
+			}
+			return false
+		}
+		p.UpdateReconciled = func() {
+			if prevUpdateReconciled != nil {
+				prevUpdateReconciled()
+			}
+			annotations := p.Reconciled.GetAnnotations()
+			for _, k := range keys {
+				delete(annotations, k)
+			}
+			p.Reconciled.SetAnnotations(annotations)
+		}
+	}
+}
+
 // ReconcileSecret creates or updates the actual secret to match the expected one.
 // Existing annotations or labels that are not expected are preserved.
 func ReconcileSecret(ctx context.Context, c k8s.Client, expected corev1.Secret, owner client.Object, opts ...func(*Params)) (corev1.Secret, error) {

--- a/pkg/controller/common/reconciler/secret_test.go
+++ b/pkg/controller/common/reconciler/secret_test.go
@@ -139,11 +139,11 @@ func TestReconcileSecret(t *testing.T) {
 
 func TestWithAnnotationsToRemove(t *testing.T) {
 	for _, tt := range []struct {
-		name            string
-		existing        *corev1.Secret
-		expected        *corev1.Secret
-		keysToRemove    []string
-		wantAnnotations map[string]string
+		name             string
+		existing         *corev1.Secret
+		expected         *corev1.Secret
+		keysToRemove     []string
+		wantAnnotations  map[string]string
 		wantUpdateCalled bool
 	}{
 		{
@@ -160,10 +160,22 @@ func TestWithAnnotationsToRemove(t *testing.T) {
 			wantUpdateCalled: true,
 		},
 		{
-			// The pre-existing secret already has the RestrictWatchedResources label that
-			// ReconcileSecret always adds, so the only reason an update could fire is the
-			// WithAnnotationsToRemove NeedsUpdate check. Since "to-remove" is absent from
-			// the existing secret's annotations, no update should be triggered.
+			name: "no spurious update when annotation is in expected but already absent from reconciled",
+			existing: createSecret("s", sampleData,
+				map[string]string{commonv1.RestrictWatchedResourcesLabelName: commonv1.RestrictWatchedResourcesLabelValue},
+				map[string]string{"keep": "keep-me"},
+			),
+			expected: createSecret("s", sampleData, nil, map[string]string{
+				"to-remove": "leaked-value",
+				"keep":      "keep-me",
+			}),
+			keysToRemove: []string{"to-remove"},
+			wantAnnotations: map[string]string{
+				"keep": "keep-me",
+			},
+			wantUpdateCalled: false,
+		},
+		{
 			name: "no spurious update when annotation is absent from pre-existing secret",
 			existing: createSecret("s", sampleData,
 				map[string]string{commonv1.RestrictWatchedResourcesLabelName: commonv1.RestrictWatchedResourcesLabelValue},
@@ -196,11 +208,11 @@ func TestWithAnnotationsToRemove(t *testing.T) {
 			},
 		},
 		{
-			name:            "multiple keys removed in one call",
-			existing:        createSecret("s", sampleData, nil, map[string]string{"a": "1", "b": "2", "c": "3"}),
-			expected:        createSecret("s", sampleData, nil, nil),
-			keysToRemove:    []string{"a", "b"},
-			wantAnnotations: map[string]string{"c": "3"},
+			name:             "multiple keys removed in one call",
+			existing:         createSecret("s", sampleData, nil, map[string]string{"a": "1", "b": "2", "c": "3"}),
+			expected:         createSecret("s", sampleData, nil, nil),
+			keysToRemove:     []string{"a", "b"},
+			wantAnnotations:  map[string]string{"c": "3"},
 			wantUpdateCalled: true,
 		},
 	} {

--- a/pkg/controller/common/reconciler/secret_test.go
+++ b/pkg/controller/common/reconciler/secret_test.go
@@ -136,6 +136,81 @@ func TestReconcileSecret(t *testing.T) {
 	}
 }
 
+func TestWithAnnotationsToRemove(t *testing.T) {
+	for _, tt := range []struct {
+		name            string
+		existing        *corev1.Secret
+		expected        *corev1.Secret
+		keysToRemove    []string
+		wantAnnotations map[string]string
+	}{
+		{
+			name: "annotation removed from pre-existing secret",
+			existing: createSecret("s", sampleData, nil, map[string]string{
+				"to-remove": "leaked-value",
+				"keep":      "keep-me",
+			}),
+			expected:     createSecret("s", sampleData, nil, nil),
+			keysToRemove: []string{"to-remove"},
+			wantAnnotations: map[string]string{
+				"keep": "keep-me",
+			},
+		},
+		{
+			name: "no spurious update when annotation is absent from pre-existing secret",
+			existing: createSecret("s", sampleData, nil, map[string]string{
+				"keep": "keep-me",
+			}),
+			expected:     createSecret("s", sampleData, nil, nil),
+			keysToRemove: []string{"to-remove"},
+			wantAnnotations: map[string]string{
+				"keep": "keep-me",
+			},
+		},
+		{
+			name:            "new secret created without the listed annotation",
+			existing:        nil,
+			expected:        createSecret("s", sampleData, nil, nil),
+			keysToRemove:    []string{"to-remove"},
+			wantAnnotations: nil,
+		},
+		{
+			name:     "annotation stripped from expected before create",
+			existing: nil,
+			expected: createSecret("s", sampleData, nil, map[string]string{
+				"to-remove": "leaked-value",
+				"keep":      "keep-me",
+			}),
+			keysToRemove: []string{"to-remove"},
+			wantAnnotations: map[string]string{
+				"keep": "keep-me",
+			},
+		},
+		{
+			name:            "multiple keys removed in one call",
+			existing:        createSecret("s", sampleData, nil, map[string]string{"a": "1", "b": "2", "c": "3"}),
+			expected:        createSecret("s", sampleData, nil, nil),
+			keysToRemove:    []string{"a", "b"},
+			wantAnnotations: map[string]string{"c": "3"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var c k8s.Client
+			if tt.existing != nil {
+				c = k8s.NewFakeClient(tt.existing)
+			} else {
+				c = k8s.NewFakeClient()
+			}
+			_, err := ReconcileSecret(t.Context(), c, *tt.expected, nil, WithAnnotationsToRemove(tt.keysToRemove...))
+			require.NoError(t, err)
+
+			var got corev1.Secret
+			require.NoError(t, c.Get(t.Context(), k8s.ExtractNamespacedName(tt.expected), &got))
+			assert.Equal(t, tt.wantAnnotations, got.Annotations)
+		})
+	}
+}
+
 func concatMaps(m1 map[string]string, m2 map[string]string) map[string]string {
 	newMap := map[string]string{}
 	maps.Merge(newMap, m1)

--- a/pkg/controller/common/reconciler/secret_test.go
+++ b/pkg/controller/common/reconciler/secret_test.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/common/v1"
@@ -143,6 +144,7 @@ func TestWithAnnotationsToRemove(t *testing.T) {
 		expected        *corev1.Secret
 		keysToRemove    []string
 		wantAnnotations map[string]string
+		wantUpdateCalled bool
 	}{
 		{
 			name: "annotation removed from pre-existing secret",
@@ -155,17 +157,24 @@ func TestWithAnnotationsToRemove(t *testing.T) {
 			wantAnnotations: map[string]string{
 				"keep": "keep-me",
 			},
+			wantUpdateCalled: true,
 		},
 		{
+			// The pre-existing secret already has the RestrictWatchedResources label that
+			// ReconcileSecret always adds, so the only reason an update could fire is the
+			// WithAnnotationsToRemove NeedsUpdate check. Since "to-remove" is absent from
+			// the existing secret's annotations, no update should be triggered.
 			name: "no spurious update when annotation is absent from pre-existing secret",
-			existing: createSecret("s", sampleData, nil, map[string]string{
-				"keep": "keep-me",
-			}),
+			existing: createSecret("s", sampleData,
+				map[string]string{commonv1.RestrictWatchedResourcesLabelName: commonv1.RestrictWatchedResourcesLabelValue},
+				map[string]string{"keep": "keep-me"},
+			),
 			expected:     createSecret("s", sampleData, nil, nil),
 			keysToRemove: []string{"to-remove"},
 			wantAnnotations: map[string]string{
 				"keep": "keep-me",
 			},
+			wantUpdateCalled: false,
 		},
 		{
 			name:            "new secret created without the listed annotation",
@@ -192,21 +201,28 @@ func TestWithAnnotationsToRemove(t *testing.T) {
 			expected:        createSecret("s", sampleData, nil, nil),
 			keysToRemove:    []string{"a", "b"},
 			wantAnnotations: map[string]string{"c": "3"},
+			wantUpdateCalled: true,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			var c k8s.Client
+			updateCalled := 0
+			builder := k8s.NewFakeClientBuilder()
 			if tt.existing != nil {
-				c = k8s.NewFakeClient(tt.existing)
-			} else {
-				c = k8s.NewFakeClient()
+				builder = k8s.NewFakeClientBuilder(tt.existing)
 			}
+			c := builder.WithInterceptorFuncs(interceptor.Funcs{
+				Update: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+					updateCalled++
+					return cl.Update(ctx, obj, opts...)
+				},
+			}).Build()
 			_, err := ReconcileSecret(t.Context(), c, *tt.expected, nil, WithAnnotationsToRemove(tt.keysToRemove...))
 			require.NoError(t, err)
 
 			var got corev1.Secret
 			require.NoError(t, c.Get(t.Context(), k8s.ExtractNamespacedName(tt.expected), &got))
 			assert.Equal(t, tt.wantAnnotations, got.Annotations)
+			assert.Equal(t, tt.wantUpdateCalled, updateCalled > 0, "unexpected Update call count: %d", updateCalled)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

When a fleet-managed Agent references a Fleet Server whose Elasticsearch is configured via a user-provided secret (an external reference), the operator sets both `CASecretName` and `AuthSecretName` in the association conf to the same user-provided secret. That secret contains not just `ca.crt` but also `url`, `username`, and `password`.

The `additionalSecrets` function in the Agent-FleetServer association controller copies the `CASecretName` secret into the fleet-managed agent's namespace so the agent can verify TLS against Elasticsearch. Because no key filtering was applied, the full secret was copied, leaking Elasticsearch credentials into the agent's namespace.

This PR restricts the cross-namespace copy to `ca.crt` only. Fleet-managed agents need the CA certificate for TLS verification and have no direct connection to Elasticsearch, so they have no legitimate need for the other fields in the source secret.

Fixes #9684.

## Changes

- Added an `AdditionalSecret` struct to `reconciler.go` with a `SourceNamespacedName` field and an optional `Keys []string` field. When `Keys` is non-empty, only those data keys are included in the cross-namespace copy.
- Updated the `AdditionalSecrets` function signature in `AssociationInfo` to return `[]AdditionalSecret` instead of `[]types.NamespacedName`, threading key filtering through to the copy site.
- Updated `copySecret` in `secret.go` to accept a `keys []string` parameter. When keys are specified it builds a filtered data map before copying and hashes only the filtered data, so credential rotations on the source secret do not change `AdditionalSecretsHash` and do not trigger unnecessary agent pod restarts.
- Updated `additionalSecrets` in `agent_fleetserver.go` to return `AdditionalSecret` values with `Keys: []string{"ca.crt"}` for the CA secret entry, preventing credentials from being included in the copy regardless of whether the Elasticsearch reference is external or managed.
- Updated `dynamic_watches.go` to extract `SourceNamespacedName` from the new struct when registering secret watches.
- Added `TestCopySecret` covering: unfiltered copy, filtered copy with credentials absent, hash stability under credential rotation, and absent key silent skip.
- Updated `TestAdditionalSecrets` and `TestReconciler_Reconcile_Transitive_Associations` to use the new struct and assert that the copied secret contains only `ca.crt`.
