### PR TITLE
[build]: replace `wolfi/go` with upstream go for the build stage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ go-build: go-build-elastic-operator
 # the .buildkite/scripts/build/verify-fips-binary.sh should be adjusted accordingly.
 go-build-fips: go-generate
 go-build-fips: export CGO_ENABLED=0
-go-build-fips: export GOFIPS140=v1.0.0
+go-build-fips: export GOFIPS140=certified
 go-build-fips: GO_LDFLAGS_EXTRA=-X runtime.godebugDefault=fips140=on
 go-build-fips: go-build-elastic-operator
 go-build-fips:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,6 @@
 # ---------------------------------------------
 # Build the operator binary
-FROM docker.elastic.co/wolfi/go:v1.27.0-r1@sha256:a96b9190e18645f37de32730ce727ac918e55f176457980d5b44a1a71f828ede AS builder
+FROM docker.io/library/golang:1.27.0@sha256:0ecdc2a9f6156af6451080bfe3d8382a662fcc4e209608c6f919e643453514c1 AS builder
 
 ARG VERSION
 ARG SHA1


### PR DESCRIPTION
In Go 1.27, Chainguard [dropped](https://github.com/wolfi-dev/os/commit/c18323a3a4c27b13ed284833041497cfdf50b3bb#:~:text=Validated%20cryptographic%20modules%20removed%2C%20as%20a%20hardened%20variation%20of%20them%20is%20instead%20implemented%20in%20the%20go%2Dgeomys%2Dfips%20image.%20This%20reduces%20the%20size%20of%20the%20toolchain.) the pinned Go native FIPS-certified modules in favor of their own FIPS implementation, [`go-geomys-fips`](https://images.chainguard.dev/directory/image/go-geomys-fips/overview). As a result, the ECK FIPS images can no longer be built.

This PR removes wolfi/go as the builder base image and uses upstream Go instead.

`GOFIPS140=certified` is an alias for the latest certified FIPS module. 

The final image is still based on `wolfi/static`.