### PR TITLE
Move golangci-lint installation to make lint cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ LOG_VERBOSITY ?= 1
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 GOBIN := $(or $(shell go env GOBIN 2>/dev/null), $(shell go env GOPATH 2>/dev/null)/bin)
 
+LOCAL_BIN := $(CURDIR)/bin
+GOLANGCI_LINT_VERSION := v2.13.2
+GOLANGCI_LINT := $(LOCAL_BIN)/golangci-lint
+
 # find or download controller-gen
 controller-gen: CONTROLLER_TOOLS_VERSION = $(shell grep controller-tools go.mod | grep -o "v[0-9\.]*")
 controller-gen:
@@ -171,6 +175,7 @@ generate-image-dependencies:
 
 clean:
 	rm -f pkg/controller/common/license/zz_generated.pubkey.go
+	rm -rf $(LOCAL_BIN)
 
 ## -- tests
 
@@ -204,8 +209,15 @@ integration-xml: setup-envtest clean
 	done; \
 	exit $$exit_code
 
-lint:
-	GOGC=40 golangci-lint run --verbose
+.PHONY: golangci-lint
+golangci-lint:
+	@if ! $(GOLANGCI_LINT) version 2>/dev/null | grep -q "version $(patsubst v%,%,$(GOLANGCI_LINT_VERSION))"; then \
+		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/$(GOLANGCI_LINT_VERSION)/install.sh \
+			| sh -s -- -b $(LOCAL_BIN) $(GOLANGCI_LINT_VERSION); \
+	fi
+
+lint: golangci-lint
+	GOGC=40 $(GOLANGCI_LINT) run --verbose
 
 manifest-gen-test:
 	hack/manifest-gen/test.sh

--- a/Makefile
+++ b/Makefile
@@ -212,6 +212,7 @@ integration-xml: setup-envtest clean
 .PHONY: golangci-lint
 golangci-lint:
 	@if ! $(GOLANGCI_LINT) version 2>/dev/null | grep -q "version $(patsubst v%,%,$(GOLANGCI_LINT_VERSION))"; then \
+		set -o pipefail; \
 		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/$(GOLANGCI_LINT_VERSION)/install.sh \
 			| sh -s -- -b $(LOCAL_BIN) $(GOLANGCI_LINT_VERSION); \
 	fi

--- a/dev-setup.md
+++ b/dev-setup.md
@@ -7,7 +7,6 @@ This page explains you how to set up your development environment.
 Before you start, install the following tools and packages:
 
 * [go](https://golang.org/dl/) (>= 1.17)
-* [golangci-lint](https://github.com/golangci/golangci-lint)
 * [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) (>= 1.14)
 * [kubebuilder](https://github.com/kubernetes-sigs/kubebuilder) (>= 2.0.0)
 * [docker](https://docs.docker.com/) (>= 19.0.0 with optional `buildx` extension for multi-arch builds)

--- a/dev-setup.md
+++ b/dev-setup.md
@@ -7,12 +7,15 @@ This page explains you how to set up your development environment.
 Before you start, install the following tools and packages:
 
 * [go](https://golang.org/dl/) (>= 1.17)
+* [curl](https://curl.se/)
 * [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) (>= 1.14)
 * [kubebuilder](https://github.com/kubernetes-sigs/kubebuilder) (>= 2.0.0)
 * [docker](https://docs.docker.com/) (>= 19.0.0 with optional `buildx` extension for multi-arch builds)
 * [helm](https://helm.sh/docs/intro/install/) (>= 3.2.0, preferably 3.9.x)
 * [helm unittest](https://github.com/helm-unittest/helm-unittest?tab=readme-ov-file#install) (only needed if developing helm charts) `helm plugin install https://github.com/helm-unittest/helm-unittest.git --version 1.0.3`
 * Kubernetes distribution such as [minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) or [kind](https://kind.sigs.k8s.io), or access to a hosted Kubernetes service such as [GKE](https://cloud.google.com/kubernetes-engine) or [AKS](https://azure.microsoft.com/en-us/services/kubernetes-service/)
+
+`make lint` downloads the required `golangci-lint` version automatically.
 
 ### Get sources
 

--- a/hack/check/check-requisites.sh
+++ b/hack/check/check-requisites.sh
@@ -100,6 +100,7 @@ check_docker_version() {
 
 
 check go
+check curl
 check kubectl
 check kubebuilder
 check_oneof gcloud minikube kind

--- a/hack/check/check-requisites.sh
+++ b/hack/check/check-requisites.sh
@@ -100,7 +100,6 @@ check_docker_version() {
 
 
 check go
-check golangci-lint
 check kubectl
 check kubebuilder
 check_oneof gcloud minikube kind


### PR DESCRIPTION
Replace expectation of globally installed lint tooling with a local install as part of running make lint. With make clean the installed tool gets cleaned up.

Assisted-by: Cursor Agent (GPT-5.6 Sol)
