### PR TITLE
[manifest-gen]: drop wolfi go and replace with upstream go base image

### DIFF
--- a/hack/manifest-gen/Dockerfile
+++ b/hack/manifest-gen/Dockerfile
@@ -1,7 +1,7 @@
-FROM docker.elastic.co/wolfi/go:v1.27.0-r1@sha256:a96b9190e18645f37de32730ce727ac918e55f176457980d5b44a1a71f828ede as builder
+FROM docker.io/library/golang:1.27.0@sha256:0ecdc2a9f6156af6451080bfe3d8382a662fcc4e209608c6f919e643453514c1 AS builder
 ADD . /manifest-gen
 WORKDIR /manifest-gen
-ENV GO111MODULE=on CGO_ENABLED=0 GOOS=linux 
+ENV GO111MODULE=on CGO_ENABLED=0 GOOS=linux
 RUN go build -a -ldflags '-w -s' -o manifest-gen .
 
 FROM scratch


### PR DESCRIPTION
Based on #9710, drop the wolfi from the manifest-gen Dockerfile. 