### PR TITLE
Fix cross-namespace naming and GC for fleet-managed agent additional secrets

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -962,6 +962,10 @@ func (r *gcRunnable) Start(ctx context.Context) error {
 	if err := garbageCollectUsers(gcCtx, r.cfg, namespaces); err != nil {
 		return fmt.Errorf("user garbage collection failed: %w", err)
 	}
+	// legacy fleet-server additional secret copies (cross-namespace copies with old naming scheme)
+	if err := associationctl.GarbageCollectLegacyFleetServerAdditionalSecrets(gcCtx, r.mgr.GetClient(), namespaces); err != nil {
+		log.Error(err, "Legacy fleet-server cross-namespace additional secrets GC failed, will be attempted again at next operator restart")
+	}
 	// - soft-owned secrets
 	garbageCollectSoftOwnedSecrets(gcCtx, r.mgr.GetClient())
 	// - autoops orphaned resources (API key secrets without owner references)

--- a/pkg/apis/common/v1/association.go
+++ b/pkg/apis/common/v1/association.go
@@ -258,10 +258,32 @@ type AssociationConf struct {
 // of a client certificate secret reconciled for mTLS. It is stored in the association conf
 // annotation so that changes trigger reconciliation of the associated resource.
 type TransitiveESRef struct {
+	// CASecretName is the name of the CA secret available in the associated resource's namespace
+	// for TLS verification of the transitive Elasticsearch. For cross-namespace deployments this
+	// is a copy with a deterministic hashed name; for same-namespace deployments it is the original
+	// secret name from the fleet server's Elasticsearch association conf.
+	// Empty when no CA is configured.
+	CASecretName string `json:"caSecretName,omitempty"`
 	// ClientCertSecretName is the name of the client certificate secret reconciled in the
 	// associated resource's namespace for mTLS with the transitive Elasticsearch.
 	// Empty when the Elasticsearch does not require client authentication.
 	ClientCertSecretName string `json:"clientCertSecretName,omitempty"`
+}
+
+// GetCASecretName returns the CA secret name, or empty string if the receiver is nil.
+func (t *TransitiveESRef) GetCASecretName() string {
+	if t == nil {
+		return ""
+	}
+	return t.CASecretName
+}
+
+// GetClientCertSecretName returns the client certificate secret name, or empty string if the receiver is nil.
+func (t *TransitiveESRef) GetClientCertSecretName() string {
+	if t == nil {
+		return ""
+	}
+	return t.ClientCertSecretName
 }
 
 // ClientCertIsConfigured returns true if a client certificate secret name is set.

--- a/pkg/controller/agent/driver.go
+++ b/pkg/controller/agent/driver.go
@@ -184,10 +184,12 @@ func internalReconcile(params Params) (*reconciler.Results, agentv1alpha1.AgentS
 		return results.WithError(err), params.Status
 	}
 
-	// For fleet-managed agents, read the client cert secret name from the transitive ES ref
-	// in the Fleet Server association conf. The cert is reconciled by the agent-fleetserver
-	// association controller.
-	esClientCertSecretName := fleetManagedAgentESClientCertSecretName(params)
+	// For fleet-managed agents, read the CA and client cert secret names from the transitive ES ref
+	// in the Fleet Server association conf. Both are reconciled by the agent-fleetserver association
+	// controller and stored in the annotation so pod changes trigger a roll.
+	transitiveRef := fleetManagedAgentTransitiveRef(params)
+	esCASecretName := transitiveRef.GetCASecretName()
+	esClientCertSecretName := transitiveRef.GetClientCertSecretName()
 
 	// Include the transitive client cert secret in the config hash so the pod rolls when it changes.
 	if esClientCertSecretName != "" {
@@ -203,7 +205,7 @@ func internalReconcile(params Params) (*reconciler.Results, agentv1alpha1.AgentS
 		}
 	}
 
-	podTemplate, err := buildPodTemplate(params, fleetCerts, fleetToken, configHash, esClientCertSecretName, clientAuthRequired)
+	podTemplate, err := buildPodTemplate(params, fleetCerts, fleetToken, configHash, esClientCertSecretName, esCASecretName, clientAuthRequired)
 	if err != nil {
 		return results.WithError(err), params.Status
 	}
@@ -366,22 +368,21 @@ func reconcileFleetServerClientAuth(params Params, clientAuthRequired bool, flee
 	return results
 }
 
-// fleetManagedAgentESClientCertSecretName returns the client cert secret name from the
-// Fleet Server association conf's TransitiveESRef, or empty string if not applicable.
-func fleetManagedAgentESClientCertSecretName(params Params) string {
+// fleetManagedAgentTransitiveRef returns the TransitiveESRef from the Fleet Server association
+// conf for fleet-managed agents (FleetServerRef set, FleetServerEnabled false), or nil otherwise.
+// The ref holds the CA and client cert secret names reconciled in the agent's namespace by the
+// agent-fleetserver association controller.
+func fleetManagedAgentTransitiveRef(params Params) *commonv1.TransitiveESRef {
 	if params.Agent.Spec.FleetServerEnabled || !params.Agent.Spec.FleetServerRef.IsSet() {
-		return ""
+		return nil
 	}
 	fsAssociation, err := association.SingleAssociationOfType(params.Agent.GetAssociations(), commonv1.FleetServerAssociationType)
 	if err != nil || fsAssociation == nil {
-		return ""
+		return nil
 	}
 	fsConf, err := fsAssociation.AssociationConf()
 	if err != nil || fsConf == nil {
-		return ""
+		return nil
 	}
-	if fsConf.TransitiveESRef.ClientCertIsConfigured() {
-		return fsConf.TransitiveESRef.ClientCertSecretName
-	}
-	return ""
+	return fsConf.TransitiveESRef
 }

--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -13,8 +13,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/metadata"
-
 	pkgerrors "github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -29,6 +27,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/container"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/defaults"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/labels"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/metadata"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/tracing"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/version"
@@ -159,7 +158,7 @@ var (
 	}
 )
 
-func buildPodTemplate(params Params, fleetCerts *certificates.CertificatesSecret, fleetToken EnrollmentAPIKey, configHash hash.Hash32, esClientCertSecretName string, clientAuthRequired bool) (corev1.PodTemplateSpec, error) {
+func buildPodTemplate(params Params, fleetCerts *certificates.CertificatesSecret, fleetToken EnrollmentAPIKey, configHash hash.Hash32, esClientCertSecretName, esCASecretName string, clientAuthRequired bool) (corev1.PodTemplateSpec, error) {
 	defer tracing.Span(&params.Context)()
 	spec := &params.Agent.Spec
 	builder := defaults.NewPodTemplateBuilder(params.GetPodTemplate(), ContainerName)
@@ -176,7 +175,7 @@ func buildPodTemplate(params Params, fleetCerts *certificates.CertificatesSecret
 	// fleet mode requires some special treatment
 	if spec.FleetModeEnabled() {
 		var err error
-		if builder, err = amendBuilderForFleetMode(params, fleetCerts, fleetToken, builder, configHash, esClientCertSecretName, clientAuthRequired); err != nil {
+		if builder, err = amendBuilderForFleetMode(params, fleetCerts, fleetToken, builder, configHash, esClientCertSecretName, esCASecretName, clientAuthRequired); err != nil {
 			return corev1.PodTemplateSpec{}, err
 		}
 		if params.AgentVersion.GTE(agentv1alpha1.FleetAdvancedConfigMinVersion) {
@@ -239,13 +238,13 @@ func fleetConfigPath(v version.Version) string {
 	return DataMountPath
 }
 
-func amendBuilderForFleetMode(params Params, fleetCerts *certificates.CertificatesSecret, fleetToken EnrollmentAPIKey, builder *defaults.PodTemplateBuilder, configHash hash.Hash, esClientCertSecretName string, clientAuthRequired bool) (*defaults.PodTemplateBuilder, error) {
+func amendBuilderForFleetMode(params Params, fleetCerts *certificates.CertificatesSecret, fleetToken EnrollmentAPIKey, builder *defaults.PodTemplateBuilder, configHash hash.Hash, esClientCertSecretName, esCASecretName string, clientAuthRequired bool) (*defaults.PodTemplateBuilder, error) {
 	esAssociation, err := getRelatedEsAssoc(params)
 	if err != nil {
 		return nil, err
 	}
 
-	builder, err = applyRelatedEsAssoc(params.Agent, esAssociation, esClientCertSecretName, builder)
+	builder, err = applyRelatedEsAssoc(params.Agent, esAssociation, esCASecretName, esClientCertSecretName, builder)
 	if err != nil {
 		return nil, err
 	}
@@ -393,7 +392,7 @@ func getRelatedEsAssoc(params Params) (commonv1.Association, error) {
 	return esAssociation, nil
 }
 
-func applyRelatedEsAssoc(agent agentv1alpha1.Agent, esAssociation commonv1.Association, esClientCertSecretName string, builder *defaults.PodTemplateBuilder) (*defaults.PodTemplateBuilder, error) {
+func applyRelatedEsAssoc(agent agentv1alpha1.Agent, esAssociation commonv1.Association, esCASecretName, esClientCertSecretName string, builder *defaults.PodTemplateBuilder) (*defaults.PodTemplateBuilder, error) {
 	if esAssociation == nil {
 		return builder, nil
 	}
@@ -402,9 +401,17 @@ func applyRelatedEsAssoc(agent agentv1alpha1.Agent, esAssociation commonv1.Assoc
 	if err != nil {
 		return nil, err
 	}
-	if assocConf.CAIsConfigured() {
+	// Mount the Elasticsearch CA for TLS verification. For fleet-managed agents esCASecretName
+	// is set to the CA copy reconciled in the agent's namespace (same name for same-namespace
+	// deployments, hashed name for cross-namespace). For Fleet Server it falls back to the CA
+	// from its own ES association conf.
+	caSecret := esCASecretName
+	if caSecret == "" && assocConf.CAIsConfigured() {
+		caSecret = assocConf.GetCASecretName()
+	}
+	if caSecret != "" {
 		builder = builder.WithVolumeLikes(volume.NewSecretVolumeWithMountPath(
-			assocConf.GetCASecretName(),
+			caSecret,
 			fmt.Sprintf("%s-certs", esAssociation.AssociationType()),
 			CertificatesDir(esAssociation),
 		))

--- a/pkg/controller/agent/pod_test.go
+++ b/pkg/controller/agent/pod_test.go
@@ -701,7 +701,7 @@ func Test_amendBuilderForFleetMode(t *testing.T) {
 			builder := generateBuilder()
 			hash := sha256.New224()
 
-			gotBuilder, gotErr := amendBuilderForFleetMode(tt.params, tt.fleetCerts, EnrollmentAPIKey{}, builder, hash, "", tt.clientAuthRequired)
+			gotBuilder, gotErr := amendBuilderForFleetMode(tt.params, tt.fleetCerts, EnrollmentAPIKey{}, builder, hash, "", "", tt.clientAuthRequired)
 
 			require.Nil(t, gotErr)
 			require.NotNil(t, gotBuilder)
@@ -1370,7 +1370,12 @@ func Test_getRelatedEsAssoc(t *testing.T) {
 func Test_applyRelatedEsAssoc(t *testing.T) {
 	optional := false
 	agentNs := "agent-ns"
+	fleetServerNs := "fleet-ns"
 	assocToSameNs := (&agentv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fleet-server",
+			Namespace: agentNs,
+		},
 		Spec: agentv1alpha1.AgentSpec{
 			ElasticsearchRefs: []agentv1alpha1.Output{
 				{
@@ -1389,6 +1394,10 @@ func Test_applyRelatedEsAssoc(t *testing.T) {
 	})
 
 	assocToOtherNs := (&agentv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fleet-server",
+			Namespace: fleetServerNs,
+		},
 		Spec: agentv1alpha1.AgentSpec{
 			ElasticsearchRefs: []agentv1alpha1.Output{
 				{
@@ -1402,6 +1411,7 @@ func Test_applyRelatedEsAssoc(t *testing.T) {
 			},
 		},
 	}).GetAssociations()[0]
+	const crossNsCASecretName = "agent-agent-fleetserver-hashxxx-es-ca"
 	assocToOtherNs.SetAssociationConf(&commonv1.AssociationConf{
 		CASecretName: "elasticsearch-es-http-certs-public",
 	})
@@ -1445,6 +1455,7 @@ fi
 		name                   string
 		agent                  agentv1alpha1.Agent
 		assoc                  commonv1.Association
+		esCASecretName         string
 		esClientCertSecretName string
 		wantPodSpec            corev1.PodSpec
 		wantErr                bool
@@ -1536,10 +1547,19 @@ fi
 					},
 				},
 			},
-			assoc:   assocToOtherNs,
-			wantErr: false,
+			assoc:          assocToOtherNs,
+			esCASecretName: crossNsCASecretName,
+			wantErr:        false,
 			wantPodSpec: generatePodSpec(func(ps corev1.PodSpec) corev1.PodSpec {
-				ps.Volumes = expectedCAVolume
+				ps.Volumes = []corev1.Volume{{
+					Name: "elasticsearch-certs",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: crossNsCASecretName,
+							Optional:   &optional,
+						},
+					},
+				}}
 				ps.Containers[0].VolumeMounts = expectedCAVolumeMountFunc("elasticsearch-ns")
 				ps.Containers[0].Command = expectedCmdFunc("elasticsearch-ns")
 				return ps
@@ -1596,6 +1616,10 @@ fi
 			},
 			assoc: func() commonv1.Association {
 				a := (&agentv1alpha1.Agent{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "fleet-server",
+						Namespace: agentNs,
+					},
 					Spec: agentv1alpha1.AgentSpec{
 						ElasticsearchRefs: []agentv1alpha1.Output{
 							{
@@ -1641,7 +1665,7 @@ fi
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			builder := generateBuilder()
-			gotBuilder, gotErr := applyRelatedEsAssoc(tt.agent, tt.assoc, tt.esClientCertSecretName, builder)
+			gotBuilder, gotErr := applyRelatedEsAssoc(tt.agent, tt.assoc, tt.esCASecretName, tt.esClientCertSecretName, builder)
 			require.Equal(t, tt.wantErr, gotErr != nil)
 			if !tt.wantErr {
 				require.Nil(t, gotErr)
@@ -2256,15 +2280,16 @@ func Test_associationClientCertificatesDir(t *testing.T) {
 	require.Equal(t, "/mnt/elastic-internal/elasticsearch-association/es-ns/elasticsearch/client-certs", got)
 }
 
-func Test_fleetManagedAgentESClientCertSecretName(t *testing.T) {
+func Test_fleetManagedAgentTransitiveRef(t *testing.T) {
 	for _, tt := range []struct {
-		name           string
-		params         Params
-		setAssocConfs  func(assocs []commonv1.Association)
-		wantSecretName string
+		name                 string
+		params               Params
+		setAssocConfs        func(assocs []commonv1.Association)
+		wantCASecret         string
+		wantClientCertSecret string
 	}{
 		{
-			name: "fleet server enabled returns empty",
+			name: "fleet server enabled returns nil",
 			params: Params{
 				Agent: agentv1alpha1.Agent{
 					Spec: agentv1alpha1.AgentSpec{
@@ -2273,10 +2298,9 @@ func Test_fleetManagedAgentESClientCertSecretName(t *testing.T) {
 					},
 				},
 			},
-			wantSecretName: "",
 		},
 		{
-			name: "no fleet server ref returns empty",
+			name: "no fleet server ref returns nil",
 			params: Params{
 				Agent: agentv1alpha1.Agent{
 					Spec: agentv1alpha1.AgentSpec{
@@ -2284,10 +2308,9 @@ func Test_fleetManagedAgentESClientCertSecretName(t *testing.T) {
 					},
 				},
 			},
-			wantSecretName: "",
 		},
 		{
-			name: "fleet server ref set but no transitive ES ref returns empty",
+			name: "fleet server ref set but no transitive ES ref returns empty names",
 			params: Params{
 				Agent: agentv1alpha1.Agent{
 					Spec: agentv1alpha1.AgentSpec{
@@ -2301,10 +2324,9 @@ func Test_fleetManagedAgentESClientCertSecretName(t *testing.T) {
 					URL: "https://fs:8220",
 				})
 			},
-			wantSecretName: "",
 		},
 		{
-			name: "fleet server ref set with transitive ES ref containing client cert",
+			name: "fleet server ref set with transitive ES ref containing CA only (ES without mTLS)",
 			params: Params{
 				Agent: agentv1alpha1.Agent{
 					Spec: agentv1alpha1.AgentSpec{
@@ -2317,11 +2339,33 @@ func Test_fleetManagedAgentESClientCertSecretName(t *testing.T) {
 				assocs[0].SetAssociationConf(&commonv1.AssociationConf{
 					URL: "https://fs:8220",
 					TransitiveESRef: &commonv1.TransitiveESRef{
+						CASecretName: "my-transitive-ca",
+					},
+				})
+			},
+			wantCASecret: "my-transitive-ca",
+		},
+		{
+			name: "fleet server ref set with transitive ES ref containing both names",
+			params: Params{
+				Agent: agentv1alpha1.Agent{
+					Spec: agentv1alpha1.AgentSpec{
+						FleetServerEnabled: false,
+						FleetServerRef:     commonv1.FleetServerSelector{ObjectSelector: commonv1.ObjectSelector{Name: "fs", Namespace: "ns"}},
+					},
+				},
+			},
+			setAssocConfs: func(assocs []commonv1.Association) {
+				assocs[0].SetAssociationConf(&commonv1.AssociationConf{
+					URL: "https://fs:8220",
+					TransitiveESRef: &commonv1.TransitiveESRef{
+						CASecretName:         "my-transitive-ca",
 						ClientCertSecretName: "my-transitive-client-cert",
 					},
 				})
 			},
-			wantSecretName: "my-transitive-client-cert",
+			wantCASecret:         "my-transitive-ca",
+			wantClientCertSecret: "my-transitive-client-cert",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -2329,8 +2373,9 @@ func Test_fleetManagedAgentESClientCertSecretName(t *testing.T) {
 				assocs := tt.params.Agent.GetAssociations()
 				tt.setAssocConfs(assocs)
 			}
-			got := fleetManagedAgentESClientCertSecretName(tt.params)
-			require.Equal(t, tt.wantSecretName, got)
+			got := fleetManagedAgentTransitiveRef(tt.params)
+			require.Equal(t, tt.wantCASecret, got.GetCASecretName())
+			require.Equal(t, tt.wantClientCertSecret, got.GetClientCertSecretName())
 		})
 	}
 }

--- a/pkg/controller/agent/resources_test.go
+++ b/pkg/controller/agent/resources_test.go
@@ -43,7 +43,7 @@ func buildAgentStandalonePodTemplate(t *testing.T, agent agentv1alpha1.Agent) co
 		Agent:        agent,
 		AgentVersion: version.MustParse(agent.Spec.Version),
 	}
-	got, err := buildPodTemplate(params, nil, EnrollmentAPIKey{}, fnv.New32a(), "", false)
+	got, err := buildPodTemplate(params, nil, EnrollmentAPIKey{}, fnv.New32a(), "", "", false)
 	require.NoError(t, err)
 	return got
 }
@@ -62,7 +62,7 @@ func buildAgentFleetPodTemplate(t *testing.T, agent agentv1alpha1.Agent) corev1.
 		Agent:        agent,
 		AgentVersion: version.MustParse(agent.Spec.Version),
 	}
-	got, err := buildPodTemplate(params, fleetCertsFixture, EnrollmentAPIKey{}, fnv.New32a(), "", false)
+	got, err := buildPodTemplate(params, fleetCertsFixture, EnrollmentAPIKey{}, fnv.New32a(), "", "", false)
 	require.NoError(t, err)
 	return got
 }

--- a/pkg/controller/association/controller/agent_fleetserver.go
+++ b/pkg/controller/association/controller/agent_fleetserver.go
@@ -63,14 +63,13 @@ func AddAgentFleetServer(mgr manager.Manager, accessReviewer rbac.AccessReviewer
 // additionalSecrets returns secrets from the Fleet Server's Elasticsearch association that
 // need to be copied into the fleet-managed agent's namespace: the CA secret (when present)
 // and the client certificate secret (when the user has provided one on the Fleet Server's ES ref).
+// For same-namespace deployments (agent and Fleet Server share a namespace) the active entries
+// (CA and client cert) are still returned so that their content is hashed into AdditionalSecretsHash;
+// copySecret detects the shared namespace and skips creating a copy while still writing the hash.
+// Legacy copies (created by older ECK with the source secret's original name) are collected by
+// GarbageCollectLegacyFleetServerAdditionalSecrets at startup.
 func additionalSecrets(ctx context.Context, c k8s.Client, assoc commonv1.Association) ([]association.AdditionalSecret, error) {
 	log := ulog.FromContext(ctx)
-	associated := assoc.Associated()
-	var agent agentv1alpha1.Agent
-	nsn := types.NamespacedName{Namespace: associated.GetNamespace(), Name: associated.GetName()}
-	if err := c.Get(ctx, nsn, &agent); err != nil {
-		return nil, err
-	}
 	fleetServerRef := assoc.AssociationRef()
 	if !fleetServerRef.IsSet() {
 		return nil, nil
@@ -102,30 +101,29 @@ func additionalSecrets(ctx context.Context, c k8s.Client, assoc commonv1.Associa
 	}
 
 	secrets := make([]association.AdditionalSecret, 0, 2)
+
 	if conf.CACertProvided {
 		log.V(1).Info("additional secret because CA provided")
-		// Always restrict the copy to ca.crt. For external ES references, CASecretName ==
-		// AuthSecretName, so the source secret also contains url/username/password — filtering
-		// to ca.crt prevents credential leakage. For managed refs the CA secret also contains
-		// tls.crt; agents only need ca.crt for TLS verification, so the narrower copy is correct
-		// in both cases.
 		secrets = append(secrets, association.AdditionalSecret{
-			Source: types.NamespacedName{
-				Namespace: fleetServer.Namespace,
-				Name:      conf.CASecretName,
-			},
-			Keys: []string{certificates.CAFileName},
+			Source: types.NamespacedName{Namespace: fleetServer.Namespace, Name: conf.CASecretName},
+			// Always restrict the copy to ca.crt. For external ES references, CASecretName ==
+			// AuthSecretName, so the source secret also contains url/username/password — filtering
+			// to ca.crt prevents credential leakage. For managed refs the CA secret also contains
+			// tls.crt; agents only need ca.crt for TLS verification, so the narrower copy is correct
+			// in both cases.
+			Keys:       []string{certificates.CAFileName},
+			TargetName: transitiveESCATargetName(assoc, conf),
 		})
 	}
+
 	if conf.ClientCertIsConfigured() && esRef.GetClientCertificateSecretName() != "" {
 		log.V(1).Info("additional secret because user client certificate is provided")
 		secrets = append(secrets, association.AdditionalSecret{
-			Source: types.NamespacedName{
-				Namespace: fleetServer.Namespace,
-				Name:      conf.GetClientCertSecretName(),
-			},
+			Source:     types.NamespacedName{Namespace: fleetServer.Namespace, Name: conf.GetClientCertSecretName()},
+			TargetName: transitiveESClientCertTargetName(assoc, conf),
 		})
 	}
+
 	return secrets, nil
 }
 
@@ -137,6 +135,34 @@ func clientCertSecretName(associated commonv1.Associated, ref commonv1.Associati
 	return association.ClientCertNamer.Suffix(associatedName, associationName, refHash, "client-cert")
 }
 
+// transitiveSecretTargetName returns the name a transitive ES secret should have in the
+// fleet-managed agent's namespace. For same-namespace deployments this is origName (the secret
+// already lives in the shared namespace, no copy needed); for cross-namespace deployments it is a
+// deterministic-hashed name that embeds the fleet server's NamespacedName to avoid collisions.
+// Used by both additionalSecrets and fleetManagedAgentTransitiveESRef so the two code paths always
+// agree on the target name.
+func transitiveSecretTargetName(assoc commonv1.Association, origName, suffix string) string {
+	agentNS := assoc.Associated().GetNamespace()
+	refNS := assoc.AssociationRef().GetNamespace()
+	switch refNS {
+	case "":
+		// Omitting namespace on the FleetServerRef means same namespace as the agent.
+		return origName
+	case agentNS:
+		return origName
+	}
+	refHash := hash.HashObject(assoc.AssociationRef().NamespacedName())
+	return association.AdditionalSecretNamer.Suffix(assoc.Associated().GetName(), "agent-fleetserver", refHash, suffix)
+}
+
+func transitiveESCATargetName(assoc commonv1.Association, conf *commonv1.AssociationConf) string {
+	return transitiveSecretTargetName(assoc, conf.CASecretName, "es-ca")
+}
+
+func transitiveESClientCertTargetName(assoc commonv1.Association, conf *commonv1.AssociationConf) string {
+	return transitiveSecretTargetName(assoc, conf.GetClientCertSecretName(), "es-client-cert")
+}
+
 // fleetManagedAgentTransitiveESRef resolves the transitive Elasticsearch association
 // (Agent -> Fleet Server -> Elasticsearch) and reconciles a client certificate for the
 // fleet-managed agent when the Elasticsearch requires client authentication.
@@ -146,9 +172,9 @@ func fleetManagedAgentTransitiveESRef(ctx context.Context, c k8s.Client, assoc c
 
 	log := ulog.FromContext(ctx)
 	associated := assoc.Associated()
-	var agent agentv1alpha1.Agent
+	var agnt agentv1alpha1.Agent
 	nsn := types.NamespacedName{Namespace: associated.GetNamespace(), Name: associated.GetName()}
-	if err := c.Get(ctx, nsn, &agent); err != nil {
+	if err := c.Get(ctx, nsn, &agnt); err != nil {
 		return nil, results.WithError(err)
 	}
 	fleetServerRef := assoc.AssociationRef()
@@ -189,18 +215,32 @@ func fleetManagedAgentTransitiveESRef(ctx context.Context, c k8s.Client, assoc c
 		return nil, nil
 	}
 
-	ref := esAssociation.AssociationRef()
-	if ref.IsExternal() {
+	esAssocRef := esAssociation.AssociationRef()
+
+	var caSecretName string
+	if conf.CACertProvided {
+		caSecretName = transitiveESCATargetName(assoc, conf)
+	}
+
+	// Compute the user-provided client cert name up front so the external-ES branch can include
+	// it in the TransitiveESRef and preserve its copy in the agent namespace.
+	var userClientCertName string
+	if esRef.GetClientCertificateSecretName() != "" && conf.ClientCertIsConfigured() {
+		userClientCertName = transitiveESClientCertTargetName(assoc, conf)
+	}
+
+	if esAssocRef.IsExternal() {
 		// For external ES references, the operator cannot determine whether client
-		// authentication is required. Skip client cert reconciliation.
-		if err := deleteOrphanedTransitiveESClientCertSecrets(ctx, c, assocMeta, associated, ""); err != nil {
+		// authentication is required. Propagate the user-provided cert copy if present
+		// but skip ECK-managed client cert reconciliation.
+		if err := deleteOrphanedTransitiveESClientCertSecrets(ctx, c, assocMeta, associated, userClientCertName); err != nil {
 			return nil, results.WithError(err)
 		}
-		return nil, nil
+		return transitiveESRefOrNil(caSecretName, userClientCertName), nil
 	}
 
 	var es esv1.Elasticsearch
-	if err := c.Get(ctx, ref.NamespacedName(), &es); err != nil {
+	if err := c.Get(ctx, esAssocRef.NamespacedName(), &es); err != nil {
 		return nil, results.WithError(err)
 	}
 
@@ -208,30 +248,30 @@ func fleetManagedAgentTransitiveESRef(ctx context.Context, c k8s.Client, assoc c
 		if err := deleteOrphanedTransitiveESClientCertSecrets(ctx, c, assocMeta, associated, ""); err != nil {
 			return nil, results.WithError(err)
 		}
-		return nil, nil
+		return transitiveESRefOrNil(caSecretName, ""), nil
 	}
 
-	// If the Fleet Server has a user-provided client certificate for its ES association, reuse it.
-	// The secret is already copied into the agent's namespace by additionalSecrets/copySecret.
-	if esRef.GetClientCertificateSecretName() != "" && conf.ClientCertIsConfigured() {
-		copiedSecretName := conf.GetClientCertSecretName()
-		if err := deleteOrphanedTransitiveESClientCertSecrets(ctx, c, assocMeta, associated, ""); err != nil {
+	// If the Fleet Server has a user-provided client certificate for its ES association, reuse
+	// it: for cross-namespace associations this is the per-agent copy created by
+	// additionalSecrets/copySecret; for same-namespace associations it is the original secret.
+	if userClientCertName != "" {
+		// Pass userClientCertName to preserve the copy: it may inherit SoftOwnerKindLabel/
+		// ClientCertificateLabelName from the source secret, so "" would match and delete it.
+		if err := deleteOrphanedTransitiveESClientCertSecrets(ctx, c, assocMeta, associated, userClientCertName); err != nil {
 			return nil, results.WithError(err)
 		}
-		return &commonv1.TransitiveESRef{
-			ClientCertSecretName: copiedSecretName,
-		}, results
+		return transitiveESRefOrNil(caSecretName, userClientCertName), results
 	}
 
 	// Build soft-owner labels pointing to the referenced server resource.
 	extraLabels := map[string]string{
-		reconciler.SoftOwnerNameLabel:      ref.GetName(),
-		reconciler.SoftOwnerNamespaceLabel: ref.GetNamespace(),
+		reconciler.SoftOwnerNameLabel:      esAssocRef.GetName(),
+		reconciler.SoftOwnerNamespaceLabel: esAssocRef.GetNamespace(),
 		reconciler.SoftOwnerKindLabel:      esv1.Kind,
 		labels.ClientCertificateLabelName:  "true",
 	}
 
-	secretName := clientCertSecretName(associated, ref, "agent-es")
+	secretName := clientCertSecretName(associated, esAssocRef, "agent-es")
 
 	_, certResults := association.ReconcileManagedClientCert(ctx, c, assoc, assocMeta, secretName, extraLabels)
 	results.WithResults(certResults)
@@ -243,9 +283,19 @@ func fleetManagedAgentTransitiveESRef(ctx context.Context, c k8s.Client, assoc c
 		return nil, results.WithError(err)
 	}
 
+	return transitiveESRefOrNil(caSecretName, secretName), results
+}
+
+// transitiveESRefOrNil returns a *TransitiveESRef populated with the provided names, or nil if
+// both are empty (indicating no transitive ES state to propagate).
+func transitiveESRefOrNil(caSecretName, clientCertSecretName string) *commonv1.TransitiveESRef {
+	if caSecretName == "" && clientCertSecretName == "" {
+		return nil
+	}
 	return &commonv1.TransitiveESRef{
-		ClientCertSecretName: secretName,
-	}, results
+		CASecretName:         caSecretName,
+		ClientCertSecretName: clientCertSecretName,
+	}
 }
 
 // deleteOrphanedTransitiveESClientCertSecrets lists transitive ES client cert secrets scoped to

--- a/pkg/controller/association/controller/agent_fleetserver_test.go
+++ b/pkg/controller/association/controller/agent_fleetserver_test.go
@@ -124,6 +124,73 @@ func TestAdditionalSecrets(t *testing.T) {
 			wantSecrets: nil,
 		},
 		{
+			name: "same-namespace fleet server with omitted namespace: CA entry returned for hashing, no copy created",
+			agent: &agentv1alpha1.Agent{
+				ObjectMeta: metav1.ObjectMeta{Name: "agent1", Namespace: "ns"},
+				Spec: agentv1alpha1.AgentSpec{
+					Version: "8.0.0",
+					// Namespace intentionally omitted — ECK treats this as same namespace.
+					FleetServerRef: commonv1.FleetServerSelector{ObjectSelector: commonv1.ObjectSelector{Name: "fleet1"}},
+				},
+			},
+			fleetServer: &agentv1alpha1.Agent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fleet1", Namespace: "ns",
+					Annotations: map[string]string{
+						esConfAnnotationKey(esSelector): esAssocConfAnnotation(commonv1.AssociationConf{
+							AuthSecretName: "-",
+							CACertProvided: true,
+							CASecretName:   "fleet1-es-ca",
+							URL:            "https://es1-http.es-ns.svc:9200",
+						}),
+					},
+				},
+				Spec: agentv1alpha1.AgentSpec{
+					Version:            "8.0.0",
+					FleetServerEnabled: true,
+					ElasticsearchRefs: []agentv1alpha1.Output{
+						{ElasticsearchSelector: commonv1.ElasticsearchSelector{ObjectSelector: esSelector}},
+					},
+				},
+			},
+			wantSecrets: []association.AdditionalSecret{
+				{Source: types.NamespacedName{Namespace: "ns", Name: "fleet1-es-ca"}, Keys: []string{"ca.crt"}, TargetName: "fleet1-es-ca"},
+			},
+		},
+		{
+			name: "same-namespace fleet server: CA entry returned for hashing, no copy created",
+			agent: &agentv1alpha1.Agent{
+				ObjectMeta: metav1.ObjectMeta{Name: "agent1", Namespace: "ns"},
+				Spec: agentv1alpha1.AgentSpec{
+					Version:        "8.0.0",
+					FleetServerRef: commonv1.FleetServerSelector{ObjectSelector: commonv1.ObjectSelector{Name: "fleet1", Namespace: "ns"}},
+				},
+			},
+			fleetServer: &agentv1alpha1.Agent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fleet1", Namespace: "ns",
+					Annotations: map[string]string{
+						esConfAnnotationKey(esSelector): esAssocConfAnnotation(commonv1.AssociationConf{
+							AuthSecretName: "-",
+							CACertProvided: true,
+							CASecretName:   "fleet1-es-ca",
+							URL:            "https://es1-http.es-ns.svc:9200",
+						}),
+					},
+				},
+				Spec: agentv1alpha1.AgentSpec{
+					Version:            "8.0.0",
+					FleetServerEnabled: true,
+					ElasticsearchRefs: []agentv1alpha1.Output{
+						{ElasticsearchSelector: commonv1.ElasticsearchSelector{ObjectSelector: esSelector}},
+					},
+				},
+			},
+			wantSecrets: []association.AdditionalSecret{
+				{Source: types.NamespacedName{Namespace: "ns", Name: "fleet1-es-ca"}, Keys: []string{"ca.crt"}, TargetName: "fleet1-es-ca"},
+			},
+		},
+		{
 			name: "fleet server has ES ref with CA returns CA secret",
 			agent: &agentv1alpha1.Agent{
 				ObjectMeta: metav1.ObjectMeta{Name: "agent1", Namespace: "ns"},
@@ -153,7 +220,7 @@ func TestAdditionalSecrets(t *testing.T) {
 				},
 			},
 			wantSecrets: []association.AdditionalSecret{
-				{Source: types.NamespacedName{Namespace: "fs-ns", Name: "fleet1-es-ca"}, Keys: []string{"ca.crt"}},
+				{Source: types.NamespacedName{Namespace: "fs-ns", Name: "fleet1-es-ca"}, Keys: []string{"ca.crt"}, TargetName: "agent1-agent-fleetserver-" + hash.HashObject(types.NamespacedName{Name: "fleet1", Namespace: "fs-ns"}) + "-es-ca"},
 			},
 		},
 		{
@@ -190,12 +257,78 @@ func TestAdditionalSecrets(t *testing.T) {
 				},
 			},
 			wantSecrets: []association.AdditionalSecret{
-				{Source: types.NamespacedName{Namespace: "fs-ns", Name: "fleet1-es-ca"}, Keys: []string{"ca.crt"}},
-				{Source: types.NamespacedName{Namespace: "fs-ns", Name: "copied-user-cert"}},
+				{Source: types.NamespacedName{Namespace: "fs-ns", Name: "fleet1-es-ca"}, Keys: []string{"ca.crt"}, TargetName: "agent1-agent-fleetserver-" + hash.HashObject(types.NamespacedName{Name: "fleet1", Namespace: "fs-ns"}) + "-es-ca"},
+				{Source: types.NamespacedName{Namespace: "fs-ns", Name: "copied-user-cert"}, TargetName: "agent1-agent-fleetserver-" + hash.HashObject(types.NamespacedName{Name: "fleet1", Namespace: "fs-ns"}) + "-es-client-cert"},
 			},
 		},
 		{
-			name: "client cert in conf but no user-provided cert name returns only CA",
+			name: "CA not provided: empty slice returned, GC handles stale copies",
+			agent: &agentv1alpha1.Agent{
+				ObjectMeta: metav1.ObjectMeta{Name: "agent1", Namespace: "ns"},
+				Spec: agentv1alpha1.AgentSpec{
+					Version:        "8.0.0",
+					FleetServerRef: commonv1.FleetServerSelector{ObjectSelector: commonv1.ObjectSelector{Name: "fleet1", Namespace: "fs-ns"}},
+				},
+			},
+			fleetServer: &agentv1alpha1.Agent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fleet1", Namespace: "fs-ns",
+					Annotations: map[string]string{
+						esConfAnnotationKey(esSelector): esAssocConfAnnotation(commonv1.AssociationConf{
+							AuthSecretName: "-",
+							CACertProvided: false,
+							CASecretName:   "fleet1-es-ca",
+							URL:            "https://es1-http.es-ns.svc:9200",
+						}),
+					},
+				},
+				Spec: agentv1alpha1.AgentSpec{
+					Version:            "8.0.0",
+					FleetServerEnabled: true,
+					ElasticsearchRefs: []agentv1alpha1.Output{
+						{ElasticsearchSelector: commonv1.ElasticsearchSelector{ObjectSelector: esSelector}},
+					},
+				},
+			},
+			wantSecrets: []association.AdditionalSecret{},
+		},
+		{
+			name: "client cert removed from ESRef but still in conf: only CA returned, GC removes stale client cert copy",
+			agent: &agentv1alpha1.Agent{
+				ObjectMeta: metav1.ObjectMeta{Name: "agent1", Namespace: "ns"},
+				Spec: agentv1alpha1.AgentSpec{
+					Version:        "8.0.0",
+					FleetServerRef: commonv1.FleetServerSelector{ObjectSelector: commonv1.ObjectSelector{Name: "fleet1", Namespace: "fs-ns"}},
+				},
+			},
+			fleetServer: &agentv1alpha1.Agent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fleet1", Namespace: "fs-ns",
+					Annotations: map[string]string{
+						esConfAnnotationKey(esSelector): esAssocConfAnnotation(commonv1.AssociationConf{
+							AuthSecretName:       "-",
+							CACertProvided:       true,
+							CASecretName:         "fleet1-es-ca",
+							ClientCertSecretName: "copied-user-cert", // stale: user removed cert ref from ESRef
+							URL:                  "https://es1-http.es-ns.svc:9200",
+						}),
+					},
+				},
+				Spec: agentv1alpha1.AgentSpec{
+					Version:            "8.0.0",
+					FleetServerEnabled: true,
+					ElasticsearchRefs: []agentv1alpha1.Output{
+						// ClientCertificateSecretName deliberately absent — user removed the ref
+						{ElasticsearchSelector: commonv1.ElasticsearchSelector{ObjectSelector: esSelector}},
+					},
+				},
+			},
+			wantSecrets: []association.AdditionalSecret{
+				{Source: types.NamespacedName{Namespace: "fs-ns", Name: "fleet1-es-ca"}, Keys: []string{"ca.crt"}, TargetName: "agent1-agent-fleetserver-" + hash.HashObject(types.NamespacedName{Name: "fleet1", Namespace: "fs-ns"}) + "-es-ca"},
+			},
+		},
+		{
+			name: "client cert in conf but no user-provided cert name: only CA returned",
 			agent: &agentv1alpha1.Agent{
 				ObjectMeta: metav1.ObjectMeta{Name: "agent1", Namespace: "ns"},
 				Spec: agentv1alpha1.AgentSpec{
@@ -225,7 +358,7 @@ func TestAdditionalSecrets(t *testing.T) {
 				},
 			},
 			wantSecrets: []association.AdditionalSecret{
-				{Source: types.NamespacedName{Namespace: "fs-ns", Name: "fleet1-es-ca"}, Keys: []string{"ca.crt"}},
+				{Source: types.NamespacedName{Namespace: "fs-ns", Name: "fleet1-es-ca"}, Keys: []string{"ca.crt"}, TargetName: "agent1-agent-fleetserver-" + hash.HashObject(types.NamespacedName{Name: "fleet1", Namespace: "fs-ns"}) + "-es-ca"},
 			},
 		},
 	} {
@@ -378,7 +511,7 @@ func TestFleetManagedAgentTransitiveESRef(t *testing.T) {
 			wantNilResults: true,
 		},
 		{
-			name: "ES without client auth annotation returns nil and cleans up",
+			name: "ES without client auth annotation returns CA-only TransitiveESRef and cleans up",
 			agent: &agentv1alpha1.Agent{
 				ObjectMeta: metav1.ObjectMeta{Name: "agent1", Namespace: "ns"},
 				Spec: agentv1alpha1.AgentSpec{
@@ -409,7 +542,9 @@ func TestFleetManagedAgentTransitiveESRef(t *testing.T) {
 			es: &esv1.Elasticsearch{
 				ObjectMeta: metav1.ObjectMeta{Name: "es1", Namespace: "es-ns"},
 			},
-			wantRef:        nil,
+			wantRef: &commonv1.TransitiveESRef{
+				CASecretName: association.AdditionalSecretNamer.Suffix("agent1", "agent-fleetserver", hash.HashObject(types.NamespacedName{Name: "fleet1", Namespace: "fs-ns"}), "es-ca"),
+			},
 			wantNilResults: true,
 		},
 		{
@@ -453,7 +588,10 @@ func TestFleetManagedAgentTransitiveESRef(t *testing.T) {
 					},
 				},
 			},
-			wantRef: &commonv1.TransitiveESRef{ClientCertSecretName: "copied-user-cert"},
+			wantRef: &commonv1.TransitiveESRef{
+				CASecretName:         association.AdditionalSecretNamer.Suffix("agent1", "agent-fleetserver", hash.HashObject(types.NamespacedName{Name: "fleet1", Namespace: "fs-ns"}), "es-ca"),
+				ClientCertSecretName: "agent1-agent-fleetserver-" + hash.HashObject(types.NamespacedName{Name: "fleet1", Namespace: "fs-ns"}) + "-es-client-cert",
+			},
 		},
 		{
 			name: "ES has client auth and no user cert returns auto-generated secret name",
@@ -493,6 +631,7 @@ func TestFleetManagedAgentTransitiveESRef(t *testing.T) {
 				},
 			},
 			wantRef: &commonv1.TransitiveESRef{
+				CASecretName:         association.AdditionalSecretNamer.Suffix("agent1", "agent-fleetserver", hash.HashObject(types.NamespacedName{Name: "fleet1", Namespace: "fs-ns"}), "es-ca"),
 				ClientCertSecretName: "agent1-agent-es-" + hash.HashObject(esSelector.NamespacedName()) + "-client-cert",
 			},
 			wantCreatedSecret: &types.NamespacedName{
@@ -533,6 +672,98 @@ func TestFleetManagedAgentTransitiveESRef(t *testing.T) {
 			wantRef:        nil,
 			wantNilResults: true,
 			wantOrphanGone: true,
+		},
+		{
+			name: "same-namespace fleet server with client auth sets CA secret name to original",
+			agent: &agentv1alpha1.Agent{
+				ObjectMeta: metav1.ObjectMeta{Name: "agent1", Namespace: "fs-ns"},
+				Spec: agentv1alpha1.AgentSpec{
+					Version:        "8.0.0",
+					FleetServerRef: commonv1.FleetServerSelector{ObjectSelector: commonv1.ObjectSelector{Name: "fleet1", Namespace: "fs-ns"}},
+				},
+			},
+			fleetServer: &agentv1alpha1.Agent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fleet1", Namespace: "fs-ns",
+					Annotations: map[string]string{
+						esConfAnnotationKey(esSelector): esAssocConfAnnotation(commonv1.AssociationConf{
+							AuthSecretName: "-",
+							CACertProvided: true,
+							CASecretName:   "fleet1-es-ca",
+							URL:            "https://es1-http.es-ns.svc:9200",
+						}),
+					},
+				},
+				Spec: agentv1alpha1.AgentSpec{
+					Version:            "8.0.0",
+					FleetServerEnabled: true,
+					ElasticsearchRefs: []agentv1alpha1.Output{
+						{ElasticsearchSelector: commonv1.ElasticsearchSelector{ObjectSelector: esSelector}},
+					},
+				},
+			},
+			es: &esv1.Elasticsearch{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "es1", Namespace: "es-ns",
+					Annotations: map[string]string{
+						annotation.ClientAuthenticationRequiredAnnotation: "true",
+					},
+				},
+			},
+			wantRef: &commonv1.TransitiveESRef{
+				CASecretName:         "fleet1-es-ca",
+				ClientCertSecretName: "agent1-agent-es-" + hash.HashObject(esSelector.NamespacedName()) + "-client-cert",
+			},
+			wantCreatedSecret: &types.NamespacedName{
+				Namespace: "fs-ns",
+				Name:      "agent1-agent-es-" + hash.HashObject(esSelector.NamespacedName()) + "-client-cert",
+			},
+		},
+		{
+			name: "same-namespace fleet server with user-provided cert returns original client cert name",
+			agent: &agentv1alpha1.Agent{
+				ObjectMeta: metav1.ObjectMeta{Name: "agent1", Namespace: "fs-ns"},
+				Spec: agentv1alpha1.AgentSpec{
+					Version:        "8.0.0",
+					FleetServerRef: commonv1.FleetServerSelector{ObjectSelector: commonv1.ObjectSelector{Name: "fleet1", Namespace: "fs-ns"}},
+				},
+			},
+			fleetServer: &agentv1alpha1.Agent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fleet1", Namespace: "fs-ns",
+					Annotations: map[string]string{
+						esConfAnnotationKey(esSelector): esAssocConfAnnotation(commonv1.AssociationConf{
+							AuthSecretName:       "-",
+							CACertProvided:       true,
+							CASecretName:         "fleet1-es-ca",
+							ClientCertSecretName: "user-provided-cert",
+							URL:                  "https://es1-http.es-ns.svc:9200",
+						}),
+					},
+				},
+				Spec: agentv1alpha1.AgentSpec{
+					Version:            "8.0.0",
+					FleetServerEnabled: true,
+					ElasticsearchRefs: []agentv1alpha1.Output{
+						{ElasticsearchSelector: commonv1.ElasticsearchSelector{
+							ObjectSelector:              esSelector,
+							ClientCertificateSecretName: "user-provided-cert",
+						}},
+					},
+				},
+			},
+			es: &esv1.Elasticsearch{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "es1", Namespace: "es-ns",
+					Annotations: map[string]string{
+						annotation.ClientAuthenticationRequiredAnnotation: "true",
+					},
+				},
+			},
+			wantRef: &commonv1.TransitiveESRef{
+				CASecretName:         "fleet1-es-ca",
+				ClientCertSecretName: "user-provided-cert",
+			},
 		},
 		{
 			name: "conf is nil returns nil and cleans up",
@@ -578,6 +809,7 @@ func TestFleetManagedAgentTransitiveESRef(t *testing.T) {
 				require.Nil(t, ref)
 			} else {
 				require.NotNil(t, ref)
+				require.Equal(t, tt.wantRef.CASecretName, ref.CASecretName)
 				require.Equal(t, tt.wantRef.ClientCertSecretName, ref.ClientCertSecretName)
 			}
 

--- a/pkg/controller/association/controller/gc.go
+++ b/pkg/controller/association/controller/gc.go
@@ -1,0 +1,72 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	commonv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/common/v1"
+	eslabel "github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/label"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
+	ulog "github.com/elastic/cloud-on-k8s/v3/pkg/utils/log"
+)
+
+// GarbageCollectLegacyFleetServerAdditionalSecrets removes secret copies that were placed in
+// fleet-managed agent namespaces by older ECK versions. Those copies used the source secret's
+// original name as the target name and carried the fleet server's Elasticsearch association labels
+// verbatim (agentassociation.k8s.elastic.co/name=<fleet-server>, type=elasticsearch). Current
+// ECK overrides those labels with agent-level labels (type=fleetserver), so the label selector
+// below exclusively matches legacy copies and never touches new-scheme copies or original secrets.
+//
+// Detection relies on a namespace-mismatch invariant: a secret that carries an association
+// namespace label (agentassociation.k8s.elastic.co/namespace) whose value differs from the
+// secret's own namespace is by definition a cross-namespace copy and not the original. Original
+// secrets always live in the same namespace as the resource they describe, so their association
+// namespace label equals their actual namespace.
+//
+// An empty managedNamespaces slice means the operator manages all namespaces.
+func GarbageCollectLegacyFleetServerAdditionalSecrets(ctx context.Context, c k8s.Client, managedNamespaces []string) error {
+	var errs error
+	log := ulog.FromContext(ctx)
+	if len(managedNamespaces) == 0 {
+		// Empty means all namespaces; use the empty string understood by client.InNamespace.
+		managedNamespaces = []string{""}
+	}
+	for _, ns := range managedNamespaces {
+		var secrets corev1.SecretList
+		if err := c.List(ctx, &secrets,
+			client.InNamespace(ns),
+			client.MatchingLabels{AgentAssociationLabelType: commonv1.ElasticsearchAssociationType},
+			client.HasLabels{AgentAssociationLabelName, AgentAssociationLabelNamespace, eslabel.ClusterNameLabelName, eslabel.ClusterNamespaceLabelName},
+		); err != nil {
+			errs = errors.Join(errs, fmt.Errorf("failed to list secrets in namespace %q: %w", ns, err))
+			continue
+		}
+		for i := range secrets.Items {
+			s := &secrets.Items[i]
+			// New-scheme copies carry an owner reference to the agent so that Kubernetes GC
+			// removes them on agent deletion. Legacy copies have no owner references.
+			if len(s.OwnerReferences) > 0 {
+				continue
+			}
+			// If the association namespace label matches the secret's actual namespace, this is
+			// the original secret in its home namespace - leave it alone.
+			if s.Labels[AgentAssociationLabelNamespace] == s.Namespace {
+				continue
+			}
+			if err := k8s.DeleteSecretIfExists(ctx, c, k8s.ExtractNamespacedName(s)); err != nil {
+				errs = errors.Join(errs, err)
+				continue
+			}
+			log.Info("Deleted legacy fleet-server additional secret copy", "secret_name", s.Name, "secret_namespace", s.Namespace)
+		}
+	}
+	return errs
+}

--- a/pkg/controller/association/controller/gc_test.go
+++ b/pkg/controller/association/controller/gc_test.go
@@ -1,0 +1,186 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	commonv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/common/v1"
+	eslabel "github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/label"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
+)
+
+func TestGarbageCollectLegacyFleetServerAdditionalSecrets(t *testing.T) {
+	const (
+		agentNS       = "agent-ns"
+		fleetServerNS = "fleet-ns"
+		sharedNS      = "shared-ns"
+		esName        = "es"
+		esNS          = "es-ns"
+	)
+
+	// fleetServerESLabels mimics the labels that copySecret propagates from the source CA/client-cert
+	// secret in the fleet server namespace. Those source secrets carry both the agent association labels
+	// (set by the fleet-server→ES association reconciler) and the ES cluster identity labels (set via
+	// AssociationResourceLabels), which the old copySecret function copies verbatim onto the copy.
+	fleetServerESLabels := func(fleetName, fleetNS string) map[string]string {
+		return map[string]string{
+			AgentAssociationLabelName:         fleetName,
+			AgentAssociationLabelNamespace:    fleetNS,
+			AgentAssociationLabelType:         commonv1.ElasticsearchAssociationType,
+			eslabel.ClusterNameLabelName:      esName,
+			eslabel.ClusterNamespaceLabelName: esNS,
+		}
+	}
+
+	for _, tt := range []struct {
+		name          string
+		secrets       []client.Object
+		managedNS     []string
+		wantDeleted   []string // secret names expected to be gone
+		wantPreserved []string // secret names expected to survive
+	}{
+		{
+			name: "cross-namespace legacy copies are deleted",
+			secrets: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Namespace: agentNS, Name: "fleet1-es-ca", Labels: fleetServerESLabels("fleet1", fleetServerNS)},
+				},
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Namespace: agentNS, Name: "fleet1-agent-es-xxx-client-cert", Labels: fleetServerESLabels("fleet1", fleetServerNS)},
+				},
+			},
+			managedNS:   []string{agentNS},
+			wantDeleted: []string{"fleet1-es-ca", "fleet1-agent-es-xxx-client-cert"},
+		},
+		{
+			name: "orphaned legacy copy with no agent objects present is still deleted",
+			secrets: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Namespace: agentNS, Name: "fleet1-es-ca", Labels: fleetServerESLabels("fleet1", fleetServerNS)},
+				},
+			},
+			managedNS:   []string{agentNS},
+			wantDeleted: []string{"fleet1-es-ca"},
+		},
+		{
+			name: "new-scheme copies with overridden labels survive",
+			secrets: []client.Object{
+				// New-scheme: agentassociation labels point to the agent, not the fleet server.
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: agentNS,
+						Name:      "agent1-agent-fleetserver-hashxxx-es-ca",
+						Labels: map[string]string{
+							AgentAssociationLabelName:      "agent1",
+							AgentAssociationLabelNamespace: agentNS,
+							AgentAssociationLabelType:      commonv1.FleetServerAssociationType,
+						},
+					},
+				},
+			},
+			managedNS:     []string{agentNS},
+			wantPreserved: []string{"agent1-agent-fleetserver-hashxxx-es-ca"},
+		},
+		{
+			name: "original CA in fleet-server namespace is not touched",
+			secrets: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Namespace: fleetServerNS, Name: "fleet1-es-ca", Labels: fleetServerESLabels("fleet1", fleetServerNS)},
+				},
+			},
+			managedNS:     []string{agentNS, fleetServerNS},
+			wantPreserved: []string{"fleet1-es-ca"},
+		},
+		{
+			name: "same-namespace secret preserved",
+			secrets: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Namespace: sharedNS, Name: "fleet1-es-ca", Labels: fleetServerESLabels("fleet1", sharedNS)},
+				},
+			},
+			managedNS:     []string{sharedNS},
+			wantPreserved: []string{"fleet1-es-ca"},
+		},
+		{
+			name: "secret with owner reference is skipped even if labels match",
+			secrets: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: agentNS, Name: "fleet1-es-ca",
+						Labels: fleetServerESLabels("fleet1", fleetServerNS),
+						OwnerReferences: []metav1.OwnerReference{
+							{APIVersion: "agent.k8s.elastic.co/v1alpha1", Kind: "Agent", Name: "agent1"},
+						},
+					},
+				},
+			},
+			managedNS:     []string{agentNS},
+			wantPreserved: []string{"fleet1-es-ca"},
+		},
+		{
+			name: "cross-namespace copies for two different fleet servers both deleted",
+			secrets: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Namespace: agentNS, Name: "fleet1-es-ca", Labels: fleetServerESLabels("fleet1", fleetServerNS)},
+				},
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Namespace: agentNS, Name: "fleet2-es-ca", Labels: fleetServerESLabels("fleet2", fleetServerNS)},
+				},
+			},
+			managedNS:   []string{agentNS},
+			wantDeleted: []string{"fleet1-es-ca", "fleet2-es-ca"},
+		},
+		{
+			name: "empty managedNamespaces sweeps all namespaces",
+			secrets: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Namespace: agentNS, Name: "fleet1-es-ca", Labels: fleetServerESLabels("fleet1", fleetServerNS)},
+				},
+			},
+			managedNS:   []string{}, // empty = all namespaces
+			wantDeleted: []string{"fleet1-es-ca"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			c := k8s.NewFakeClient(tt.secrets...)
+			require.NoError(t, GarbageCollectLegacyFleetServerAdditionalSecrets(context.Background(), c, tt.managedNS))
+			// Build name→namespace from input fixtures so the deleted-check is not tied to a hardcoded namespace.
+			secretNSByName := make(map[string]string, len(tt.secrets))
+			secretNSs := make([]string, 0, len(tt.secrets))
+			for _, obj := range tt.secrets {
+				secretNSByName[obj.GetName()] = obj.GetNamespace()
+				secretNSs = append(secretNSs, obj.GetNamespace())
+			}
+			for _, name := range tt.wantDeleted {
+				ns := secretNSByName[name]
+				var s corev1.Secret
+				err := c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: name}, &s)
+				require.True(t, apierrors.IsNotFound(err), "expected %q in namespace %q to be deleted, got: %v", name, ns, err)
+			}
+			// Collect the namespaces of all input secrets so the preserved-check works
+			// regardless of whether managedNS is empty (all-namespaces mode).
+			for _, name := range tt.wantPreserved {
+				found := false
+				for _, ns := range secretNSs {
+					var s corev1.Secret
+					if err := c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: name}, &s); err == nil {
+						found = true
+						break
+					}
+				}
+				require.True(t, found, "expected %q to be preserved", name)
+			}
+		})
+	}
+}

--- a/pkg/controller/association/dynamic_watches.go
+++ b/pkg/controller/association/dynamic_watches.go
@@ -127,10 +127,21 @@ func (r *Reconciler) reconcileWatches(ctx context.Context, associated types.Name
 				// Watch both the source secret and the copy in the association namespace
 				// so that changes on either side trigger reconciliation.
 				for _, sec := range secs {
-					toWatch = append(toWatch,
-						sec.Source,
-						types.NamespacedName{Name: sec.Source.Name, Namespace: association.GetNamespace()},
-					)
+					// Watch the source secret
+					toWatch = append(toWatch, sec.Source)
+					// Also watch the target copy in the association's namespace.
+					if sec.Source.Namespace == association.GetNamespace() {
+						// Same-namespace: source and target are the same secret, no second watch needed.
+						continue
+					}
+					targetName := sec.Source.Name
+					if sec.TargetName != "" {
+						targetName = sec.TargetName
+					}
+					toWatch = append(toWatch, types.NamespacedName{
+						Name:      targetName,
+						Namespace: association.GetNamespace(),
+					})
 				}
 			}
 			return toWatch, nil

--- a/pkg/controller/association/reconciler.go
+++ b/pkg/controller/association/reconciler.go
@@ -16,6 +16,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	toolsevents "k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -42,12 +43,22 @@ import (
 
 var defaultRequeue = reconcile.Result{RequeueAfter: reconciler.DefaultRequeue}
 
-// AdditionalSecret is a secret to be copied into an associated resource's namespace.
+// AdditionalSecretNamer is a Namer for transitive Elasticsearch secrets (CA copies and client
+// certificate copies) placed in fleet-managed agent namespaces. Secrets use DNS subdomain naming
+// (253 chars max) and can therefore be longer than label-constrained resource names.
+var AdditionalSecretNamer = name.NewSecretNamer()
+
+// AdditionalSecret describes one secret that should be copied into the associated resource's namespace.
+// The reconciler copies every descriptor returned by the AdditionalSecrets callback and GCs any stale
+// copies (those that are no longer returned) automatically via deleteStaleAdditionalSecrets.
 type AdditionalSecret struct {
 	// Source is the namespace/name of the secret to copy from (in the referenced resource's namespace).
 	Source types.NamespacedName
 	// Keys is an optional list of data keys to include in the copy; all keys are copied when empty.
 	Keys []string
+	// TargetName is the name to give the copy in the associated resource's namespace.
+	// Defaults to Source.Name when empty.
+	TargetName string
 }
 
 // AssociationInfo contains information specific to a particular associated resource (eg. Kibana, APMServer, etc.).
@@ -297,18 +308,9 @@ func (r *Reconciler) reconcileAssociation(ctx context.Context, association commo
 		return commonv1.AssociationPending, results.WithError(err) // maybe not created yet
 	}
 
-	var secretsHash hash.Hash32
-	if r.AdditionalSecrets != nil {
-		secretsHash = fnv.New32a()
-		additionalSecrets, err := r.AdditionalSecrets(ctx, r.Client, association)
-		if err != nil {
-			return commonv1.AssociationPending, results.WithError(err) // maybe not created yet
-		}
-		for _, sec := range additionalSecrets {
-			if err := copySecret(ctx, r.Client, secretsHash, association.GetNamespace(), sec.Source, sec.Keys); err != nil {
-				return commonv1.AssociationPending, results.WithError(err)
-			}
-		}
+	secretsHash, err := r.reconcileAdditionalSecrets(ctx, association)
+	if err != nil {
+		return commonv1.AssociationPending, results.WithError(err)
 	}
 
 	url, err := r.AssociationInfo.ExternalServiceURL(r.Client, association)
@@ -533,8 +535,53 @@ func (r *Reconciler) Unbind(ctx context.Context, association commonv1.Associatio
 		}
 	}
 
+	// Delete any per-agent additional secret copies (e.g. transitive ES CA) that
+	// live in the associated resource's namespace. Passing nil or an empty set deletes all copies.
+	if r.AdditionalSecrets != nil {
+		assocLabels := r.AssociationResourceLabels(k8s.ExtractNamespacedName(association), association.AssociationRef().NamespacedName())
+		if err := deleteStaleAdditionalSecrets(ctx, r.Client, association.GetNamespace(), assocLabels, nil); err != nil {
+			return err
+		}
+	}
+
 	// Also remove the association configuration
 	return RemoveAssociationConf(ctx, r.Client, association)
+}
+
+// reconcileAdditionalSecrets copies secrets required by the association into the associated
+// resource's namespace, hashes their content, and GCs any stale copies from previous reconciles.
+// Returns nil, nil when AdditionalSecrets is not configured for this association type.
+// If AdditionalSecrets returns an error the stale GC is intentionally skipped: existing copies
+// remain until the referenced resource is reachable again or Kubernetes GC removes them via the
+// owner references set on each copy.
+func (r *Reconciler) reconcileAdditionalSecrets(ctx context.Context, association commonv1.Association) (hash.Hash32, error) {
+	if r.AdditionalSecrets == nil {
+		return nil, nil
+	}
+	secretsHash := fnv.New32a()
+	additionalSecrets, err := r.AdditionalSecrets(ctx, r.Client, association)
+	if err != nil {
+		return nil, err
+	}
+	assocLabels := r.AssociationResourceLabels(k8s.ExtractNamespacedName(association), association.AssociationRef().NamespacedName())
+	copiedNames := sets.New[string]()
+	for _, sec := range additionalSecrets {
+		destName := sec.TargetName
+		if destName == "" {
+			destName = sec.Source.Name
+		}
+		copied, err := copySecret(ctx, r.Client, secretsHash, association.GetNamespace(), sec.Source, sec.Keys, destName, association.Associated(), assocLabels)
+		if err != nil {
+			return nil, err
+		}
+		if copied {
+			copiedNames.Insert(destName)
+		}
+	}
+	if err := deleteStaleAdditionalSecrets(ctx, r.Client, association.GetNamespace(), assocLabels, copiedNames); err != nil {
+		return nil, err
+	}
+	return secretsHash, nil
 }
 
 // updateAssocConf updates associated with the expected association conf.

--- a/pkg/controller/association/reconciler_test.go
+++ b/pkg/controller/association/reconciler_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -28,6 +29,7 @@ import (
 	kbv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/kibana/v1"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/comparison"
+	commonhash "github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/hash"
 	common_name "github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/name"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/operator"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/password/fixtures"
@@ -1149,6 +1151,7 @@ func TestReconciler_Reconcile_Transitive_Associations(t *testing.T) {
 				return nil, err
 			}
 			fleetServerRef := assoc.AssociationRef()
+			caTargetName := AdditionalSecretNamer.Suffix(associated.GetName(), "agent-fleetserver", commonhash.HashObject(fleetServerRef.NamespacedName()), "es-ca")
 			if !fleetServerRef.IsSet() {
 				return nil, nil
 			}
@@ -1156,9 +1159,6 @@ func TestReconciler_Reconcile_Transitive_Associations(t *testing.T) {
 			if err := c.Get(context.Background(), fleetServerRef.NamespacedName(), &fleetServer); err != nil {
 				return nil, err
 			}
-
-			// If the Fleet Server Agent is not associated with an Elasticsearch cluster
-			// (potentially because of a manual setup) we should do nothing.
 			if len(fleetServer.Spec.ElasticsearchRefs) == 0 {
 				return nil, nil
 			}
@@ -1166,7 +1166,6 @@ func TestReconciler_Reconcile_Transitive_Associations(t *testing.T) {
 			if err != nil {
 				return nil, err
 			}
-
 			conf, err := esAssociation.AssociationConf()
 			if err != nil {
 				return nil, err
@@ -1175,11 +1174,9 @@ func TestReconciler_Reconcile_Transitive_Associations(t *testing.T) {
 				return nil, nil
 			}
 			return []AdditionalSecret{{
-				Source: types.NamespacedName{
-					Namespace: fleetServer.Namespace,
-					Name:      conf.CASecretName,
-				},
-				Keys: []string{"ca.crt"},
+				Source:     types.NamespacedName{Namespace: fleetServer.Namespace, Name: conf.CASecretName},
+				Keys:       []string{"ca.crt"},
+				TargetName: caTargetName,
 			}}, nil
 		},
 	}
@@ -1339,18 +1336,33 @@ func TestReconciler_Reconcile_Transitive_Associations(t *testing.T) {
 			true,
 			"ca.crt", "tls.crt",
 		),
-		mkAgentSecret(
-			"fleet-server1-agent-es-default-es1-ca",
-			"agentNs",
-			"fleet-ns",
-			"fleet-server1",
-			"es-ns",
-			"es1",
-			false,
-			false,
-			true,
-			"ca.crt",
-		),
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      AdditionalSecretNamer.Suffix("agent1", "agent-fleetserver", commonhash.HashObject(types.NamespacedName{Name: "fleet-server1", Namespace: "fleet-ns"}), "es-ca"),
+				Namespace: "agentNs",
+				Labels: map[string]string{
+					"agent.k8s.elastic.co/name":                      "fleet-server1",
+					"agent.k8s.elastic.co/namespace":                 "fleet-ns",
+					"agentassociation.k8s.elastic.co/name":           "agent1",
+					"agentassociation.k8s.elastic.co/namespace":      "agentNs",
+					"agentassociation.k8s.elastic.co/type":           commonv1.FleetServerAssociationType,
+					AdditionalSecretLabelName:                        "true",
+					commonv1.RestrictWatchedResourcesLabelName:       commonv1.RestrictWatchedResourcesLabelValue,
+					"elasticsearch.k8s.elastic.co/cluster-name":      "es1",
+					"elasticsearch.k8s.elastic.co/cluster-namespace": "es-ns",
+				},
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion:         "agent.k8s.elastic.co/v1alpha1",
+						Kind:               "Agent",
+						Name:               "agent1",
+						Controller:         &varTrue,
+						BlockOwnerDeletion: &varTrue,
+					},
+				},
+			},
+			Data: map[string][]byte{"ca.crt": []byte("ca cert content")},
+		},
 	}
 
 	// initial reconciliation, all resources should be created
@@ -1361,7 +1373,7 @@ func TestReconciler_Reconcile_Transitive_Associations(t *testing.T) {
 
 	// get Agent resource and run checks
 	require.NoError(t, r.Get(context.Background(), k8s.ExtractNamespacedName(&agent), &agent))
-	checkSecrets(t, r, true, false, ref1ExpectedSecrets)
+	checkSecrets(t, r, true, true, ref1ExpectedSecrets)
 	checkAnnotations(t, agent, true, generateAnnotationName("fleet-ns", "fleet-server1"))
 	checkWatches(t, r.watches, true, false)
 	checkStatus(t, agent, false, "fleet-ns/fleet-server1")
@@ -1375,11 +1387,326 @@ func TestReconciler_Reconcile_Transitive_Associations(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, reconcile.Result{}, results)
 
-	// check whether clean up was done
-	// These aren't being removed properly....
-	// Temporarily disabling.
+	// Kubernetes GC removes per-agent copies via owner references when the agent is deleted.
+	// The fake client does not simulate GC, so this path is not covered by this test.
 	// checkSecrets(t, r, false, false, ref1ExpectedSecrets)
 	checkWatches(t, r.watches, false, true)
+}
+
+func TestReconciler_Reconcile_Transitive_SameNamespace(t *testing.T) {
+	const ns = "shared-ns"
+
+	caSecret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "fleet1-es-ca"},
+		Data:       map[string][]byte{"ca.crt": []byte("original-ca")},
+	}
+	fleetServer := agentv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "fleet1", Namespace: ns},
+		Spec:       agentv1alpha1.AgentSpec{Version: "7.7.0", FleetServerEnabled: true},
+	}
+	agent := agentv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "agent1", Namespace: ns},
+		Spec: agentv1alpha1.AgentSpec{
+			Version:        "7.7.0",
+			FleetServerRef: commonv1.FleetServerSelector{ObjectSelector: commonv1.ObjectSelector{Name: "fleet1", Namespace: ns}},
+		},
+	}
+	agent.GetAssociations()[0].SetAssociationConf(&commonv1.AssociationConf{
+		URL: "https://fleet1:8220",
+	})
+
+	info := AssociationInfo{
+		AssociationType:       commonv1.FleetServerAssociationType,
+		AssociatedObjTemplate: func() commonv1.Associated { return &agentv1alpha1.Agent{} },
+		ReferencedObjTemplate: func() client.Object { return &agentv1alpha1.Agent{} },
+		ReferencedResourceVersion: func(_ k8s.Client, _ commonv1.Association) (string, bool, error) {
+			return "7.7.0", false, nil
+		},
+		ExternalServiceURL: func(_ k8s.Client, _ commonv1.Association) (string, error) {
+			return "https://fleet1:8220", nil
+		},
+		ReferencedResourceNamer:               common_name.NewNamer("agent"),
+		AssociationName:                       "agent-fleetserver",
+		AssociatedShortName:                   "agent",
+		AssociationConfAnnotationNameBase:     commonv1.FleetServerConfigAnnotationNameBase,
+		AssociationResourceNameLabelName:      "agent.k8s.elastic.co/name",
+		AssociationResourceNamespaceLabelName: "agent.k8s.elastic.co/namespace",
+		Labels: func(associated types.NamespacedName) map[string]string {
+			return map[string]string{
+				"agentassociation.k8s.elastic.co/name":      associated.Name,
+				"agentassociation.k8s.elastic.co/namespace": associated.Namespace,
+				"agentassociation.k8s.elastic.co/type":      commonv1.FleetServerAssociationType,
+			}
+		},
+		// AdditionalSecrets returns a source in the agent namespace (same-namespace case):
+		// copySecret will hash the data but skip creating a copy.
+		AdditionalSecrets: func(_ context.Context, _ k8s.Client, _ commonv1.Association) ([]AdditionalSecret, error) {
+			return []AdditionalSecret{
+				{Source: types.NamespacedName{Namespace: ns, Name: "fleet1-es-ca"}, TargetName: "fleet1-es-ca"},
+			}, nil
+		},
+	}
+
+	r := Reconciler{
+		AssociationInfo: info,
+		Client:          k8s.NewFakeClient(&agent, &fleetServer, &caSecret),
+		accessReviewer:  rbac.NewPermissiveAccessReviewer(),
+		watches:         watches.NewDynamicWatches(),
+		recorder:        toolsevents.NewFakeRecorder(10),
+		Parameters: operator.Parameters{
+			OperatorInfo: about.OperatorInfo{BuildInfo: about.BuildInfo{Version: "1.4.0-unittest"}},
+		},
+	}
+
+	// First reconcile: CA source is in the same namespace as the agent — no copy should be created.
+	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: k8s.ExtractNamespacedName(&agent)})
+	require.NoError(t, err)
+
+	// Exactly one secret should exist (the original CA); no copy was created.
+	var secrets corev1.SecretList
+	require.NoError(t, r.List(context.Background(), &secrets, client.InNamespace(ns)))
+	require.Len(t, secrets.Items, 1, "exactly one secret should exist in the namespace after first reconcile (original CA only, no copy)")
+	require.Equal(t, "fleet1-es-ca", secrets.Items[0].Name)
+
+	// Read the agent annotation to capture the initial hash.
+	var updatedAgent agentv1alpha1.Agent
+	require.NoError(t, r.Get(context.Background(), k8s.ExtractNamespacedName(&agent), &updatedAgent))
+	assocAnnotation := updatedAgent.GetAssociations()[0].AssociationConfAnnotationName()
+	firstAnnotation := updatedAgent.Annotations[assocAnnotation]
+	require.NotEmpty(t, firstAnnotation, "association conf annotation must be set after first reconcile")
+
+	// Simulate CA rotation: update the CA secret with new data.
+	caSecret.Data = map[string][]byte{"ca.crt": []byte("rotated-ca")}
+	require.NoError(t, r.Update(context.Background(), &caSecret))
+
+	// Second reconcile after CA rotation: AdditionalSecretsHash must change to trigger a reconcile.
+	_, err = r.Reconcile(context.Background(), reconcile.Request{NamespacedName: k8s.ExtractNamespacedName(&agent)})
+	require.NoError(t, err)
+
+	require.NoError(t, r.Get(context.Background(), k8s.ExtractNamespacedName(&agent), &updatedAgent))
+	secondAnnotation := updatedAgent.Annotations[assocAnnotation]
+	require.NotEmpty(t, secondAnnotation, "association conf annotation must be set after second reconcile")
+	require.NotEqual(t, firstAnnotation, secondAnnotation, "AdditionalSecretsHash must change after CA rotation to trigger a reconcile")
+
+	// Still no copy — only the original secret should exist.
+	require.NoError(t, r.List(context.Background(), &secrets, client.InNamespace(ns)))
+	require.Len(t, secrets.Items, 1, "only the original CA secret should exist after CA rotation")
+	require.Equal(t, "fleet1-es-ca", secrets.Items[0].Name)
+}
+
+// TestReconciler_AdditionalSecrets_StaleDeleteOnConditionChange verifies that a per-agent secret
+// copy (e.g. transitive CA) is deleted when the condition that required it no longer holds
+// (e.g. CACertProvided transitions from true to false).
+func TestReconciler_AdditionalSecrets_StaleDeleteOnConditionChange(t *testing.T) {
+	const caTargetName = "agent1-transitive-es-ca"
+
+	caCertProvided := true
+
+	info := AssociationInfo{
+		AssociationType:       commonv1.FleetServerAssociationType,
+		AssociatedObjTemplate: func() commonv1.Associated { return &agentv1alpha1.Agent{} },
+		ReferencedObjTemplate: func() client.Object { return &agentv1alpha1.Agent{} },
+		ReferencedResourceVersion: func(c k8s.Client, association commonv1.Association) (string, bool, error) {
+			return "7.7.0", false, nil
+		},
+		ExternalServiceURL: func(c k8s.Client, assoc commonv1.Association) (string, error) {
+			return "https://fleet:8220", nil
+		},
+		ReferencedResourceNamer:               common_name.NewNamer("agent"),
+		AssociationName:                       "agent-fleetserver",
+		AssociatedShortName:                   "agent",
+		AssociationConfAnnotationNameBase:     commonv1.FleetServerConfigAnnotationNameBase,
+		AssociationResourceNameLabelName:      "agent.k8s.elastic.co/name",
+		AssociationResourceNamespaceLabelName: "agent.k8s.elastic.co/namespace",
+		Labels: func(associated types.NamespacedName) map[string]string {
+			return map[string]string{
+				"agentassociation.k8s.elastic.co/name":      associated.Name,
+				"agentassociation.k8s.elastic.co/namespace": associated.Namespace,
+				"agentassociation.k8s.elastic.co/type":      commonv1.FleetServerAssociationType,
+			}
+		},
+		AdditionalSecrets: func(ctx context.Context, c k8s.Client, assoc commonv1.Association) ([]AdditionalSecret, error) {
+			if !caCertProvided {
+				return nil, nil
+			}
+			return []AdditionalSecret{{
+				Source:     types.NamespacedName{Namespace: "fleet-ns", Name: "fleet-server1-es-ca"},
+				Keys:       []string{"ca.crt"},
+				TargetName: caTargetName,
+			}}, nil
+		},
+	}
+
+	agent := agentv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "agent1", Namespace: "agentNs"},
+		Spec: agentv1alpha1.AgentSpec{
+			Version:        "7.7.0",
+			FleetServerRef: commonv1.FleetServerSelector{ObjectSelector: commonv1.ObjectSelector{Name: "fleet-server1", Namespace: "fleet-ns"}},
+		},
+	}
+	agent.GetAssociations()[0].SetAssociationConf(&commonv1.AssociationConf{
+		URL:            "https://fleet:8220",
+		CACertProvided: true,
+	})
+
+	fleetAgent := agentv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "fleet-server1", Namespace: "fleet-ns"},
+		Spec: agentv1alpha1.AgentSpec{
+			Version:            "7.7.0",
+			FleetServerEnabled: true,
+		},
+	}
+
+	caSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "fleet-ns", Name: "fleet-server1-es-ca"},
+		Data:       map[string][]byte{"ca.crt": []byte("ca-data")},
+	}
+	// Simulate a stale per-agent CA copy left from when CACertProvided was true.
+	staleCAcopy := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "agentNs", Name: caTargetName},
+		Data:       map[string][]byte{"ca.crt": []byte("ca-data")},
+	}
+
+	r := Reconciler{
+		AssociationInfo: info,
+		Client:          k8s.NewFakeClient(&agent, &fleetAgent, caSecret, staleCAcopy),
+		accessReviewer:  rbac.NewPermissiveAccessReviewer(),
+		watches:         watches.NewDynamicWatches(),
+		recorder:        toolsevents.NewFakeRecorder(10),
+		Parameters: operator.Parameters{
+			OperatorInfo: about.OperatorInfo{
+				BuildInfo: about.BuildInfo{Version: "1.4.0-unittest"},
+			},
+		},
+	}
+
+	// First reconcile: caCertProvided=true → per-agent CA copy is created/refreshed.
+	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: k8s.ExtractNamespacedName(&agent)})
+	require.NoError(t, err)
+	var got corev1.Secret
+	require.NoError(t, r.Get(context.Background(), types.NamespacedName{Namespace: "agentNs", Name: caTargetName}, &got))
+	require.Len(t, got.OwnerReferences, 1)
+	require.Equal(t, "agent1", got.OwnerReferences[0].Name)
+
+	// Simulate CA being removed from the fleet server's ES association.
+	caCertProvided = false
+
+	// Second reconcile: caCertProvided=false → stale CA copy must be deleted.
+	_, err = r.Reconcile(context.Background(), reconcile.Request{NamespacedName: k8s.ExtractNamespacedName(&agent)})
+	require.NoError(t, err)
+	err = r.Get(context.Background(), types.NamespacedName{Namespace: "agentNs", Name: caTargetName}, &got)
+	require.True(t, apierrors.IsNotFound(err), "stale CA copy should have been deleted, got: %v", err)
+}
+
+// TestReconciler_AdditionalSecrets_CrossToSameNamespaceTransition verifies that a stale hashed
+// copy in the agent namespace is deleted when the topology transitions from cross-namespace to
+// same-namespace. In the same-namespace case copySecret returns copied=false, leaving copiedNames
+// empty, so deleteStaleAdditionalSecrets must remove all prior AdditionalSecretLabelName copies.
+func TestReconciler_AdditionalSecrets_CrossToSameNamespaceTransition(t *testing.T) {
+	const (
+		agentNS      = "agent-ns"
+		fleetNS      = "fleet-ns"
+		caTargetName = "agent1-agent-fleetserver-hashxxx-es-ca"
+	)
+
+	crossNS := true
+
+	info := AssociationInfo{
+		AssociationType:       commonv1.FleetServerAssociationType,
+		AssociatedObjTemplate: func() commonv1.Associated { return &agentv1alpha1.Agent{} },
+		ReferencedObjTemplate: func() client.Object { return &agentv1alpha1.Agent{} },
+		ReferencedResourceVersion: func(_ k8s.Client, _ commonv1.Association) (string, bool, error) {
+			return "7.7.0", false, nil
+		},
+		ExternalServiceURL: func(_ k8s.Client, _ commonv1.Association) (string, error) {
+			return "https://fleet:8220", nil
+		},
+		ReferencedResourceNamer:               common_name.NewNamer("agent"),
+		AssociationName:                       "agent-fleetserver",
+		AssociatedShortName:                   "agent",
+		AssociationConfAnnotationNameBase:     commonv1.FleetServerConfigAnnotationNameBase,
+		AssociationResourceNameLabelName:      "agent.k8s.elastic.co/name",
+		AssociationResourceNamespaceLabelName: "agent.k8s.elastic.co/namespace",
+		Labels: func(associated types.NamespacedName) map[string]string {
+			return map[string]string{
+				"agentassociation.k8s.elastic.co/name":      associated.Name,
+				"agentassociation.k8s.elastic.co/namespace": associated.Namespace,
+				"agentassociation.k8s.elastic.co/type":      commonv1.FleetServerAssociationType,
+			}
+		},
+		AdditionalSecrets: func(_ context.Context, _ k8s.Client, _ commonv1.Association) ([]AdditionalSecret, error) {
+			if crossNS {
+				return []AdditionalSecret{{
+					Source:     types.NamespacedName{Namespace: fleetNS, Name: "fleet1-es-ca"},
+					Keys:       []string{"ca.crt"},
+					TargetName: caTargetName,
+				}}, nil
+			}
+			// Same-namespace: copySecret will see source.Namespace == targetNamespace and skip copying.
+			return []AdditionalSecret{{
+				Source:     types.NamespacedName{Namespace: agentNS, Name: "fleet1-es-ca"},
+				Keys:       []string{"ca.crt"},
+				TargetName: "fleet1-es-ca",
+			}}, nil
+		},
+	}
+
+	agent := agentv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "agent1", Namespace: agentNS},
+		Spec: agentv1alpha1.AgentSpec{
+			Version:        "7.7.0",
+			FleetServerRef: commonv1.FleetServerSelector{ObjectSelector: commonv1.ObjectSelector{Name: "fleet1", Namespace: fleetNS}},
+		},
+	}
+	agent.GetAssociations()[0].SetAssociationConf(&commonv1.AssociationConf{URL: "https://fleet:8220"})
+
+	fleetAgent := agentv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "fleet1", Namespace: fleetNS},
+		Spec:       agentv1alpha1.AgentSpec{Version: "7.7.0", FleetServerEnabled: true},
+	}
+
+	// Pre-create CA secrets in both namespaces so both reconcile phases can read from their source.
+	caInFleetNS := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: fleetNS, Name: "fleet1-es-ca"},
+		Data:       map[string][]byte{"ca.crt": []byte("ca-data")},
+	}
+	caInAgentNS := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: agentNS, Name: "fleet1-es-ca"},
+		Data:       map[string][]byte{"ca.crt": []byte("ca-data")},
+	}
+
+	r := Reconciler{
+		AssociationInfo: info,
+		Client:          k8s.NewFakeClient(&agent, &fleetAgent, caInFleetNS, caInAgentNS),
+		accessReviewer:  rbac.NewPermissiveAccessReviewer(),
+		watches:         watches.NewDynamicWatches(),
+		recorder:        toolsevents.NewFakeRecorder(10),
+		Parameters: operator.Parameters{
+			OperatorInfo: about.OperatorInfo{BuildInfo: about.BuildInfo{Version: "1.4.0-unittest"}},
+		},
+	}
+
+	// First reconcile: cross-namespace → hashed copy is created in agent-ns.
+	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: k8s.ExtractNamespacedName(&agent)})
+	require.NoError(t, err)
+	var secretCopy corev1.Secret
+	require.NoError(t, r.Get(context.Background(), types.NamespacedName{Namespace: agentNS, Name: caTargetName}, &secretCopy),
+		"hashed CA copy must exist in agent-ns after cross-namespace reconcile")
+
+	// Transition: fleet server moves to agent-ns (same namespace). Switch AdditionalSecrets to return
+	// the same-namespace source; copySecret will skip the copy, leaving copiedNames empty.
+	crossNS = false
+
+	// Second reconcile: same-namespace → hashed copy must be deleted, original in agent-ns preserved.
+	_, err = r.Reconcile(context.Background(), reconcile.Request{NamespacedName: k8s.ExtractNamespacedName(&agent)})
+	require.NoError(t, err)
+
+	err = r.Get(context.Background(), types.NamespacedName{Namespace: agentNS, Name: caTargetName}, &secretCopy)
+	require.True(t, apierrors.IsNotFound(err), "stale hashed CA copy must be deleted after topology transition, got: %v", err)
+
+	var original corev1.Secret
+	require.NoError(t, r.Get(context.Background(), types.NamespacedName{Namespace: agentNS, Name: "fleet1-es-ca"}, &original),
+		"original CA in agent-ns must be preserved after topology transition")
 }
 
 func checkSecrets(t *testing.T, client k8s.Client, expected bool, withOwnerRefs bool, secrets ...[]corev1.Secret) {
@@ -1590,19 +1917,38 @@ func TestReconciler_ReconcileSecretRef(t *testing.T) {
 	require.Equal(t, commonv1.AssociationEstablished, updatedKibana.Status.AssociationStatus)
 }
 
-// TestReconciler_Unbind_ServiceAccountTokens verifies that Unbind deletes both the
-// Elasticsearch-side and application-side service-account-token secrets so that a
-// revoked cross-namespace association cannot continue to authenticate against ES.
-func TestReconciler_Unbind_ServiceAccountTokens(t *testing.T) {
-	// Labels that both SA token secrets carry from the association metadata.
+// sameNSReconciler returns a Reconciler wired with AdditionalSecrets that returns a single hash-only entry
+// (Source.Namespace == association.GetNamespace()), simulating a same-namespace agent→fleet-server association.
+func sameNSReconciler(objs ...client.Object) Reconciler {
+	const ns = "shared-ns"
+	return Reconciler{
+		AssociationInfo: AssociationInfo{
+			Labels:                                func(types.NamespacedName) map[string]string { return nil },
+			AssociationResourceNameLabelName:      "test",
+			AssociationResourceNamespaceLabelName: "test-ns",
+			ReferencedResourceNamer:               common_name.NewNamer("agent"),
+			AdditionalSecrets: func(_ context.Context, _ k8s.Client, _ commonv1.Association) ([]AdditionalSecret, error) {
+				// Hash-only entry: Source.Namespace == agent namespace — no cross-namespace copy.
+				return []AdditionalSecret{
+					{Source: types.NamespacedName{Namespace: ns, Name: "fleet1-es-ca"}, TargetName: "fleet1-es-ca"},
+				}, nil
+			},
+		},
+		Client:  k8s.NewFakeClient(objs...),
+		watches: watches.NewDynamicWatches(),
+	}
+}
+
+func TestReconciler_Unbind(t *testing.T) {
+	const sharedNS = "shared-ns"
+
+	// Fixtures for the SA-token case.
 	assocResourceLabels := map[string]string{
 		"elasticsearch.k8s.elastic.co/cluster-name":      sampleES.Name,
 		"elasticsearch.k8s.elastic.co/cluster-namespace": sampleES.Namespace,
 		"kibanaassociation.k8s.elastic.co/name":          "kbname",
 		"kibanaassociation.k8s.elastic.co/namespace":     kibanaNamespace,
 	}
-
-	// ES-side SA token secret: Elasticsearch reads this to validate the bearer token.
 	esTokenSecret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: esNamespace,
@@ -1616,9 +1962,6 @@ func TestReconciler_Unbind_ServiceAccountTokens(t *testing.T) {
 			},
 		},
 	}
-
-	// Application-side SA token secret: holds the bearer token value, lives in the associated namespace.
-	// secretKey(kb.EsAssociation(), "kibana-user") = {Namespace: kibanaNamespace, Name: "kbname-kibana-user"}.
 	appTokenSecret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: kibanaNamespace,
@@ -1632,20 +1975,134 @@ func TestReconciler_Unbind_ServiceAccountTokens(t *testing.T) {
 			},
 		},
 	}
-
 	kb := sampleKibanaWithESRef()
-	r := testReconciler(&sampleES, &kb, &esTokenSecret, &appTokenSecret)
 
-	err := r.Unbind(context.Background(), kb.EsAssociation())
-	require.NoError(t, err)
+	// Fixtures for the same-namespace case.
+	caSecret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: sharedNS, Name: "fleet1-es-ca"},
+		Data:       map[string][]byte{"ca.crt": []byte("CACERT")},
+	}
+	sameNSAgent := agentv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "agent1", Namespace: sharedNS},
+		Spec: agentv1alpha1.AgentSpec{
+			FleetServerRef: commonv1.FleetServerSelector{
+				ObjectSelector: commonv1.ObjectSelector{Name: "fleet1", Namespace: sharedNS},
+			},
+		},
+	}
 
-	// ES-side token secret must be deleted to revoke Elasticsearch access.
-	var esSecret corev1.Secret
-	err = r.Client.Get(context.Background(), k8s.ExtractNamespacedName(&esTokenSecret), &esSecret)
-	require.True(t, apierrors.IsNotFound(err), "ES-side SA token secret should have been deleted by Unbind")
+	// Fixtures for the cross-namespace case.
+	const agentNS, fleetNS = "agent-ns", "fleet-ns"
+	caCopy := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: agentNS,
+			Name:      "fleet1-es-ca-copy",
+			Labels: map[string]string{
+				AdditionalSecretLabelName: "true",
+				// These match what AssociationResourceLabels produces for the test reconciler
+				// (AssociationResourceNameLabelName="test", fleet server ref name="fleet1"/"fleet-ns").
+				"test":    "fleet1",
+				"test-ns": "fleet-ns",
+			},
+		},
+		Data: map[string][]byte{"ca.crt": []byte("CACERT")},
+	}
+	crossNSAgent := agentv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "agent1", Namespace: agentNS},
+		Spec: agentv1alpha1.AgentSpec{
+			FleetServerRef: commonv1.FleetServerSelector{
+				ObjectSelector: commonv1.ObjectSelector{Name: "fleet1", Namespace: fleetNS},
+			},
+		},
+	}
 
-	// Application-side token secret must also be deleted.
-	var appSecret corev1.Secret
-	err = r.Client.Get(context.Background(), k8s.ExtractNamespacedName(&appTokenSecret), &appSecret)
-	require.True(t, apierrors.IsNotFound(err), "Application-side SA token secret should have been deleted by Unbind")
+	for _, tt := range []struct {
+		name  string
+		setup func() (Reconciler, commonv1.Association)
+		check func(t *testing.T, r Reconciler)
+	}{
+		{
+			// Unbind must delete both sides of the SA token pair so that a revoked association
+			// cannot continue to authenticate against Elasticsearch.
+			name: "SA token secrets are deleted",
+			setup: func() (Reconciler, commonv1.Association) {
+				return testReconciler(&sampleES, &kb, &esTokenSecret, &appTokenSecret), kb.EsAssociation()
+			},
+			check: func(t *testing.T, r Reconciler) {
+				t.Helper()
+				var esSecret corev1.Secret
+				err := r.Client.Get(context.Background(), k8s.ExtractNamespacedName(&esTokenSecret), &esSecret)
+				require.True(t, apierrors.IsNotFound(err), "ES-side SA token secret should have been deleted by Unbind")
+				var appSecret corev1.Secret
+				err = r.Client.Get(context.Background(), k8s.ExtractNamespacedName(&appTokenSecret), &appSecret)
+				require.True(t, apierrors.IsNotFound(err), "Application-side SA token secret should have been deleted by Unbind")
+			},
+		},
+		{
+			name: "original CA secret survives when agent and fleet server share a namespace",
+			setup: func() (Reconciler, commonv1.Association) {
+				return sameNSReconciler(&sameNSAgent, &caSecret), sameNSAgent.GetAssociations()[0]
+			},
+			check: func(t *testing.T, r Reconciler) {
+				t.Helper()
+				var got corev1.Secret
+				err := r.Client.Get(context.Background(), k8s.ExtractNamespacedName(&caSecret), &got)
+				assert.NoError(t, err, "original CA secret must survive Unbind when agent and fleet server share a namespace")
+			},
+		},
+		{
+			name: "cross-namespace CA copy is deleted",
+			setup: func() (Reconciler, commonv1.Association) {
+				r := Reconciler{
+					AssociationInfo: AssociationInfo{
+						Labels:                                func(types.NamespacedName) map[string]string { return nil },
+						AssociationResourceNameLabelName:      "test",
+						AssociationResourceNamespaceLabelName: "test-ns",
+						ReferencedResourceNamer:               common_name.NewNamer("agent"),
+						AdditionalSecrets: func(_ context.Context, _ k8s.Client, _ commonv1.Association) ([]AdditionalSecret, error) {
+							return []AdditionalSecret{
+								{Source: types.NamespacedName{Namespace: fleetNS, Name: "fleet1-es-ca"}, TargetName: caCopy.Name},
+							}, nil
+						},
+					},
+					Client:  k8s.NewFakeClient(&crossNSAgent, &caCopy),
+					watches: watches.NewDynamicWatches(),
+				}
+				return r, crossNSAgent.GetAssociations()[0]
+			},
+			check: func(t *testing.T, r Reconciler) {
+				t.Helper()
+				var got corev1.Secret
+				err := r.Client.Get(context.Background(), k8s.ExtractNamespacedName(&caCopy), &got)
+				require.True(t, apierrors.IsNotFound(err), "cross-namespace CA copy must be deleted by Unbind")
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			r, assoc := tt.setup()
+			require.NoError(t, r.Unbind(context.Background(), assoc))
+			tt.check(t, r)
+		})
+	}
+}
+
+func TestReconcileWatches_SameNamespace_WatchRegistered(t *testing.T) {
+	const ns = "shared-ns"
+
+	agent := agentv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "agent1", Namespace: ns},
+		Spec: agentv1alpha1.AgentSpec{
+			FleetServerRef: commonv1.FleetServerSelector{
+				ObjectSelector: commonv1.ObjectSelector{Name: "fleet1", Namespace: ns},
+			},
+		},
+	}
+	assoc := agent.GetAssociations()[0]
+
+	r := sameNSReconciler(&agent)
+	agentNSN := types.NamespacedName{Namespace: ns, Name: "agent1"}
+	require.NoError(t, r.reconcileWatches(context.Background(), agentNSN, []commonv1.Association{assoc}))
+
+	assert.Contains(t, r.watches.Secrets.Registrations(), additionalSecretWatchName(agentNSN),
+		"additional-secret watch must be registered even when agent and fleet server share a namespace")
 }

--- a/pkg/controller/association/secret.go
+++ b/pkg/controller/association/secret.go
@@ -11,17 +11,20 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash"
+	"maps"
 	"net/http"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/common/v1"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/certificates"
 	commonhash "github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/hash"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/reconciler"
-	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/client"
+	esClient "github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/client"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
 	ulog "github.com/elastic/cloud-on-k8s/v3/pkg/utils/log"
 )
@@ -39,6 +42,11 @@ const (
 	AuthTypeUnmanagedBasic = iota
 	AuthTypeUnmanagedAPIKey
 )
+
+// AdditionalSecretLabelName marks secrets created as cross-namespace copies by the additional-secrets
+// mechanism. deleteStaleAdditionalSecrets uses this label (combined with association labels) to find
+// and GC copies that are no longer needed.
+const AdditionalSecretLabelName = "association.k8s.elastic.co/additional-secret"
 
 // ExpectedConfigFromUnmanagedAssociation returns the association configuration to associate the external unmanaged resource referenced
 // in the given association.
@@ -172,7 +180,7 @@ func (r UnmanagedAssociationConnectionInfo) Request(path string, out any) error 
 	}
 
 	httpClient := &http.Client{
-		Timeout: client.DefaultESClientTimeout,
+		Timeout: esClient.DefaultESClientTimeout,
 	}
 	// configure CA if it exists
 	if r.CaCert != "" {
@@ -224,14 +232,26 @@ func filterManagedElasticRef(associations []commonv1.Association) []commonv1.Ass
 	return r
 }
 
-// copySecret hashes the source secret data (restricted to keys when non-empty) and, when
-// targetNamespace differs from the source namespace, reconciles a copy of the secret there.
-// The hash is always written so that AdditionalSecretsHash reflects CA cert changes even
-// when source and target share a namespace.
-func copySecret(ctx context.Context, client k8s.Client, secHash hash.Hash, targetNamespace string, source types.NamespacedName, keys []string) error {
+// copySecret copies the source secret into targetNamespace under destName, hashing the
+// (filtered) source data into secHash. Keys restricts which data keys are included; all keys
+// are copied when empty. extraLabels are merged onto the source labels. owner is set as the
+// controller owner reference so Kubernetes GC removes the copy on deletion.
+// Returns true when a secret reconciliation is issued (source and target in different namespaces),
+// false when both share a namespace (hash-only path, no Secret is written).
+func copySecret(
+	ctx context.Context,
+	c k8s.Client,
+	secHash hash.Hash,
+	targetNamespace string,
+	source types.NamespacedName,
+	keys []string,
+	targetName string,
+	owner client.Object,
+	extraLabels map[string]string,
+) (bool, error) {
 	var original corev1.Secret
-	if err := client.Get(ctx, source, &original); err != nil {
-		return err
+	if err := c.Get(ctx, source, &original); err != nil {
+		return false, err
 	}
 
 	data := original.Data
@@ -251,14 +271,19 @@ func copySecret(ctx context.Context, client k8s.Client, secHash hash.Hash, targe
 	// the CA cert (the only field that actually reaches pods) has not changed.
 	commonhash.WriteHashObject(secHash, data)
 	if targetNamespace == original.Namespace {
-		return nil
+		return false, nil
 	}
+
+	merged := make(map[string]string, len(original.Labels)+len(extraLabels)+1)
+	maps.Copy(merged, original.Labels)
+	maps.Copy(merged, extraLabels)
+	merged[AdditionalSecretLabelName] = "true"
 
 	expected := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        original.Name,
+			Name:        targetName,
 			Namespace:   targetNamespace,
-			Labels:      original.Labels,
+			Labels:      merged,
 			Annotations: original.Annotations,
 		},
 		Data: data,
@@ -268,6 +293,34 @@ func copySecret(ctx context.Context, client k8s.Client, secHash hash.Hash, targe
 	// kubectl.kubernetes.io/last-applied-configuration embeds the full original Secret
 	// manifest as base64, which would re-expose any credential fields that were filtered
 	// out of Data. Always drop it unconditionally.
-	_, err := reconciler.ReconcileSecret(ctx, client, expected, nil, reconciler.WithAnnotationsToRemove(corev1.LastAppliedConfigAnnotation))
-	return err
+	if _, err := reconciler.ReconcileSecret(ctx, c, expected, owner,
+		reconciler.WithAnnotationsToRemove(corev1.LastAppliedConfigAnnotation)); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// deleteStaleAdditionalSecrets lists secrets in targetNamespace that carry AdditionalSecretLabelName
+// and the given assocLabels, then deletes those whose name is not in copiedNames.
+// copiedNames holds the names of copies that must be preserved; any copy absent from the set is
+// deleted. Pass nil to delete all matching copies (used by Unbind).
+func deleteStaleAdditionalSecrets(ctx context.Context, c client.Client, targetNamespace string, assocLabels map[string]string, copiedNames sets.Set[string]) error {
+	selector := make(client.MatchingLabels, len(assocLabels)+1)
+	maps.Copy(selector, assocLabels)
+	selector[AdditionalSecretLabelName] = "true"
+
+	var secrets corev1.SecretList
+	if err := c.List(ctx, &secrets, client.InNamespace(targetNamespace), selector); err != nil {
+		return err
+	}
+	for i := range secrets.Items {
+		if exists := copiedNames.Has(secrets.Items[i].Name); exists {
+			continue
+		}
+		if err := k8s.DeleteSecretIfExists(ctx, c, k8s.ExtractNamespacedName(&secrets.Items[i])); err != nil {
+			return err
+		}
+		ulog.FromContext(ctx).V(1).Info("Deleted stale additional secret copy", "secret_namespace", secrets.Items[i].Namespace, "secret_name", secrets.Items[i].Name)
+	}
+	return nil
 }

--- a/pkg/controller/association/secret_test.go
+++ b/pkg/controller/association/secret_test.go
@@ -12,8 +12,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/common/v1"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
@@ -212,7 +214,8 @@ func TestCopySecret(t *testing.T) {
 	hashOf := func(t *testing.T, secret *corev1.Secret, keys []string) uint32 {
 		t.Helper()
 		h := fnv.New32a()
-		require.NoError(t, copySecret(context.Background(), k8s.NewFakeClient(secret), h, "dst-ns", srcNSN, keys))
+		_, err := copySecret(context.Background(), k8s.NewFakeClient(secret), h, "dst-ns", srcNSN, keys, srcNSN.Name, nil, nil)
+		require.NoError(t, err)
 		return h.Sum32()
 	}
 
@@ -232,24 +235,33 @@ func TestCopySecret(t *testing.T) {
 		name                string
 		srcSecret           *corev1.Secret
 		existingTarget      *corev1.Secret
+		targetNamespace     string // defaults to "dst-ns" when empty
+		targetName          string // defaults to srcNSN.Name when empty
 		keys                []string
+		owner               client.Object
+		extraLabels         map[string]string
+		wantCopied          bool
 		wantKeys            []string
 		wantMissKeys        []string
 		wantMissAnnotations []string
 		wantAnnotations     map[string]string
+		wantLabels          map[string]string
+		wantOwnerName       string
 		wantHash            *uint32
 		wantHashNot         *uint32
 	}{
 		{
-			name:      "no filter: all keys copied",
-			srcSecret: externalESSecret,
-			keys:      nil,
-			wantKeys:  []string{"ca.crt", "url", "username", "password"},
+			name:       "no filter: all keys copied",
+			srcSecret:  externalESSecret,
+			keys:       nil,
+			wantCopied: true,
+			wantKeys:   []string{"ca.crt", "url", "username", "password"},
 		},
 		{
 			name:                "no filter: last-applied-configuration stripped",
 			srcSecret:           secretWithLastApplied,
 			keys:                nil,
+			wantCopied:          true,
 			wantKeys:            []string{"ca.crt", "url", "username", "password"},
 			wantMissAnnotations: []string{corev1.LastAppliedConfigAnnotation},
 			wantAnnotations:     map[string]string{"other-annotation": "keep-me"},
@@ -258,6 +270,7 @@ func TestCopySecret(t *testing.T) {
 			name:         "ca.crt filter: only ca.crt copied, credentials absent",
 			srcSecret:    externalESSecret,
 			keys:         []string{"ca.crt"},
+			wantCopied:   true,
 			wantKeys:     []string{"ca.crt"},
 			wantMissKeys: []string{"url", "username", "password"},
 			wantHashNot:  &hashNoFilter,
@@ -268,6 +281,7 @@ func TestCopySecret(t *testing.T) {
 			name:         "password rotation does not change hash when ca.crt filter is active",
 			srcSecret:    rotated,
 			keys:         []string{"ca.crt"},
+			wantCopied:   true,
 			wantKeys:     []string{"ca.crt"},
 			wantMissKeys: []string{"url", "username", "password"},
 			wantHash:     &hashCAFilter,
@@ -276,6 +290,7 @@ func TestCopySecret(t *testing.T) {
 			name:         "absent key in filter is skipped with a debug log",
 			srcSecret:    externalESSecret,
 			keys:         []string{"ca.crt", "nonexistent-key"},
+			wantCopied:   true,
 			wantKeys:     []string{"ca.crt"},
 			wantMissKeys: []string{"nonexistent-key", "url", "username", "password"},
 		},
@@ -285,6 +300,7 @@ func TestCopySecret(t *testing.T) {
 			name:                "last-applied-configuration annotation stripped, other annotations kept",
 			srcSecret:           secretWithLastApplied,
 			keys:                []string{"ca.crt"},
+			wantCopied:          true,
 			wantKeys:            []string{"ca.crt"},
 			wantMissAnnotations: []string{corev1.LastAppliedConfigAnnotation},
 			wantAnnotations:     map[string]string{"other-annotation": "keep-me"},
@@ -303,8 +319,47 @@ func TestCopySecret(t *testing.T) {
 				Data: map[string][]byte{"ca.crt": []byte("CACERT")},
 			},
 			keys:                []string{"ca.crt"},
+			wantCopied:          true,
 			wantKeys:            []string{"ca.crt"},
 			wantMissAnnotations: []string{corev1.LastAppliedConfigAnnotation},
+		},
+		{
+			name:          "owner reference is set on copy",
+			srcSecret:     externalESSecret,
+			keys:          []string{"ca.crt"},
+			owner:         &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "agent1", Namespace: "dst-ns", UID: "test-uid"}},
+			wantCopied:    true,
+			wantKeys:      []string{"ca.crt"},
+			wantOwnerName: "agent1",
+		},
+		{
+			name: "extra labels are merged onto source labels in copy",
+			srcSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: srcNSN.Namespace, Name: srcNSN.Name,
+					Labels: map[string]string{"src-label": "src-value"},
+				},
+				Data: map[string][]byte{"ca.crt": []byte("CACERT")},
+			},
+			extraLabels: map[string]string{"extra-label": "extra-value"},
+			wantCopied:  true,
+			wantKeys:    []string{"ca.crt"},
+			wantLabels:  map[string]string{"src-label": "src-value", "extra-label": "extra-value"},
+		},
+		{
+			name:            "same-namespace: hash written, no copy created",
+			srcSecret:       externalESSecret,
+			keys:            []string{"ca.crt"},
+			targetNamespace: srcNSN.Namespace,
+			wantCopied:      false,
+		},
+		{
+			name:       "custom targetName: copy created under targetName, not source name",
+			srcSecret:  externalESSecret,
+			keys:       []string{"ca.crt"},
+			targetName: "agent1-agent-fleetserver-hashxxx-es-ca",
+			wantCopied: true,
+			wantKeys:   []string{"ca.crt"},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -314,11 +369,32 @@ func TestCopySecret(t *testing.T) {
 			} else {
 				fakeClient = k8s.NewFakeClient(tt.srcSecret)
 			}
+			targetNS := tt.targetNamespace
+			if targetNS == "" {
+				targetNS = "dst-ns"
+			}
+			tgtName := tt.targetName
+			if tgtName == "" {
+				tgtName = srcNSN.Name
+			}
 			h := fnv.New32a()
-			require.NoError(t, copySecret(context.Background(), fakeClient, h, "dst-ns", srcNSN, tt.keys))
+			wasCopied, err := copySecret(context.Background(), fakeClient, h, targetNS, srcNSN, tt.keys, tgtName, tt.owner, tt.extraLabels)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantCopied, wasCopied)
+			if !tt.wantCopied {
+				return
+			}
 
 			var copied corev1.Secret
-			require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "dst-ns", Name: srcNSN.Name}, &copied))
+			require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{Namespace: targetNS, Name: tgtName}, &copied))
+			// copySecret must always mark cross-namespace copies so deleteStaleAdditionalSecrets can GC them.
+			assert.Equal(t, "true", copied.Labels[AdditionalSecretLabelName], "cross-namespace copy must carry AdditionalSecretLabelName label")
+			if tt.targetName != "" {
+				// Confirm the copy does NOT exist under the source name when targetName overrides it.
+				var ghost corev1.Secret
+				err := fakeClient.Get(context.Background(), types.NamespacedName{Namespace: targetNS, Name: srcNSN.Name}, &ghost)
+				assert.True(t, apierrors.IsNotFound(err), "copy must not exist under source name %q when targetName %q overrides it", srcNSN.Name, tt.targetName)
+			}
 
 			for _, key := range tt.wantKeys {
 				assert.Contains(t, copied.Data, key, "expected key %q in copied secret", key)
@@ -331,6 +407,13 @@ func TestCopySecret(t *testing.T) {
 			}
 			for k, v := range tt.wantAnnotations {
 				assert.Equal(t, v, copied.Annotations[k], "annotation %q must be preserved in copied secret", k)
+			}
+			for k, v := range tt.wantLabels {
+				assert.Equal(t, v, copied.Labels[k], "label %q must be present in copied secret", k)
+			}
+			if tt.wantOwnerName != "" {
+				require.Len(t, copied.OwnerReferences, 1)
+				assert.Equal(t, tt.wantOwnerName, copied.OwnerReferences[0].Name)
 			}
 			if tt.wantHash != nil {
 				assert.Equal(t, *tt.wantHash, h.Sum32())


### PR DESCRIPTION
## Summary

The agent-fleetserver association controller copies additional secrets (the fleet server's Elasticsearch CA and any user-provided client certificate) from the fleet server's namespace into the fleet-managed agent's namespace. Three root-cause problems existed in this path, all stemming from how `copySecret` constructed the destination secret.

- **No owner reference.** The copy was created without an owner reference, so Kubernetes GC never removed it when the agent was deleted. The generic orphan cleanup also could not match it because the copy carried labels from the source secret, not from the downstream agent association.
- **Name derived from the source secret only.** The destination name was always `Source.Name`. Multiple fleet-managed agents in the same namespace pointing to fleet servers with identically-named CA secrets would overwrite each other's copy. And because the name carried no per-agent identity, removing one agent's association would not know which copy (if any) belonged exclusively to it.
- **No per-reconcile GC.** When a condition changed - for example `CACertProvided` transitioning false after Elasticsearch TLS was disabled - the stale copy was never removed from the agent namespace.

Fixes #9681.

## Changes

**Collision-free naming for cross-namespace copies.** The `AdditionalSecret` struct gains a `TargetName` field. For cross-namespace fleet-server additional secrets the target name is `<agent-name>-agent-fleetserver-<hash(fleet-server-namespace/name)>-<suffix>`, which is unique per (agent, fleet-server) pair and embeds the fleet server's namespaced name to prevent collisions. For same-namespace deployments no copy is created - the secret data is only hashed into `AdditionalSecretsHash` to keep the pod roll trigger working.

**Owner references on copies.** Cross-namespace copies now set the fleet-managed agent as their controller owner reference. Kubernetes GC therefore removes copies automatically when the agent resource is deleted.

**Per-reconcile stale copy GC.** After processing `AdditionalSecrets`, the reconciler calls `deleteStaleAdditionalSecrets`, which lists secrets in the agent namespace that carry the new `association.k8s.elastic.co/additional-secret=true` marker label and the association labels, then deletes any whose name is not in the current set of active copies. This handles mid-lifecycle condition changes (CA removed, client cert reference removed) without requiring an operator restart.

**Cleanup on Unbind.** `Reconciler.Unbind` now calls `deleteStaleAdditionalSecrets` with a nil keep-set to remove all cross-namespace copies when the association itself is unbound (e.g. the agent removes or changes its `fleetServerRef`).

**CA secret name propagated through the transitive ES ref.** `TransitiveESRef` gains a `CASecretName` field alongside the existing `ClientCertSecretName`. The agent-fleetserver controller populates it with the name the CA copy will have in the agent's namespace (original name for same-namespace, hashed name for cross-namespace). The agent driver reads both fields and passes `CASecretName` to `applyRelatedEsAssoc`, which mounts it instead of the CA name from the agent's own ES association conf. This ensures the pod mounts the correct secret in both deployment topologies and rolls when its content changes.

**One-shot migration GC at startup.** `GarbageCollectLegacyFleetServerAdditionalSecrets` runs once during operator startup to clean up copies created by older ECK versions. It identifies secrets in agent namespaces that carry the old-scheme labels (fleet server's Elasticsearch association labels, no owner references) and deletes them.
