### PR TITLE
Fix flaky tests

### DIFF
--- a/hack/deployer/runner/gke.go
+++ b/hack/deployer/runner/gke.go
@@ -326,7 +326,7 @@ func (d *GKEDriver) create() error {
 	if !d.plan.Gke.Autopilot {
 		createGKEClusterCommand = `gcloud container --quiet --project {{.GCloudProject}} clusters create {{.ClusterName}} ` +
 			`--labels "` + labels + `" --region {{.Region}} --no-enable-basic-auth --cluster-version {{.KubernetesVersion}} ` +
-			`--machine-type {{.MachineType}} --disk-type pd-ssd --disk-size 50 ` +
+			`--machine-type {{.MachineType}} --disk-type pd-ssd --disk-size 100 ` +
 			`--local-ssd-count {{.LocalSsdCount}} --scopes {{.GcpScopes}} --num-nodes {{.NodeCountPerZone}} ` +
 			`--addons HorizontalPodAutoscaling,HttpLoadBalancing ` +
 			`--no-enable-autoupgrade --no-enable-autorepair --enable-ip-alias --metadata disable-legacy-endpoints=true ` +

--- a/pkg/utils/retry/retry.go
+++ b/pkg/utils/retry/retry.go
@@ -26,6 +26,22 @@ func (e *ErrTimeoutReached) Error() string {
 // an ErrTimeoutReached is returned.
 // Otherwise, the error from the last attempt is returned.
 func UntilSuccess(f func() error, timeout time.Duration, retryInterval time.Duration) error {
+	return RetryOnError(f, func(error) bool { return true }, timeout, retryInterval)
+}
+
+// RetryOnError retries the given function f for up to the given timeout,
+// separating each attempt by the given retryInterval. An error is retried only
+// when shouldRetry returns true. Non-retryable errors are returned immediately.
+//
+// f is considered successful if it does not return an error. If the timeout is
+// reached before the first failure of f, an ErrTimeoutReached is returned.
+// Otherwise, the error from the last attempt is returned.
+func RetryOnError(
+	f func() error,
+	shouldRetry func(error) bool,
+	timeout time.Duration,
+	retryInterval time.Duration,
+) error {
 	totalTimer := time.NewTimer(timeout)
 	defer totalTimer.Stop()
 	var lastErr error
@@ -48,12 +64,16 @@ func UntilSuccess(f func() error, timeout time.Duration, retryInterval time.Dura
 				return nil
 			}
 			lastErr = err
+			if !shouldRetry(err) {
+				return err
+			}
 			retryTimer := time.NewTimer(retryInterval)
 			select {
 			case <-retryTimer.C:
 				retryTimer.Stop()
 				continue
 			case <-totalTimer.C:
+				retryTimer.Stop()
 				return errorToReturn()
 			}
 		}

--- a/pkg/utils/retry/retry.go
+++ b/pkg/utils/retry/retry.go
@@ -32,6 +32,7 @@ func UntilSuccess(f func() error, timeout time.Duration, retryInterval time.Dura
 // RetryOnError retries the given function f for up to the given timeout,
 // separating each attempt by the given retryInterval. An error is retried only
 // when shouldRetry returns true. Non-retryable errors are returned immediately.
+// A nil shouldRetry retries all errors.
 //
 // f is considered successful if it does not return an error. If the timeout is
 // reached before the first failure of f, an ErrTimeoutReached is returned.
@@ -52,7 +53,7 @@ func RetryOnError(
 		return lastErr
 	}
 	for {
-		resp := make(chan (error))
+		resp := make(chan error, 1)
 		go func() {
 			resp <- f()
 		}()
@@ -64,7 +65,7 @@ func RetryOnError(
 				return nil
 			}
 			lastErr = err
-			if !shouldRetry(err) {
+			if shouldRetry != nil && !shouldRetry(err) {
 				return err
 			}
 			retryTimer := time.NewTimer(retryInterval)

--- a/pkg/utils/retry/retry.go
+++ b/pkg/utils/retry/retry.go
@@ -26,10 +26,10 @@ func (e *ErrTimeoutReached) Error() string {
 // an ErrTimeoutReached is returned.
 // Otherwise, the error from the last attempt is returned.
 func UntilSuccess(f func() error, timeout time.Duration, retryInterval time.Duration) error {
-	return RetryOnError(f, func(error) bool { return true }, timeout, retryInterval)
+	return OnError(f, func(error) bool { return true }, timeout, retryInterval)
 }
 
-// RetryOnError retries the given function f for up to the given timeout,
+// OnError retries the given function f for up to the given timeout,
 // separating each attempt by the given retryInterval. An error is retried only
 // when shouldRetry returns true. Non-retryable errors are returned immediately.
 // A nil shouldRetry retries all errors.
@@ -37,7 +37,7 @@ func UntilSuccess(f func() error, timeout time.Duration, retryInterval time.Dura
 // f is considered successful if it does not return an error. If the timeout is
 // reached before the first failure of f, an ErrTimeoutReached is returned.
 // Otherwise, the error from the last attempt is returned.
-func RetryOnError(
+func OnError(
 	f func() error,
 	shouldRetry func(error) bool,
 	timeout time.Duration,

--- a/pkg/utils/retry/retry_test.go
+++ b/pkg/utils/retry/retry_test.go
@@ -68,6 +68,43 @@ func TestRetryOnErrorReturnsNonRetryableError(t *testing.T) {
 	assert.Equal(t, 1, nAttempts)
 }
 
+func TestRetryOnErrorReturnsNonRetryableErrorAfterRetry(t *testing.T) {
+	retryableErr := errors.New("retryable")
+	permanentErr := errors.New("permanent")
+	nAttempts := 0
+	f := func() error {
+		nAttempts++
+		if nAttempts == 1 {
+			return retryableErr
+		}
+		return permanentErr
+	}
+
+	err := RetryOnError(
+		f,
+		func(err error) bool { return errors.Is(err, retryableErr) },
+		10*time.Second,
+		0,
+	)
+
+	assert.ErrorIs(t, err, permanentErr)
+	assert.Equal(t, 2, nAttempts)
+}
+
+func TestRetryOnErrorWithNilPredicateRetriesAllErrors(t *testing.T) {
+	nAttempts := 0
+	f := func() error {
+		nAttempts++
+		if nAttempts == 2 {
+			return nil
+		}
+		return errors.New("retryable")
+	}
+
+	assert.NoError(t, RetryOnError(f, nil, 10*time.Second, 0))
+	assert.Equal(t, 2, nAttempts)
+}
+
 func TestGlobalTimeoutOnFirstCall(t *testing.T) {
 	timeout := 1 * time.Millisecond
 	stopChan := make(chan (struct{}))

--- a/pkg/utils/retry/retry_test.go
+++ b/pkg/utils/retry/retry_test.go
@@ -43,7 +43,7 @@ func TestRetryOnErrorRetriesMatchingError(t *testing.T) {
 		return retryableErr
 	}
 
-	err := RetryOnError(
+	err := OnError(
 		f,
 		func(err error) bool { return errors.Is(err, retryableErr) },
 		10*time.Second,
@@ -62,7 +62,7 @@ func TestRetryOnErrorReturnsNonRetryableError(t *testing.T) {
 		return permanentErr
 	}
 
-	err := RetryOnError(f, func(error) bool { return false }, 10*time.Second, 0)
+	err := OnError(f, func(error) bool { return false }, 10*time.Second, 0)
 
 	assert.ErrorIs(t, err, permanentErr)
 	assert.Equal(t, 1, nAttempts)
@@ -80,7 +80,7 @@ func TestRetryOnErrorReturnsNonRetryableErrorAfterRetry(t *testing.T) {
 		return permanentErr
 	}
 
-	err := RetryOnError(
+	err := OnError(
 		f,
 		func(err error) bool { return errors.Is(err, retryableErr) },
 		10*time.Second,
@@ -101,7 +101,7 @@ func TestRetryOnErrorWithNilPredicateRetriesAllErrors(t *testing.T) {
 		return errors.New("retryable")
 	}
 
-	assert.NoError(t, RetryOnError(f, nil, 10*time.Second, 0))
+	assert.NoError(t, OnError(f, nil, 10*time.Second, 0))
 	assert.Equal(t, 2, nAttempts)
 }
 

--- a/pkg/utils/retry/retry_test.go
+++ b/pkg/utils/retry/retry_test.go
@@ -32,6 +32,42 @@ func TestLaterSuccess(t *testing.T) {
 	assert.NoError(t, UntilSuccess(f, 10*time.Second, 0*time.Second))
 }
 
+func TestRetryOnErrorRetriesMatchingError(t *testing.T) {
+	retryableErr := errors.New("retryable")
+	nAttempts := 0
+	f := func() error {
+		nAttempts++
+		if nAttempts == 2 {
+			return nil
+		}
+		return retryableErr
+	}
+
+	err := RetryOnError(
+		f,
+		func(err error) bool { return errors.Is(err, retryableErr) },
+		10*time.Second,
+		0,
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, nAttempts)
+}
+
+func TestRetryOnErrorReturnsNonRetryableError(t *testing.T) {
+	permanentErr := errors.New("permanent")
+	nAttempts := 0
+	f := func() error {
+		nAttempts++
+		return permanentErr
+	}
+
+	err := RetryOnError(f, func(error) bool { return false }, 10*time.Second, 0)
+
+	assert.ErrorIs(t, err, permanentErr)
+	assert.Equal(t, 1, nAttempts)
+}
+
 func TestGlobalTimeoutOnFirstCall(t *testing.T) {
 	timeout := 1 * time.Millisecond
 	stopChan := make(chan (struct{}))

--- a/test/e2e/test/agent/steps.go
+++ b/test/e2e/test/agent/steps.go
@@ -11,6 +11,7 @@ import (
 	"maps"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
@@ -29,6 +30,8 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test/elasticsearch"
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test/generation"
 )
+
+const k8sRequestRetryTimeout = time.Minute
 
 func (b Builder) InitTestSteps(k *test.K8sClient) test.StepList {
 	return test.StepList{
@@ -120,21 +123,25 @@ func (b Builder) CreationTestSteps(k *test.K8sClient) test.StepList {
 				Name: "Creating an Agent should succeed",
 				Test: func(t *testing.T) {
 					t.Helper()
-					for _, obj := range b.RuntimeObjects() {
-						err := k.Client.Create(context.Background(), obj)
-						require.NoError(t, err)
-					}
+					require.NoError(t, k.CreateWithRetry(
+						test.IsRetryableError,
+						k8sRequestRetryTimeout,
+						b.RuntimeObjects()...,
+					))
 				},
 			},
 			test.Step{
 				Name: "Agent should be created",
-				Test: func(t *testing.T) {
-					t.Helper()
+				Test: test.RetryOnError(func() error {
 					var createdAgent agentv1alpha1.Agent
-					err := k.Client.Get(context.Background(), k8s.ExtractNamespacedName(&b.Agent), &createdAgent)
-					require.NoError(t, err)
-					require.Equal(t, b.Agent.Spec.Version, createdAgent.Spec.Version)
-				},
+					if err := k.Client.Get(context.Background(), k8s.ExtractNamespacedName(&b.Agent), &createdAgent); err != nil {
+						return err
+					}
+					if b.Agent.Spec.Version != createdAgent.Spec.Version {
+						return fmt.Errorf("expected version %s but got %s", b.Agent.Spec.Version, createdAgent.Spec.Version)
+					}
+					return nil
+				}, test.IsRetryableError, k8sRequestRetryTimeout),
 			},
 		})
 }

--- a/test/e2e/test/autoops/steps.go
+++ b/test/e2e/test/autoops/steps.go
@@ -28,6 +28,8 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/test/e2e/test/generation"
 )
 
+const k8sRequestRetryTimeout = time.Minute
+
 func (b Builder) InitTestSteps(k *test.K8sClient) test.StepList {
 	return test.StepList{
 		{
@@ -119,12 +121,11 @@ func (b Builder) CreationTestSteps(k *test.K8sClient) test.StepList {
 			Name: "Creating an AutoOpsAgentPolicy should succeed",
 			Test: func(t *testing.T) {
 				t.Helper()
-				for _, obj := range b.RuntimeObjects() {
-					err := k.Client.Create(context.Background(), obj)
-					if err != nil && !apierrors.IsAlreadyExists(err) {
-						require.NoError(t, err)
-					}
-				}
+				require.NoError(t, k.CreateWithRetry(
+					test.IsRetryableError,
+					k8sRequestRetryTimeout,
+					b.RuntimeObjects()...,
+				))
 			},
 		}).
 		WithStep(test.Step{

--- a/test/e2e/test/k8s_client.go
+++ b/test/e2e/test/k8s_client.go
@@ -450,7 +450,7 @@ func (k *K8sClient) CreateWithRetry(
 	objs ...k8sclient.Object,
 ) error {
 	for _, desired := range objs {
-		err := retry.RetryOnError(func() error {
+		err := retry.OnError(func() error {
 			obj := k8s.DeepCopyObject(desired)
 			err := k.Client.Create(context.Background(), obj)
 			if apierrors.IsAlreadyExists(err) {

--- a/test/e2e/test/k8s_client.go
+++ b/test/e2e/test/k8s_client.go
@@ -10,6 +10,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"os"
+	"time"
 
 	computeclassv1 "github.com/googlecloudplatform/compute-class-api/api/cloud.google.com/v1"
 	"github.com/pkg/errors"
@@ -52,6 +53,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/maps"
 	eprlabels "github.com/elastic/cloud-on-k8s/v3/pkg/controller/packageregistry/label"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/retry"
 )
 
 type K8sClient struct {
@@ -423,6 +425,40 @@ func (k *K8sClient) CreateOrUpdateSecrets(secrets ...corev1.Secret) error {
 func (k *K8sClient) DeleteSecrets(secrets ...corev1.Secret) error {
 	for i := range secrets {
 		if err := k.Client.Delete(context.Background(), &secrets[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// IsRetryableError reports whether err represents a transient Kubernetes API
+// server response for which retrying the request may succeed.
+func IsRetryableError(err error) bool {
+	return apierrors.IsInternalError(err) ||
+		apierrors.IsServerTimeout(err) ||
+		apierrors.IsServiceUnavailable(err) ||
+		apierrors.IsTooManyRequests(err) ||
+		apierrors.IsTimeout(err)
+}
+
+// CreateWithRetry creates each object independently, retrying errors accepted by
+// shouldRetry for up to timeout. An existing object is considered a successful
+// outcome. The caller's objects are not modified.
+func (k *K8sClient) CreateWithRetry(
+	shouldRetry func(error) bool,
+	timeout time.Duration,
+	objs ...k8sclient.Object,
+) error {
+	for _, desired := range objs {
+		err := retry.RetryOnError(func() error {
+			obj := k8s.DeepCopyObject(desired)
+			err := k.Client.Create(context.Background(), obj)
+			if apierrors.IsAlreadyExists(err) {
+				return nil
+			}
+			return err
+		}, shouldRetry, timeout, DefaultRetryDelay)
+		if err != nil {
 			return err
 		}
 	}

--- a/test/e2e/test/k8s_client_test.go
+++ b/test/e2e/test/k8s_client_test.go
@@ -1,0 +1,93 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestIsRetryableK8sError(t *testing.T) {
+	transientErrors := []error{
+		apierrors.NewInternalError(errors.New("internal error")),
+		apierrors.NewServerTimeout(schema.GroupResource{Resource: "agents"}, "get", 1),
+		apierrors.NewServiceUnavailable("service unavailable"),
+		apierrors.NewTooManyRequests("too many requests", 1),
+		apierrors.NewTimeoutError("timeout", 1),
+	}
+	for _, err := range transientErrors {
+		require.True(t, IsRetryableError(err), "expected %T to be retryable", err)
+	}
+
+	permanentErrors := []error{
+		apierrors.NewBadRequest("bad request"),
+		apierrors.NewForbidden(schema.GroupResource{Resource: "agents"}, "agent", errors.New("forbidden")),
+		apierrors.NewNotFound(schema.GroupResource{Resource: "agents"}, "agent"),
+	}
+	for _, err := range permanentErrors {
+		require.False(t, IsRetryableError(err), "expected %T not to be retryable", err)
+	}
+}
+
+func TestCreateWithRetryAcceptsExistingObjects(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "config",
+			Namespace: "default",
+		},
+		Data: map[string]string{"value": "old"},
+	}
+	baseClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(existing).
+		Build()
+	k := &K8sClient{Client: baseClient}
+
+	desiredExisting := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      existing.Name,
+			Namespace: existing.Namespace,
+		},
+		Data: map[string]string{"value": "new"},
+	}
+	desiredNew := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "new-config",
+			Namespace: existing.Namespace,
+		},
+		Data: map[string]string{"value": "new"},
+	}
+	require.NoError(t, k.CreateWithRetry(
+		func(error) bool { return false },
+		time.Second,
+		desiredExisting,
+		desiredNew,
+	))
+
+	var actualExisting corev1.ConfigMap
+	require.NoError(t, baseClient.Get(context.Background(), k8sclient.ObjectKeyFromObject(existing), &actualExisting))
+	require.Equal(t, existing.Data, actualExisting.Data)
+
+	var actualNew corev1.ConfigMap
+	require.NoError(t, baseClient.Get(context.Background(), k8sclient.ObjectKeyFromObject(desiredNew), &actualNew))
+	require.Equal(t, desiredNew.Data, actualNew.Data)
+
+	require.Empty(t, desiredExisting.ResourceVersion)
+	require.Empty(t, desiredNew.ResourceVersion)
+}

--- a/test/e2e/test/k8s_client_test.go
+++ b/test/e2e/test/k8s_client_test.go
@@ -20,7 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func TestIsRetryableK8sError(t *testing.T) {
+func TestIsRetryableError(t *testing.T) {
 	transientErrors := []error{
 		apierrors.NewInternalError(errors.New("internal error")),
 		apierrors.NewServerTimeout(schema.GroupResource{Resource: "agents"}, "get", 1),

--- a/test/e2e/test/utils.go
+++ b/test/e2e/test/utils.go
@@ -92,7 +92,7 @@ func RetryOnError(f func() error, shouldRetry func(error) bool, timeout time.Dur
 	return func(t *testing.T) {
 		t.Helper()
 		fmt.Printf("Retries (%s timeout): ", timeout)
-		err := retry.RetryOnError(func() error {
+		err := retry.OnError(func() error {
 			fmt.Print(".") // super modern progress bar 2.0!
 			return f()
 		}, shouldRetry, timeout, DefaultRetryDelay)

--- a/test/e2e/test/utils.go
+++ b/test/e2e/test/utils.go
@@ -83,13 +83,19 @@ func Eventually(f func() error) func(*testing.T) {
 
 // UntilSuccess executes f until it succeeds, or the timeout is reached.
 func UntilSuccess(f func() error, timeout time.Duration) func(*testing.T) {
+	return RetryOnError(f, func(error) bool { return true }, timeout)
+}
+
+// RetryOnError executes f until it succeeds, a non-retryable error is returned,
+// or the timeout is reached.
+func RetryOnError(f func() error, shouldRetry func(error) bool, timeout time.Duration) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Helper()
 		fmt.Printf("Retries (%s timeout): ", timeout)
-		err := retry.UntilSuccess(func() error {
+		err := retry.RetryOnError(func() error {
 			fmt.Print(".") // super modern progress bar 2.0!
 			return f()
-		}, timeout, DefaultRetryDelay)
+		}, shouldRetry, timeout, DefaultRetryDelay)
 		fmt.Println()
 		require.NoError(t, err)
 	}


### PR DESCRIPTION
## Summary

- Increase GKE E2E node disks from 50 GB to 100 GB to accommodate the growing Package Registry image.
- Retry transient Kubernetes API errors during Agent creation and read-back, while failing immediately on permanent errors.
- Add configurable error-aware retry support and idempotent, per-object creation for E2E tests.

## Testing

- `go test ./hack/deployer/runner`
- `go test ./pkg/utils/retry ./test/e2e/test ./test/e2e/test/agent`