### PR TITLE
update GKE Kubernetes version from 1.33 to 1.34 in deployer plans

### DIFF
--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -3,7 +3,7 @@ plans:
   operation: create
   clusterName: ci
   provider: gke
-  kubernetesVersion: 1.33
+  kubernetesVersion: 1.34
   machineType: n1-standard-4
   serviceAccount: true
   enforceSecurityPolicies: true
@@ -18,7 +18,7 @@ plans:
   operation: create
   clusterName: ci-autopilot
   provider: gke
-  kubernetesVersion: 1.33
+  kubernetesVersion: 1.34
   serviceAccount: true
   enforceSecurityPolicies: true
   # this is disabled in autopilot: container provisioner is privileged; not allowed in Autopilot
@@ -31,7 +31,7 @@ plans:
   operation: create
   clusterName: dev
   provider: gke
-  kubernetesVersion: 1.33
+  kubernetesVersion: 1.34
   machineType: n1-standard-8
   serviceAccount: false
   enforceSecurityPolicies: true
@@ -67,7 +67,7 @@ plans:
   operation: create
   clusterName: dev-autopilot
   provider: gke
-  kubernetesVersion: 1.33
+  kubernetesVersion: 1.34
   serviceAccount: false
   enforceSecurityPolicies: true
   gke:


### PR DESCRIPTION
## Summary

GKE stopped serving Kubernetes 1.33 in the `elastic-cloud-dev` project, causing cluster creation to fail with "No valid versions with the prefix 1.33 found". This updates the deployer plans to request version 1.34, which is the oldest version currently available in the channel (1.34-1.36).

## Changes

- Updated `kubernetesVersion` from 1.33 to 1.34 in all four GKE deployer plans (`gke-ci`, `gke-autopilot-ci`, `gke-dev`, `gke-autopilot-dev`).
