### PR TITLE
fix OCP kubeconfig cleanup to use actual cluster name

### DIFF
--- a/hack/deployer/runner/ocp.go
+++ b/hack/deployer/runner/ocp.go
@@ -491,7 +491,7 @@ func (d *OCPDriver) copyKubeconfig() error {
 }
 
 func (d *OCPDriver) removeKubeconfig() error {
-	return removeKubeconfig("admin", "admin", "admin")
+	return removeKubeconfig("admin", d.plan.ClusterName, "admin")
 }
 
 func (d *OCPDriver) bucketParams() map[string]any {


### PR DESCRIPTION
## Summary

When an OCP cluster is torn down, `OCPDriver.removeKubeconfig()` is responsible for removing the cluster's entry from the local kubeconfig. The second argument to the shared `removeKubeconfig(context, clusterName, userName string)` helper was hardcoded to `"admin"` instead of using `d.plan.ClusterName`. As a result, teardown would attempt to remove a kubeconfig entry named `"admin"` regardless of the actual cluster name, leaving stale entries behind for any cluster not named `"admin"`.

## Changes

- Fixed `OCPDriver.removeKubeconfig()` to pass `d.plan.ClusterName` as the cluster name argument instead of the hardcoded string `"admin"`, ensuring the correct kubeconfig entry is removed on cluster teardown.
