### PR TITLE
fix transitive ES RBAC check for Agent-FleetServer associations and perform all association secrets cleanup on unbind

### DIFF
--- a/cmd/manager/main_test.go
+++ b/cmd/manager/main_test.go
@@ -18,15 +18,26 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
+	ctrlrecorder "sigs.k8s.io/controller-runtime/pkg/recorder"
+	ctrlwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
+	webhookconversion "sigs.k8s.io/controller-runtime/pkg/webhook/conversion"
 
 	apmv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/apm/v1"
 	beatv1beta1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/beat/v1beta1"
@@ -36,7 +47,9 @@ import (
 	kbv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/kibana/v1"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/operator"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/reconciler"
+	controllerscheme "github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/scheme"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/rbac"
 )
 
 func ownedSecret(namespace, name, ownerNs, ownerName, ownerKind string) *corev1.Secret {
@@ -497,4 +510,37 @@ func Test_parseNSSelector(t *testing.T) {
 			assert.Equal(t, tt.wantSel, got)
 		})
 	}
+}
+
+// fakeManager implements manager.Manager with just enough behavior for registerControllers
+// to succeed: a fully populated scheme (for GVK lookups and owner-reference handlers),
+// SkipNameValidation to avoid the global controller-name uniqueness registry, and nil/no-op
+// returns for everything that is only stored and never called during controller setup.
+type fakeManager struct {
+	ctrlmgr.Manager // embed to satisfy unimplemented methods — panics if unexpectedly called
+}
+
+func (fakeManager) GetScheme() *runtime.Scheme        { return clientgoscheme.Scheme }
+func (fakeManager) GetClient() client.Client          { return nil }
+func (fakeManager) GetCache() cache.Cache             { return nil }
+func (fakeManager) GetRESTMapper() apimeta.RESTMapper { return nil }
+func (fakeManager) GetLogger() logr.Logger            { return logr.Discard() }
+func (fakeManager) GetControllerOptions() config.Controller {
+	return config.Controller{Logger: logr.Discard(), SkipNameValidation: new(true)}
+}
+func (fakeManager) Add(ctrlmgr.Runnable) error                         { return nil }
+func (fakeManager) GetEventRecorderFor(string) record.EventRecorder    { return nil }
+func (fakeManager) GetEventRecorder(string) ctrlrecorder.EventRecorder { return nil }
+func (fakeManager) AddHealthzCheck(string, healthz.Checker) error      { return nil }
+func (fakeManager) AddReadyzCheck(string, healthz.Checker) error       { return nil }
+func (fakeManager) GetWebhookServer() ctrlwebhook.Server               { return nil }
+func (fakeManager) GetConverterRegistry() webhookconversion.Registry   { return nil }
+
+// TestRegisterControllers verifies that registerControllers succeeds with a fake manager.
+// It acts as a registration smoke-test: if any controller's AssociationInfo violates
+// ValidateAssociationInfo (e.g. ElasticsearchUserCreation set but ElasticsearchRef nil),
+// this test catches it before the operator starts.
+func TestRegisterControllers(t *testing.T) {
+	controllerscheme.SetupScheme()
+	require.NoError(t, registerControllers(fakeManager{}, operator.Parameters{}, rbac.NewPermissiveAccessReviewer()))
 }

--- a/pkg/controller/association/controller.go
+++ b/pkg/controller/association/controller.go
@@ -26,6 +26,16 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/rbac"
 )
 
+// ValidateAssociationInfo returns an error if the invariants of info are violated.
+// ElasticsearchRef must be set whenever ElasticsearchUserCreation is non-nil: without it
+// the reconciler would attempt ES user creation against a zero-value Elasticsearch object.
+func ValidateAssociationInfo(info AssociationInfo) error {
+	if info.ElasticsearchUserCreation != nil && info.ElasticsearchRef == nil {
+		return fmt.Errorf("AssociationInfo %q: ElasticsearchRef must be set when ElasticsearchUserCreation is non-nil", info.AssociationName)
+	}
+	return nil
+}
+
 // AddAssociationController sets up and starts an association controller for the given associationInfo.
 func AddAssociationController(
 	mgr manager.Manager,
@@ -33,6 +43,9 @@ func AddAssociationController(
 	params operator.Parameters,
 	associationInfo AssociationInfo,
 ) error {
+	if err := ValidateAssociationInfo(associationInfo); err != nil {
+		return err
+	}
 	// Derive the referenced resource Kind from the scheme at setup time,
 	// making the relationship with ReferencedObjTemplate explicit and unbreakable.
 	referencedResourceKind, err := referencedObjKind(mgr, associationInfo.ReferencedObjTemplate())

--- a/pkg/controller/association/controller/agent_es.go
+++ b/pkg/controller/association/controller/agent_es.go
@@ -15,7 +15,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/association"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/operator"
 	eslabel "github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/label"
-	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/rbac"
 )
 
@@ -53,10 +52,8 @@ func AddAgentES(mgr manager.Manager, accessReviewer rbac.AccessReviewer, params 
 		AssociationResourceNameLabelName:      eslabel.ClusterNameLabelName,
 		AssociationResourceNamespaceLabelName: eslabel.ClusterNamespaceLabelName,
 
+		ElasticsearchRef: directElasticsearchRef,
 		ElasticsearchUserCreation: &association.ElasticsearchUserCreation{
-			ElasticsearchRef: func(c k8s.Client, association commonv1.Association) (bool, commonv1.AssociationRef, error) {
-				return true, association.AssociationRef(), nil
-			},
 			UserSecretSuffix: "agent-user",
 			ESUserRole: func(associated commonv1.Associated) (string, error) {
 				return "superuser", nil

--- a/pkg/controller/association/controller/agent_fleetserver.go
+++ b/pkg/controller/association/controller/agent_fleetserver.go
@@ -204,11 +204,6 @@ func fleetManagedAgentTransitiveESRef(ctx context.Context, c k8s.Client, assoc c
 
 	log := ulog.FromContext(ctx)
 	associated := assoc.Associated()
-	var agnt agentv1alpha1.Agent
-	nsn := types.NamespacedName{Namespace: associated.GetNamespace(), Name: associated.GetName()}
-	if err := c.Get(ctx, nsn, &agnt); err != nil {
-		return nil, results.WithError(err)
-	}
 	fleetServerRef := assoc.AssociationRef()
 	if !fleetServerRef.IsSet() {
 		if err := deleteOrphanedTransitiveESClientCertSecrets(ctx, c, assocMeta, associated, ""); err != nil {

--- a/pkg/controller/association/controller/agent_fleetserver.go
+++ b/pkg/controller/association/controller/agent_fleetserver.go
@@ -32,8 +32,8 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/rbac"
 )
 
-func AddAgentFleetServer(mgr manager.Manager, accessReviewer rbac.AccessReviewer, params operator.Parameters) error {
-	return association.AddAssociationController(mgr, accessReviewer, params, association.AssociationInfo{
+func agentFleetServerAssociationInfo() association.AssociationInfo {
+	return association.AssociationInfo{
 		AssociatedObjTemplate:        func() commonv1.Associated { return &agentv1alpha1.Agent{} },
 		AssociatedObjListTemplate:    func() client.ObjectList { return &agentv1alpha1.AgentList{} },
 		ReferencedObjTemplate:        func() client.Object { return &agentv1alpha1.Agent{} },
@@ -44,6 +44,7 @@ func AddAgentFleetServer(mgr manager.Manager, accessReviewer rbac.AccessReviewer
 		AssociatedShortName:          "agent",
 		AssociationType:              commonv1.FleetServerAssociationType,
 		AdditionalSecrets:            additionalSecrets,
+		ElasticsearchRef:             agentFleetServerESRef,
 		ReconcileTransitiveESSecrets: fleetManagedAgentTransitiveESRef,
 		Labels: func(associated types.NamespacedName) map[string]string {
 			return map[string]string{
@@ -57,7 +58,47 @@ func AddAgentFleetServer(mgr manager.Manager, accessReviewer rbac.AccessReviewer
 		AssociationResourceNamespaceLabelName: agent.NamespaceLabelName,
 
 		ElasticsearchUserCreation: nil,
-	})
+	}
+}
+
+func AddAgentFleetServer(mgr manager.Manager, accessReviewer rbac.AccessReviewer, params operator.Parameters) error {
+	return association.AddAssociationController(mgr, accessReviewer, params, agentFleetServerAssociationInfo())
+}
+
+// getFleetServerESAssociation fetches the fleet server at nsn and returns its single
+// Elasticsearch association. Returns (nil, nil) when the fleet server has no
+// ElasticsearchRefs. Returns (nil, err) on any lookup or ambiguity error.
+func getFleetServerESAssociation(ctx context.Context, c k8s.Client, nsn types.NamespacedName) (commonv1.Association, error) {
+	var fleetServer agentv1alpha1.Agent
+	if err := c.Get(ctx, nsn, &fleetServer); err != nil {
+		return nil, err
+	}
+	if len(fleetServer.Spec.ElasticsearchRefs) == 0 {
+		return nil, nil
+	}
+	return association.SingleAssociationOfType(fleetServer.GetAssociations(), commonv1.ElasticsearchAssociationType)
+}
+
+// agentFleetServerESRef resolves the Elasticsearch reference transitively via the Fleet Server
+// (Agent -> Fleet Server -> Elasticsearch) for RBAC enforcement purposes.
+// Returns (false, _, nil) whenever no transitive ES ref can be resolved: the fleet server ref is
+// not set on the agent, the fleet server does not exist yet, or the fleet server has no ES association.
+func agentFleetServerESRef(ctx context.Context, c k8s.Client, assoc commonv1.Association) (bool, commonv1.AssociationRef, error) {
+	fleetServerRef := assoc.AssociationRef()
+	if !fleetServerRef.IsSet() {
+		return false, commonv1.ObjectSelector{}, nil
+	}
+	esAssociation, err := getFleetServerESAssociation(ctx, c, fleetServerRef.NamespacedName())
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, commonv1.ObjectSelector{}, nil
+		}
+		return false, commonv1.ObjectSelector{}, err
+	}
+	if esAssociation == nil {
+		return false, commonv1.ObjectSelector{}, nil
+	}
+	return true, esAssociation.AssociationRef(), nil
 }
 
 // additionalSecrets returns secrets from the Fleet Server's Elasticsearch association that
@@ -74,22 +115,13 @@ func additionalSecrets(ctx context.Context, c k8s.Client, assoc commonv1.Associa
 	if !fleetServerRef.IsSet() {
 		return nil, nil
 	}
-	fleetServer := agentv1alpha1.Agent{}
-	if err := c.Get(ctx, fleetServerRef.NamespacedName(), &fleetServer); err != nil {
-		return nil, err
-	}
-
-	// If the Fleet Server Agent is not associated with an Elasticsearch cluster
-	// (potentially because of a manual setup) we should do nothing.
-	if len(fleetServer.Spec.ElasticsearchRefs) == 0 {
-		return nil, nil
-	}
-	esRef := fleetServer.Spec.ElasticsearchRefs[0]
-	esAssociation, err := association.SingleAssociationOfType(fleetServer.GetAssociations(), commonv1.ElasticsearchAssociationType)
+	esAssociation, err := getFleetServerESAssociation(ctx, c, fleetServerRef.NamespacedName())
 	if err != nil {
 		return nil, err
 	}
-
+	if esAssociation == nil {
+		return nil, nil
+	}
 	conf, err := esAssociation.AssociationConf()
 	if err != nil {
 		log.V(1).Info("no additional secrets because no assoc conf")
@@ -105,7 +137,7 @@ func additionalSecrets(ctx context.Context, c k8s.Client, assoc commonv1.Associa
 	if conf.CACertProvided {
 		log.V(1).Info("additional secret because CA provided")
 		secrets = append(secrets, association.AdditionalSecret{
-			Source: types.NamespacedName{Namespace: fleetServer.Namespace, Name: conf.CASecretName},
+			Source: types.NamespacedName{Namespace: fleetServerRef.NamespacedName().Namespace, Name: conf.CASecretName},
 			// Always restrict the copy to ca.crt. For external ES references, CASecretName ==
 			// AuthSecretName, so the source secret also contains url/username/password — filtering
 			// to ca.crt prevents credential leakage. For managed refs the CA secret also contains
@@ -116,10 +148,10 @@ func additionalSecrets(ctx context.Context, c k8s.Client, assoc commonv1.Associa
 		})
 	}
 
-	if conf.ClientCertIsConfigured() && esRef.GetClientCertificateSecretName() != "" {
+	if conf.ClientCertIsConfigured() && esAssociation.AssociationRef().GetClientCertificateSecretName() != "" {
 		log.V(1).Info("additional secret because user client certificate is provided")
 		secrets = append(secrets, association.AdditionalSecret{
-			Source:     types.NamespacedName{Namespace: fleetServer.Namespace, Name: conf.GetClientCertSecretName()},
+			Source:     types.NamespacedName{Namespace: fleetServerRef.NamespacedName().Namespace, Name: conf.GetClientCertSecretName()},
 			TargetName: transitiveESClientCertTargetName(assoc, conf),
 		})
 	}
@@ -184,24 +216,16 @@ func fleetManagedAgentTransitiveESRef(ctx context.Context, c k8s.Client, assoc c
 		}
 		return nil, nil
 	}
-	fleetServer := agentv1alpha1.Agent{}
-	if err := c.Get(ctx, fleetServerRef.NamespacedName(), &fleetServer); err != nil {
+	esAssociation, err := getFleetServerESAssociation(ctx, c, fleetServerRef.NamespacedName())
+	if err != nil {
 		return nil, results.WithError(err)
 	}
-
-	// Fleet Server Agent is not associated with an Elasticsearch cluster
-	if len(fleetServer.Spec.ElasticsearchRefs) == 0 {
+	if esAssociation == nil {
 		if err := deleteOrphanedTransitiveESClientCertSecrets(ctx, c, assocMeta, associated, ""); err != nil {
 			return nil, results.WithError(err)
 		}
 		return nil, nil
 	}
-	esRef := fleetServer.Spec.ElasticsearchRefs[0]
-	esAssociation, err := association.SingleAssociationOfType(fleetServer.GetAssociations(), commonv1.ElasticsearchAssociationType)
-	if err != nil {
-		return nil, results.WithError(err)
-	}
-
 	conf, err := esAssociation.AssociationConf()
 	if err != nil {
 		log.V(1).Info("Transitive ES association conf not available")
@@ -225,7 +249,7 @@ func fleetManagedAgentTransitiveESRef(ctx context.Context, c k8s.Client, assoc c
 	// Compute the user-provided client cert name up front so the external-ES branch can include
 	// it in the TransitiveESRef and preserve its copy in the agent namespace.
 	var userClientCertName string
-	if esRef.GetClientCertificateSecretName() != "" && conf.ClientCertIsConfigured() {
+	if esAssociation.AssociationRef().GetClientCertificateSecretName() != "" && conf.ClientCertIsConfigured() {
 		userClientCertName = transitiveESClientCertTargetName(assoc, conf)
 	}
 

--- a/pkg/controller/association/controller/agent_fleetserver_test.go
+++ b/pkg/controller/association/controller/agent_fleetserver_test.go
@@ -12,12 +12,15 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	agentv1alpha1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/agent/v1alpha1"
 	commonv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/agent"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/association"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/annotation"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/hash"
@@ -25,6 +28,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/metadata"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/rbac"
 )
 
 // esAssocConfAnnotation returns the JSON-encoded association conf annotation value for a fleet server's ES association.
@@ -897,4 +901,324 @@ func TestFleetManagedAgentTransitiveESRef_ResultsNotNil(t *testing.T) {
 	require.NotNil(t, ref)
 	require.NotNil(t, results)
 	require.False(t, results.HasError())
+}
+
+func TestAgentFleetServerESRef(t *testing.T) {
+	esSelector := commonv1.ObjectSelector{Name: "es1", Namespace: "es-ns"}
+
+	fleetServer := &agentv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "fleet1", Namespace: "fs-ns"},
+		Spec: agentv1alpha1.AgentSpec{
+			FleetServerEnabled: true,
+			ElasticsearchRefs: []agentv1alpha1.Output{
+				{ElasticsearchSelector: commonv1.ElasticsearchSelector{ObjectSelector: esSelector}},
+			},
+		},
+	}
+	fleetServer.GetAssociations()[0].SetAssociationConf(&commonv1.AssociationConf{
+		AuthSecretName: "-",
+		CACertProvided: true,
+		CASecretName:   "fleet1-es-ca",
+		URL:            "https://es1-http.es-ns.svc:9200",
+	})
+
+	agent := &agentv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "agent1", Namespace: "agent-ns"},
+		Spec: agentv1alpha1.AgentSpec{
+			FleetServerRef: commonv1.FleetServerSelector{ObjectSelector: commonv1.ObjectSelector{Name: "fleet1", Namespace: "fs-ns"}},
+		},
+	}
+
+	agentNoRef := &agentv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "agent1", Namespace: "agent-ns"},
+	}
+
+	for _, tt := range []struct {
+		name         string
+		agent        *agentv1alpha1.Agent // nil uses the default agent fixture
+		objects      []client.Object
+		wantFound    bool
+		wantESNSName types.NamespacedName
+		wantErr      bool
+	}{
+		{
+			name:         "resolves transitive ES ref through fleet server",
+			objects:      []client.Object{agent, fleetServer},
+			wantFound:    true,
+			wantESNSName: types.NamespacedName{Namespace: "es-ns", Name: "es1"},
+		},
+		{
+			name:      "fleet server not found returns not-found",
+			objects:   []client.Object{agent},
+			wantFound: false,
+		},
+		{
+			name:      "fleet server ref not set returns not-found",
+			agent:     agentNoRef,
+			wantFound: false,
+		},
+		{
+			name: "fleet server has no ES refs returns not-found",
+			objects: []client.Object{agent, func() *agentv1alpha1.Agent {
+				fs := fleetServer.DeepCopy()
+				fs.Spec.ElasticsearchRefs = nil
+				return fs
+			}()},
+			wantFound: false,
+		},
+		{
+			name: "fleet server with multiple ES refs returns error",
+			objects: []client.Object{agent, func() *agentv1alpha1.Agent {
+				fs := fleetServer.DeepCopy()
+				fs.Spec.ElasticsearchRefs = append(fs.Spec.ElasticsearchRefs,
+					agentv1alpha1.Output{ElasticsearchSelector: commonv1.ElasticsearchSelector{ObjectSelector: commonv1.ObjectSelector{Name: "es2", Namespace: "es-ns"}}},
+				)
+				return fs
+			}()},
+			wantErr: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			c := k8s.NewFakeClient(tt.objects...)
+			a := agent
+			if tt.agent != nil {
+				a = tt.agent
+			}
+			assoc := &agentv1alpha1.AgentFleetServerAssociation{Agent: a}
+
+			found, ref, err := agentFleetServerESRef(t.Context(), c, assoc)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantFound, found)
+			if tt.wantFound {
+				require.Equal(t, tt.wantESNSName, ref.NamespacedName())
+			}
+		})
+	}
+}
+
+// denyESReviewer allows any object that is not an Elasticsearch resource.
+// It simulates a scenario where the Fleet Server passes the RBAC check but
+// the backing Elasticsearch cluster does not.
+type denyESReviewer struct{}
+
+func (d denyESReviewer) AccessAllowed(_ context.Context, _ string, _ string, obj runtime.Object) (bool, error) {
+	_, isES := obj.(*esv1.Elasticsearch)
+	return !isES, nil
+}
+
+var _ rbac.AccessReviewer = denyESReviewer{}
+
+func TestAgentFleetServerTransitiveESRBAC(t *testing.T) {
+	agentObj := &agentv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "agent1", Namespace: "agent-ns"},
+		Spec: agentv1alpha1.AgentSpec{
+			Version:        "8.0.0",
+			FleetServerRef: commonv1.FleetServerSelector{ObjectSelector: commonv1.ObjectSelector{Name: "fleet1", Namespace: "fleet-ns"}},
+		},
+	}
+
+	fleetServer := &agentv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fleet1",
+			Namespace: "fleet-ns",
+			Annotations: map[string]string{
+				esConfAnnotationKey(commonv1.ObjectSelector{Name: "es1", Namespace: "es-ns"}): esAssocConfAnnotation(commonv1.AssociationConf{
+					AuthSecretName: "-",
+					CACertProvided: true,
+					CASecretName:   "fleet1-es-ca",
+					URL:            "https://es1-http.es-ns.svc:9200",
+				}),
+			},
+		},
+		Spec: agentv1alpha1.AgentSpec{
+			Version:            "8.0.0",
+			FleetServerEnabled: true,
+			ElasticsearchRefs: []agentv1alpha1.Output{
+				{ElasticsearchSelector: commonv1.ElasticsearchSelector{ObjectSelector: commonv1.ObjectSelector{Name: "es1", Namespace: "es-ns"}}},
+			},
+		},
+	}
+	fleetServer.GetAssociations()[0].SetAssociationConf(&commonv1.AssociationConf{
+		AuthSecretName: "-",
+		CACertProvided: true,
+		CASecretName:   "fleet1-es-ca",
+		URL:            "https://es1-http.es-ns.svc:9200",
+	})
+
+	es := &esv1.Elasticsearch{
+		ObjectMeta: metav1.ObjectMeta{Name: "es1", Namespace: "es-ns"},
+		Spec:       esv1.ElasticsearchSpec{Version: "8.0.0"},
+	}
+
+	// CA secret in the Fleet Server namespace — would be copied to agent-ns on success.
+	fleetESCA := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "fleet-ns", Name: "fleet1-es-ca"},
+		Data:       map[string][]byte{"ca.crt": []byte("cacert"), "tls.crt": []byte("tlscert")},
+	}
+	fleetHTTPCerts := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "fleet-ns", Name: "fleet1-agent-http-certs-public"},
+		Data:       map[string][]byte{"ca.crt": []byte("cacert"), "tls.crt": []byte("tlscert")},
+	}
+	fleetService := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "fleet-ns", Name: "fleet1-agent-http"},
+		Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Name: "https", Port: 8220}}},
+	}
+
+	// Fleet Server with no ElasticsearchRefs — manual/external setup, no transitive ES.
+	fleetServerNoES := &agentv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "fleet1", Namespace: "fleet-ns"},
+		Spec: agentv1alpha1.AgentSpec{
+			Version:            "8.0.0",
+			FleetServerEnabled: true,
+		},
+	}
+
+	// Fleet Server whose Elasticsearch is unmanaged (external secret). The RBAC check is skipped
+	// for external associations, so the agent association should establish regardless of the reviewer.
+	fleetServerWithExternalES := &agentv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "fleet1", Namespace: "fleet-ns"},
+		Spec: agentv1alpha1.AgentSpec{
+			Version:            "8.0.0",
+			FleetServerEnabled: true,
+			ElasticsearchRefs: []agentv1alpha1.Output{
+				{ElasticsearchSelector: commonv1.ElasticsearchSelector{
+					ObjectSelector: commonv1.ObjectSelector{SecretName: "external-es-secret"},
+				}},
+			},
+		},
+	}
+
+	// agentObjEstablished simulates an agent whose FleetServer association was previously established.
+	agentObjEstablished := agentObj.DeepCopy()
+	agentObjEstablished.Annotations = map[string]string{
+		commonv1.FleetServerConfigAnnotationNameBase: esAssocConfAnnotation(commonv1.AssociationConf{
+			AuthSecretName: commonv1.NoAuthRequiredValue,
+			CACertProvided: true,
+			CASecretName:   "fleet1-agent-http-certs-public",
+			URL:            "https://fleet1-agent-http.fleet-ns.svc:8220",
+		}),
+	}
+
+	// staleCAInAgentNs simulates a transitive ES CA copy that was placed in the agent namespace
+	// during a previous reconcile where RBAC was allowed. It must be actively deleted when RBAC is revoked.
+	staleCAInAgentNs := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "stale-es-ca",
+			Namespace: "agent-ns",
+			Labels: map[string]string{
+				association.AdditionalSecretLabelName: "true",
+				AgentAssociationLabelName:             "agent1",
+				AgentAssociationLabelNamespace:        "agent-ns",
+				AgentAssociationLabelType:             commonv1.FleetServerAssociationType,
+				agent.NameLabelName:                   "fleet1",
+				agent.NamespaceLabelName:              "fleet-ns",
+			},
+		},
+		Data: map[string][]byte{"ca.crt": []byte("cacert")},
+	}
+
+	for _, tt := range []struct {
+		name            string
+		accessReviewer  rbac.AccessReviewer
+		runtimeObjs     []client.Object
+		wantStatus      commonv1.AssociationStatus
+		wantCAInAgentNs bool
+		wantConfCleared bool
+	}{
+		{
+			name:            "transitive ES RBAC allowed: association established and CA copied",
+			accessReviewer:  rbac.NewPermissiveAccessReviewer(),
+			runtimeObjs:     []client.Object{agentObj.DeepCopy(), fleetServer, es, fleetESCA, fleetHTTPCerts, fleetService},
+			wantStatus:      commonv1.AssociationEstablished,
+			wantCAInAgentNs: true,
+		},
+		{
+			name:            "transitive ES RBAC denied: association pending and CA not copied",
+			accessReviewer:  denyESReviewer{},
+			runtimeObjs:     []client.Object{agentObj.DeepCopy(), fleetServer, es, fleetESCA, fleetHTTPCerts, fleetService},
+			wantStatus:      commonv1.AssociationPending,
+			wantCAInAgentNs: false,
+		},
+		{
+			name:            "fleet server has no ES ref (manual setup): association establishes",
+			accessReviewer:  rbac.NewPermissiveAccessReviewer(),
+			runtimeObjs:     []client.Object{agentObj.DeepCopy(), fleetServerNoES, fleetHTTPCerts, fleetService},
+			wantStatus:      commonv1.AssociationEstablished,
+			wantCAInAgentNs: false,
+		},
+		{
+			name:            "established association is unbound when transitive ES RBAC is revoked",
+			accessReviewer:  denyESReviewer{},
+			runtimeObjs:     []client.Object{agentObjEstablished, fleetServer, es, fleetESCA, fleetHTTPCerts, fleetService, staleCAInAgentNs},
+			wantStatus:      commonv1.AssociationPending,
+			wantCAInAgentNs: false,
+			wantConfCleared: true,
+		},
+		{
+			name:            "transitive ES not found yet: association pending and CA not copied",
+			accessReviewer:  rbac.NewPermissiveAccessReviewer(),
+			runtimeObjs:     []client.Object{agentObj.DeepCopy(), fleetServer, fleetHTTPCerts, fleetService},
+			wantStatus:      commonv1.AssociationPending,
+			wantCAInAgentNs: false,
+		},
+		{
+			name:            "fleet server absent: association pending and CA not copied",
+			accessReviewer:  rbac.NewPermissiveAccessReviewer(),
+			runtimeObjs:     []client.Object{agentObj.DeepCopy()},
+			wantStatus:      commonv1.AssociationPending,
+			wantCAInAgentNs: false,
+		},
+		{
+			// denyESReviewer is used deliberately: external ES skips the RBAC check entirely,
+			// so the association must establish even though the reviewer would deny ES access.
+			name:            "fleet server ES is external (unmanaged): RBAC check skipped, association establishes",
+			accessReviewer:  denyESReviewer{},
+			runtimeObjs:     []client.Object{agentObj.DeepCopy(), fleetServerWithExternalES, fleetHTTPCerts, fleetService},
+			wantStatus:      commonv1.AssociationEstablished,
+			wantCAInAgentNs: false,
+		},
+		{
+			name:            "fleet server removes ES ref (switches to manual setup): stale CA copy cleaned up",
+			accessReviewer:  rbac.NewPermissiveAccessReviewer(),
+			runtimeObjs:     []client.Object{agentObjEstablished, fleetServerNoES, fleetHTTPCerts, fleetService, staleCAInAgentNs},
+			wantStatus:      commonv1.AssociationEstablished,
+			wantCAInAgentNs: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			r := association.NewTestAssociationReconcilerWithReviewer(
+				agentFleetServerAssociationInfo(),
+				tt.accessReviewer,
+				tt.runtimeObjs...,
+			)
+
+			_, err := r.Reconcile(t.Context(), reconcile.Request{NamespacedName: k8s.ExtractNamespacedName(agentObj)})
+			require.NoError(t, err)
+
+			var updatedAgent agentv1alpha1.Agent
+			require.NoError(t, r.Get(t.Context(), k8s.ExtractNamespacedName(agentObj), &updatedAgent))
+			require.Equal(t, tt.wantStatus, updatedAgent.Status.FleetServerAssociationStatus)
+
+			if tt.wantConfCleared {
+				_, hasConf := updatedAgent.Annotations[commonv1.FleetServerConfigAnnotationNameBase]
+				require.False(t, hasConf, "FleetServer association conf annotation must be removed when transitive ES RBAC is revoked")
+			}
+
+			var copiedSecrets corev1.SecretList
+			require.NoError(t, r.List(t.Context(), &copiedSecrets,
+				client.InNamespace("agent-ns"),
+				client.MatchingLabels{association.AdditionalSecretLabelName: "true"},
+			))
+			if tt.wantCAInAgentNs {
+				require.NotEmpty(t, copiedSecrets.Items, "transitive ES CA must be present in agent namespace when RBAC is allowed")
+				require.Contains(t, copiedSecrets.Items[0].Data, "ca.crt")
+			} else {
+				require.Empty(t, copiedSecrets.Items, "transitive ES CA must not be copied when transitive ES RBAC is denied")
+			}
+		})
+	}
 }

--- a/pkg/controller/association/controller/agent_kibana.go
+++ b/pkg/controller/association/controller/agent_kibana.go
@@ -43,8 +43,8 @@ func AddAgentKibana(mgr manager.Manager, accessReviewer rbac.AccessReviewer, par
 		AssociationResourceNameLabelName:      kblabel.KibanaNameLabelName,
 		AssociationResourceNamespaceLabelName: kblabel.KibanaNamespaceLabelName,
 
+		ElasticsearchRef: getElasticsearchFromKibana,
 		ElasticsearchUserCreation: &association.ElasticsearchUserCreation{ //nolint:gosec
-			ElasticsearchRef: getElasticsearchFromKibana,
 			UserSecretSuffix: "agent-kb-user",
 			ESUserRole: func(associated commonv1.Associated) (string, error) {
 				agent, ok := associated.(*agentv1alpha1.Agent)

--- a/pkg/controller/association/controller/apm_es.go
+++ b/pkg/controller/association/controller/apm_es.go
@@ -58,10 +58,8 @@ func AddApmES(mgr manager.Manager, accessReviewer rbac.AccessReviewer, params op
 		AssociationResourceNameLabelName:      eslabel.ClusterNameLabelName,
 		AssociationResourceNamespaceLabelName: eslabel.ClusterNamespaceLabelName,
 
+		ElasticsearchRef: directElasticsearchRef,
 		ElasticsearchUserCreation: &association.ElasticsearchUserCreation{
-			ElasticsearchRef: func(c k8s.Client, association commonv1.Association) (bool, commonv1.AssociationRef, error) {
-				return true, association.AssociationRef(), nil
-			},
 			UserSecretSuffix: "apm-user",
 			ESUserRole:       getAPMElasticsearchRoles,
 		},

--- a/pkg/controller/association/controller/apm_kibana.go
+++ b/pkg/controller/association/controller/apm_kibana.go
@@ -7,7 +7,6 @@ package controller
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -47,8 +46,8 @@ func AddApmKibana(mgr manager.Manager, accessReviewer rbac.AccessReviewer, param
 		AssociationResourceNameLabelName:      kblabel.KibanaNameLabelName,
 		AssociationResourceNamespaceLabelName: kblabel.KibanaNamespaceLabelName,
 
+		ElasticsearchRef: getElasticsearchFromKibana,
 		ElasticsearchUserCreation: &association.ElasticsearchUserCreation{ //nolint:gosec
-			ElasticsearchRef: getElasticsearchFromKibana,
 			UserSecretSuffix: "apm-kb-user",
 			ESUserRole: func(_ commonv1.Associated) (string, error) {
 				return user.ApmAgentUserRole, nil
@@ -122,23 +121,4 @@ func referencedKibanaStatusVersion(c k8s.Client, kbAssociation commonv1.Associat
 		return "", false, err
 	}
 	return kb.Status.Version, false, nil
-}
-
-// getElasticsearchFromKibana returns the Elasticsearch reference in which the user must be created for this association.
-func getElasticsearchFromKibana(c k8s.Client, association commonv1.Association) (bool, commonv1.AssociationRef, error) {
-	kibanaRef := association.AssociationRef()
-	if !kibanaRef.IsSet() {
-		return false, commonv1.ObjectSelector{}, nil
-	}
-
-	kb := kbv1.Kibana{}
-	err := c.Get(context.Background(), kibanaRef.NamespacedName(), &kb)
-	if errors.IsNotFound(err) {
-		return false, commonv1.ObjectSelector{}, nil
-	}
-	if err != nil {
-		return false, commonv1.ObjectSelector{}, err
-	}
-
-	return true, kb.EsAssociation().AssociationRef(), nil
 }

--- a/pkg/controller/association/controller/beat_es.go
+++ b/pkg/controller/association/controller/beat_es.go
@@ -21,7 +21,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/version"
 	eslabel "github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/label"
 	esuser "github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/user"
-	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/rbac"
 )
 
@@ -59,10 +58,8 @@ func AddBeatES(mgr manager.Manager, accessReviewer rbac.AccessReviewer, params o
 		AssociationResourceNameLabelName:      eslabel.ClusterNameLabelName,
 		AssociationResourceNamespaceLabelName: eslabel.ClusterNamespaceLabelName,
 
+		ElasticsearchRef: directElasticsearchRef,
 		ElasticsearchUserCreation: &association.ElasticsearchUserCreation{
-			ElasticsearchRef: func(c k8s.Client, association commonv1.Association) (bool, commonv1.AssociationRef, error) {
-				return true, association.AssociationRef(), nil
-			},
 			UserSecretSuffix: "beat-user",
 			ESUserRole:       getBeatRoles,
 		},

--- a/pkg/controller/association/controller/beat_kibana.go
+++ b/pkg/controller/association/controller/beat_kibana.go
@@ -46,8 +46,8 @@ func AddBeatKibana(mgr manager.Manager, accessReviewer rbac.AccessReviewer, para
 		AssociationResourceNameLabelName:      kblabel.KibanaNameLabelName,
 		AssociationResourceNamespaceLabelName: kblabel.KibanaNamespaceLabelName,
 
+		ElasticsearchRef: getElasticsearchFromKibana,
 		ElasticsearchUserCreation: &association.ElasticsearchUserCreation{ //nolint:gosec
-			ElasticsearchRef: getElasticsearchFromKibana,
 			UserSecretSuffix: "beat-kb-user",
 			ESUserRole:       getBeatKibanaRoles,
 		},

--- a/pkg/controller/association/controller/beat_monitoring.go
+++ b/pkg/controller/association/controller/beat_monitoring.go
@@ -16,7 +16,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/operator"
 	eslabel "github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/user"
-	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/rbac"
 )
 
@@ -44,10 +43,8 @@ func AddBeatMonitoring(mgr manager.Manager, accessReviewer rbac.AccessReviewer, 
 		AssociationResourceNameLabelName:      eslabel.ClusterNameLabelName,
 		AssociationResourceNamespaceLabelName: eslabel.ClusterNamespaceLabelName,
 
+		ElasticsearchRef: directElasticsearchRef,
 		ElasticsearchUserCreation: &association.ElasticsearchUserCreation{ //nolint:gosec
-			ElasticsearchRef: func(c k8s.Client, association commonv1.Association) (bool, commonv1.AssociationRef, error) {
-				return true, association.AssociationRef(), nil
-			},
 			UserSecretSuffix: "beat-es-mon-user",
 			ESUserRole: func(associated commonv1.Associated) (string, error) {
 				return user.StackMonitoringUserRole, nil

--- a/pkg/controller/association/controller/common.go
+++ b/pkg/controller/association/controller/common.go
@@ -1,0 +1,44 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package controller
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+
+	commonv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/common/v1"
+	kbv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/kibana/v1"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
+)
+
+// directElasticsearchRef is the ElasticsearchRef resolver for associations that reference
+// Elasticsearch directly: it returns the association's own ref unchanged.
+func directElasticsearchRef(_ context.Context, _ k8s.Client, assoc commonv1.Association) (bool, commonv1.AssociationRef, error) {
+	return true, assoc.AssociationRef(), nil
+}
+
+// getElasticsearchFromKibana returns the Elasticsearch reference in which the user must be created for this association.
+func getElasticsearchFromKibana(ctx context.Context, c k8s.Client, association commonv1.Association) (bool, commonv1.AssociationRef, error) {
+	kibanaRef := association.AssociationRef()
+	if !kibanaRef.IsSet() {
+		return false, commonv1.ObjectSelector{}, nil
+	}
+
+	kb := kbv1.Kibana{}
+	err := c.Get(ctx, kibanaRef.NamespacedName(), &kb)
+	if errors.IsNotFound(err) {
+		return false, commonv1.ObjectSelector{}, nil
+	}
+	if err != nil {
+		return false, commonv1.ObjectSelector{}, err
+	}
+
+	esRef := kb.EsAssociation().AssociationRef()
+	if !esRef.IsSet() {
+		return false, commonv1.ObjectSelector{}, nil
+	}
+	return true, esRef, nil
+}

--- a/pkg/controller/association/controller/common_test.go
+++ b/pkg/controller/association/controller/common_test.go
@@ -1,0 +1,102 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	beatv1beta1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/beat/v1beta1"
+	commonv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/common/v1"
+	kbv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/kibana/v1"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
+)
+
+func Test_getElasticsearchFromKibana(t *testing.T) {
+	tests := []struct {
+		name      string
+		assoc     func() commonv1.Association
+		objects   []client.Object
+		wantFound bool
+		wantRef   commonv1.AssociationRef
+		wantErr   bool
+	}{
+		{
+			name: "association kibana ref unset",
+			assoc: func() commonv1.Association {
+				return &beatv1beta1.BeatKibanaAssociation{
+					Beat: &beatv1beta1.Beat{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "beat"}},
+				}
+			},
+			wantFound: false,
+		},
+		{
+			name: "kibana not found",
+			assoc: func() commonv1.Association {
+				return &beatv1beta1.BeatKibanaAssociation{
+					Beat: &beatv1beta1.Beat{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "beat"},
+						Spec:       beatv1beta1.BeatSpec{KibanaRef: commonv1.ObjectSelector{Name: "kb", Namespace: "ns"}},
+					},
+				}
+			},
+			wantFound: false,
+		},
+		{
+			name: "kibana exists but has no elasticsearch ref",
+			assoc: func() commonv1.Association {
+				return &beatv1beta1.BeatKibanaAssociation{
+					Beat: &beatv1beta1.Beat{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "beat"},
+						Spec:       beatv1beta1.BeatSpec{KibanaRef: commonv1.ObjectSelector{Name: "kb", Namespace: "ns"}},
+					},
+				}
+			},
+			objects:   []client.Object{&kbv1.Kibana{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "kb"}}},
+			wantFound: false,
+		},
+		{
+			name: "kibana exists with elasticsearch ref",
+			assoc: func() commonv1.Association {
+				return &beatv1beta1.BeatKibanaAssociation{
+					Beat: &beatv1beta1.Beat{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "beat"},
+						Spec:       beatv1beta1.BeatSpec{KibanaRef: commonv1.ObjectSelector{Name: "kb", Namespace: "ns"}},
+					},
+				}
+			},
+			objects: []client.Object{&kbv1.Kibana{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "kb"},
+				Spec: kbv1.KibanaSpec{
+					ElasticsearchRef: commonv1.ElasticsearchSelector{
+						ObjectSelector: commonv1.ObjectSelector{Name: "es", Namespace: "ns"},
+					},
+				},
+			}},
+			wantFound: true,
+			wantRef:   commonv1.ElasticsearchSelector{ObjectSelector: commonv1.ObjectSelector{Name: "es", Namespace: "ns"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := k8s.NewFakeClient(tt.objects...)
+			found, ref, err := getElasticsearchFromKibana(context.Background(), c, tt.assoc())
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantFound, found)
+			if tt.wantFound {
+				require.Equal(t, tt.wantRef, ref)
+			}
+		})
+	}
+}

--- a/pkg/controller/association/controller/ent_es.go
+++ b/pkg/controller/association/controller/ent_es.go
@@ -16,7 +16,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/operator"
 	eslabel "github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/label"
 	esuser "github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/user"
-	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/rbac"
 )
 
@@ -54,10 +53,8 @@ func AddEntES(mgr manager.Manager, accessReviewer rbac.AccessReviewer, params op
 		AssociationResourceNameLabelName:      eslabel.ClusterNameLabelName,
 		AssociationResourceNamespaceLabelName: eslabel.ClusterNamespaceLabelName,
 
+		ElasticsearchRef: directElasticsearchRef,
 		ElasticsearchUserCreation: &association.ElasticsearchUserCreation{
-			ElasticsearchRef: func(c k8s.Client, association commonv1.Association) (bool, commonv1.AssociationRef, error) {
-				return true, association.AssociationRef(), nil
-			},
 			UserSecretSuffix: "ent-user",
 			ESUserRole: func(_ commonv1.Associated) (string, error) {
 				return esuser.SuperUserBuiltinRole, nil

--- a/pkg/controller/association/controller/es_monitoring.go
+++ b/pkg/controller/association/controller/es_monitoring.go
@@ -15,7 +15,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/operator"
 	eslabel "github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/user"
-	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/rbac"
 )
 
@@ -60,10 +59,8 @@ func esMonitoringAssociationInfo() association.AssociationInfo {
 		AssociationResourceNameLabelName:      eslabel.ClusterNameLabelName,
 		AssociationResourceNamespaceLabelName: eslabel.ClusterNamespaceLabelName,
 
+		ElasticsearchRef: directElasticsearchRef,
 		ElasticsearchUserCreation: &association.ElasticsearchUserCreation{ //nolint:gosec
-			ElasticsearchRef: func(c k8s.Client, association commonv1.Association) (bool, commonv1.AssociationRef, error) {
-				return true, association.AssociationRef(), nil
-			},
 			UserSecretSuffix: "beat-es-mon-user",
 			ESUserRole: func(associated commonv1.Associated) (string, error) {
 				return user.StackMonitoringUserRole, nil

--- a/pkg/controller/association/controller/kb_monitoring.go
+++ b/pkg/controller/association/controller/kb_monitoring.go
@@ -16,7 +16,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/operator"
 	eslabel "github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/user"
-	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/rbac"
 )
 
@@ -45,10 +44,8 @@ func AddKbMonitoring(mgr manager.Manager, accessReviewer rbac.AccessReviewer, pa
 		AssociationResourceNameLabelName:      eslabel.ClusterNameLabelName,
 		AssociationResourceNamespaceLabelName: eslabel.ClusterNamespaceLabelName,
 
+		ElasticsearchRef: directElasticsearchRef,
 		ElasticsearchUserCreation: &association.ElasticsearchUserCreation{ //nolint:gosec
-			ElasticsearchRef: func(c k8s.Client, association commonv1.Association) (bool, commonv1.AssociationRef, error) {
-				return true, association.AssociationRef(), nil
-			},
 			UserSecretSuffix: "beat-kb-mon-user",
 			ESUserRole: func(associated commonv1.Associated) (string, error) {
 				return user.StackMonitoringUserRole, nil

--- a/pkg/controller/association/controller/kibana_ent.go
+++ b/pkg/controller/association/controller/kibana_ent.go
@@ -43,6 +43,7 @@ func AddKibanaEnt(mgr manager.Manager, accessReviewer rbac.AccessReviewer, param
 		AssociationConfAnnotationNameBase:     commonv1.EntConfigAnnotationNameBase,
 		AssociationResourceNameLabelName:      entctl.EnterpriseSearchNameLabelName,
 		AssociationResourceNamespaceLabelName: entctl.EnterpriseSearchNamespaceLabelName,
+		ElasticsearchRef:                      nil, // no transitive ES association for Kibana->Ent connection
 		ElasticsearchUserCreation:             nil, // no dedicated ES user required for Kibana->Ent connection
 	})
 }

--- a/pkg/controller/association/controller/kibana_epr.go
+++ b/pkg/controller/association/controller/kibana_epr.go
@@ -44,6 +44,7 @@ func AddKibanaEPR(mgr manager.Manager, accessReviewer rbac.AccessReviewer, param
 		AssociationConfAnnotationNameBase:     commonv1.EPRConfigAnnotationNameBase,
 		AssociationResourceNameLabelName:      eprlabels.NameLabelName,
 		AssociationResourceNamespaceLabelName: eprlabels.PackageRegistryNamespaceLabelName,
+		ElasticsearchRef:                      nil, // no transitive ES association for Kibana->EPR connection
 		ElasticsearchUserCreation:             nil, // no dedicated ES user required for Kibana->EPR connection
 	})
 }

--- a/pkg/controller/association/controller/kibana_es.go
+++ b/pkg/controller/association/controller/kibana_es.go
@@ -62,10 +62,8 @@ func AddKibanaES(mgr manager.Manager, accessReviewer rbac.AccessReviewer, params
 		AssociationResourceNameLabelName:      eslabel.ClusterNameLabelName,
 		AssociationResourceNamespaceLabelName: eslabel.ClusterNamespaceLabelName,
 
+		ElasticsearchRef: directElasticsearchRef,
 		ElasticsearchUserCreation: &association.ElasticsearchUserCreation{
-			ElasticsearchRef: func(c k8s.Client, association commonv1.Association) (bool, commonv1.AssociationRef, error) {
-				return true, association.AssociationRef(), nil
-			},
 			UserSecretSuffix: "kibana-user",
 			ESUserRole: func(associated commonv1.Associated) (string, error) {
 				return KibanaSystemUserBuiltinRole, nil

--- a/pkg/controller/association/controller/logstash_es.go
+++ b/pkg/controller/association/controller/logstash_es.go
@@ -16,7 +16,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/operator"
 	eslabel "github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/user"
-	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/rbac"
 )
 
@@ -54,10 +53,8 @@ func AddLogstashES(mgr manager.Manager, accessReviewer rbac.AccessReviewer, para
 		AssociationResourceNameLabelName:      eslabel.ClusterNameLabelName,
 		AssociationResourceNamespaceLabelName: eslabel.ClusterNamespaceLabelName,
 
+		ElasticsearchRef: directElasticsearchRef,
 		ElasticsearchUserCreation: &association.ElasticsearchUserCreation{ //nolint:gosec
-			ElasticsearchRef: func(c k8s.Client, association commonv1.Association) (bool, commonv1.AssociationRef, error) {
-				return true, association.AssociationRef(), nil
-			},
 			UserSecretSuffix: "logstash-user",
 			ESUserRole: func(associated commonv1.Associated) (string, error) {
 				return user.LogstashUserRole, nil

--- a/pkg/controller/association/controller/logstash_monitoring.go
+++ b/pkg/controller/association/controller/logstash_monitoring.go
@@ -16,7 +16,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/operator"
 	eslabel "github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/user"
-	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/rbac"
 )
 
@@ -45,10 +44,8 @@ func AddLogstashMonitoring(mgr manager.Manager, accessReviewer rbac.AccessReview
 		AssociationResourceNameLabelName:      eslabel.ClusterNameLabelName,
 		AssociationResourceNamespaceLabelName: eslabel.ClusterNamespaceLabelName,
 
+		ElasticsearchRef: directElasticsearchRef,
 		ElasticsearchUserCreation: &association.ElasticsearchUserCreation{ //nolint:gosec
-			ElasticsearchRef: func(c k8s.Client, association commonv1.Association) (bool, commonv1.AssociationRef, error) {
-				return true, association.AssociationRef(), nil
-			},
 			UserSecretSuffix: "beat-ls-mon-user",
 			ESUserRole: func(associated commonv1.Associated) (string, error) {
 				return user.StackMonitoringUserRole, nil

--- a/pkg/controller/association/controller/maps_es.go
+++ b/pkg/controller/association/controller/maps_es.go
@@ -16,7 +16,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/operator"
 	eslabel "github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/user"
-	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/rbac"
 )
 
@@ -57,10 +56,8 @@ func AddMapsES(mgr manager.Manager, accessReviewer rbac.AccessReviewer, params o
 		AssociationResourceNameLabelName:      eslabel.ClusterNameLabelName,
 		AssociationResourceNamespaceLabelName: eslabel.ClusterNamespaceLabelName,
 
+		ElasticsearchRef: directElasticsearchRef,
 		ElasticsearchUserCreation: &association.ElasticsearchUserCreation{
-			ElasticsearchRef: func(c k8s.Client, association commonv1.Association) (bool, commonv1.AssociationRef, error) {
-				return true, association.AssociationRef(), nil
-			},
 			UserSecretSuffix: "maps-user",
 			ESUserRole: func(associated commonv1.Associated) (string, error) {
 				return MapsSystemUserBuiltinRole, nil

--- a/pkg/controller/association/controller_test.go
+++ b/pkg/controller/association/controller_test.go
@@ -18,6 +18,7 @@ import (
 
 	apmv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/apm/v1"
 	commonv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/common/v1"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
 	cachemock "github.com/elastic/cloud-on-k8s/v3/pkg/utils/test/mock"
 )
 
@@ -73,4 +74,44 @@ func Test_namespaceFlipRequests(t *testing.T) {
 		{NamespacedName: types.NamespacedName{Namespace: "scoped", Name: "cross-ref"}},
 		{NamespacedName: types.NamespacedName{Namespace: "descoped", Name: "default-ns-ref"}},
 	}, reqs)
+}
+
+func TestValidateAssociationInfo(t *testing.T) {
+	withUserCreation := &ElasticsearchUserCreation{UserSecretSuffix: "x"}
+	withESRef := func(_ context.Context, _ k8s.Client, assoc commonv1.Association) (bool, commonv1.AssociationRef, error) {
+		return true, assoc.AssociationRef(), nil
+	}
+
+	for _, tt := range []struct {
+		name    string
+		info    AssociationInfo
+		wantErr bool
+	}{
+		{
+			name: "both nil: valid (no user creation, no transitive ES ref)",
+			info: AssociationInfo{AssociationName: "test"},
+		},
+		{
+			name: "ElasticsearchRef set without user creation: valid (transitive RBAC only)",
+			info: AssociationInfo{AssociationName: "test", ElasticsearchRef: withESRef},
+		},
+		{
+			name: "both set: valid",
+			info: AssociationInfo{AssociationName: "test", ElasticsearchRef: withESRef, ElasticsearchUserCreation: withUserCreation},
+		},
+		{
+			name:    "user creation without ElasticsearchRef: invalid",
+			info:    AssociationInfo{AssociationName: "test", ElasticsearchUserCreation: withUserCreation},
+			wantErr: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateAssociationInfo(tt.info)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }

--- a/pkg/controller/association/dynamic_watches.go
+++ b/pkg/controller/association/dynamic_watches.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -121,6 +122,11 @@ func (r *Reconciler) reconcileWatches(ctx context.Context, associated types.Name
 			var toWatch []types.NamespacedName
 			for _, association := range associations {
 				secs, err := r.AdditionalSecrets(ctx, r.Client, association)
+				if apierrors.IsNotFound(err) {
+					// Transitive resource not yet created; no additional secrets to watch yet.
+					// The watch on the referenced resource re-enqueues when it appears.
+					continue
+				}
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/controller/association/reconciler.go
+++ b/pkg/controller/association/reconciler.go
@@ -115,15 +115,19 @@ type AssociationInfo struct { //nolint:revive
 	// association conf annotation) along with reconciler results for requeue scheduling.
 	ReconcileTransitiveESSecrets func(context.Context, k8s.Client, commonv1.Association, metadata.Metadata) (*commonv1.TransitiveESRef, *reconciler.Results)
 
+	// ElasticsearchRef resolves the (possibly transitive) Elasticsearch reference for this association.
+	// When set, RBAC is checked against the resolved ES before any side-effecting operations.
+	// Must be set whenever ElasticsearchUserCreation is non-nil. May also be set without
+	// ElasticsearchUserCreation to apply the transitive ES RBAC check for associations that
+	// copy ES-sourced secrets without creating a dedicated ES user (e.g. Agent -> Fleet Server -> Elasticsearch).
+	ElasticsearchRef func(ctx context.Context, c k8s.Client, assoc commonv1.Association) (bool, commonv1.AssociationRef, error)
+
 	// ElasticsearchUserCreation specifies settings to create an Elasticsearch user as part of the association.
 	// May be nil if no user creation is required.
 	ElasticsearchUserCreation *ElasticsearchUserCreation
 }
 
 type ElasticsearchUserCreation struct {
-	// ElasticsearchRef is a function which returns the maybe transitive Elasticsearch reference (eg. APMServer -> Kibana -> Elasticsearch).
-	// In the case of a transitive reference this is used to create the Elasticsearch user.
-	ElasticsearchRef func(c k8s.Client, association commonv1.Association) (bool, commonv1.AssociationRef, error)
 	// UserSecretSuffix is used as a suffix in the name of the secret holding user data in the associated namespace.
 	UserSecretSuffix string
 	// ESUserRole is the role to use for the Elasticsearch user created by the association.
@@ -295,6 +299,15 @@ func (r *Reconciler) reconcileAssociation(ctx context.Context, association commo
 		return status, results.WithError(err)
 	}
 
+	// Resolve the (possibly transitive) ES ref and enforce RBAC against it before any side-effecting operations.
+	// esAssocRef is nil in two cases: ElasticsearchRef is not configured at all, or ElasticsearchRef returns
+	// !found with ElasticsearchUserCreation==nil (e.g. Fleet Server in manual-setup mode with no ES ref).
+	// The ElasticsearchUserCreation==nil guard below prevents any dereference in either path.
+	esAssocRef, es, assocStatus, err := r.resolveESAndCheckRBAC(ctx, association)
+	if assocStatus != "" || err != nil {
+		return assocStatus, results.WithError(err)
+	}
+
 	// metadata to propagate to children
 	assocMeta := metadata.Propagate(association, metadata.Metadata{Labels: r.AssociationResourceLabels(k8s.ExtractNamespacedName(association), association.AssociationRef().NamespacedName())})
 	caSecret, err := r.ReconcileCASecret(
@@ -375,16 +388,6 @@ func (r *Reconciler) reconcileAssociation(ctx context.Context, association commo
 		return status, results.WithError(err)
 	}
 
-	// since Elasticsearch can be a transitive reference we need to use the provided ElasticsearchRef function
-	found, esAssocRef, err := r.ElasticsearchUserCreation.ElasticsearchRef(r.Client, association)
-	if err != nil {
-		return commonv1.AssociationFailed, results.WithError(err)
-	}
-	// the Elasticsearch ref does not exist yet, set status to Pending
-	if !found {
-		return commonv1.AssociationPending, results.WithError(RemoveAssociationConf(ctx, r.Client, association))
-	}
-
 	if esAssocRef.IsExternal() {
 		log.V(1).Info("Association with a transitive unmanaged Elasticsearch, skip user creation",
 			"name", association.Associated().GetName(), "ref_name", assocRef.NameOrSecretName(), "es_ref_name", esAssocRef.NameOrSecretName())
@@ -393,17 +396,6 @@ func (r *Reconciler) reconcileAssociation(ctx context.Context, association commo
 		expectedAssocConf.AuthSecretKey = authPasswordUnmanagedSecretKey
 		status, err := r.updateAssocConf(ctx, expectedAssocConf, association)
 		return status, results.WithError(err)
-	}
-
-	// retrieve the Elasticsearch resource
-	es, associationStatus, err := r.getElasticsearch(ctx, association, esAssocRef)
-	if associationStatus != "" || err != nil {
-		return associationStatus, results.WithError(err)
-	}
-
-	// check if reference to Elasticsearch is allowed to be established
-	if allowed, err := CheckAndUnbind(ctx, r.accessReviewer, association, &es, r, r.recorder); err != nil || !allowed {
-		return commonv1.AssociationPending, results.WithError(err)
 	}
 
 	serviceAccount, err := association.ElasticServiceAccount()
@@ -504,6 +496,56 @@ func (r *Reconciler) getElasticsearch(
 	return es, "", nil
 }
 
+// resolveESAndCheckRBAC resolves the (possibly transitive) Elasticsearch reference for the association
+// and checks RBAC against it. It returns the resolved ref and ES object for use by the caller.
+// A non-empty status or a non-nil error means the caller should return immediately.
+func (r *Reconciler) resolveESAndCheckRBAC(ctx context.Context, association commonv1.Association) (commonv1.AssociationRef, esv1.Elasticsearch, commonv1.AssociationStatus, error) {
+	if r.ElasticsearchRef == nil {
+		return nil, esv1.Elasticsearch{}, "", nil
+	}
+	found, esAssocRef, err := r.ElasticsearchRef(ctx, r.Client, association)
+	if err != nil {
+		return nil, esv1.Elasticsearch{}, commonv1.AssociationFailed, err
+	}
+	if !found {
+		if r.ElasticsearchUserCreation != nil {
+			// Transitive ES not yet established; without it we cannot create the ES user.
+			return nil, esv1.Elasticsearch{}, commonv1.AssociationPending, RemoveAssociationConf(ctx, r.Client, association)
+		}
+		// No ES ref and no user creation required (e.g. Fleet Server with no ES ref
+		// configured - manual setup). Skip the transitive RBAC check and proceed.
+		return nil, esv1.Elasticsearch{}, "", nil
+	}
+	if esAssocRef.IsExternal() {
+		return esAssocRef, esv1.Elasticsearch{}, "", nil
+	}
+	es, status, err := r.getElasticsearch(ctx, association, esAssocRef)
+	if status != "" || err != nil {
+		return nil, esv1.Elasticsearch{}, status, err
+	}
+	if allowed, err := CheckAndUnbind(ctx, r.accessReviewer, association, &es, r, r.recorder); err != nil || !allowed {
+		return nil, esv1.Elasticsearch{}, commonv1.AssociationPending, err
+	}
+	return esAssocRef, es, "", nil
+}
+
+// deleteAllAssociationSecrets deletes every secret in the associated resource's namespace that
+// carries the association's resource labels: the CA copy, additional-secret copies, and any
+// transitive ES client cert secrets.
+func (r *Reconciler) deleteAllAssociationSecrets(ctx context.Context, association commonv1.Association) error {
+	assocLabels := r.AssociationResourceLabels(k8s.ExtractNamespacedName(association), association.AssociationRef().NamespacedName())
+	var secrets corev1.SecretList
+	if err := r.List(ctx, &secrets, client.InNamespace(association.GetNamespace()), assocLabels); err != nil {
+		return err
+	}
+	for i := range secrets.Items {
+		if err := k8s.DeleteSecretIfExists(ctx, r.Client, k8s.ExtractNamespacedName(&secrets.Items[i])); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Unbind removes the association resources.
 func (r *Reconciler) Unbind(ctx context.Context, association commonv1.Association) error {
 	associated := k8s.ExtractNamespacedName(association)
@@ -535,13 +577,10 @@ func (r *Reconciler) Unbind(ctx context.Context, association commonv1.Associatio
 		}
 	}
 
-	// Delete any per-agent additional secret copies (e.g. transitive ES CA) that
-	// live in the associated resource's namespace. Passing nil or an empty set deletes all copies.
-	if r.AdditionalSecrets != nil {
-		assocLabels := r.AssociationResourceLabels(k8s.ExtractNamespacedName(association), association.AssociationRef().NamespacedName())
-		if err := deleteStaleAdditionalSecrets(ctx, r.Client, association.GetNamespace(), assocLabels, nil); err != nil {
-			return err
-		}
+	// Delete all association-labeled secrets in the associated resource's namespace: CA copy,
+	// additional-secret copies, and any transitive ES client cert secrets.
+	if err := r.deleteAllAssociationSecrets(ctx, association); err != nil {
+		return err
 	}
 
 	// Also remove the association configuration
@@ -673,10 +712,14 @@ func (r *Reconciler) onDelete(ctx context.Context, associated types.NamespacedNa
 
 // NewTestAssociationReconciler creates a new AssociationReconciler given an AssociationInfo for testing.
 func NewTestAssociationReconciler(assocInfo AssociationInfo, runtimeObjs ...client.Object) Reconciler {
+	return NewTestAssociationReconcilerWithReviewer(assocInfo, rbac.NewPermissiveAccessReviewer(), runtimeObjs...)
+}
+
+func NewTestAssociationReconcilerWithReviewer(assocInfo AssociationInfo, reviewer rbac.AccessReviewer, runtimeObjs ...client.Object) Reconciler {
 	return Reconciler{
 		AssociationInfo: assocInfo,
 		Client:          k8s.NewFakeClient(runtimeObjs...),
-		accessReviewer:  rbac.NewPermissiveAccessReviewer(),
+		accessReviewer:  reviewer,
 		watches:         watches.NewDynamicWatches(),
 		recorder:        toolsevents.NewFakeRecorder(10),
 		Parameters: operator.Parameters{

--- a/pkg/controller/association/reconciler_test.go
+++ b/pkg/controller/association/reconciler_test.go
@@ -7,6 +7,7 @@ package association
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -95,10 +96,10 @@ var (
 		AssociationConfAnnotationNameBase:     "association.k8s.elastic.co/es-conf",
 		AssociationResourceNameLabelName:      "elasticsearch.k8s.elastic.co/cluster-name",
 		AssociationResourceNamespaceLabelName: "elasticsearch.k8s.elastic.co/cluster-namespace",
+		ElasticsearchRef: func(_ context.Context, c k8s.Client, association commonv1.Association) (bool, commonv1.AssociationRef, error) {
+			return true, association.AssociationRef(), nil
+		},
 		ElasticsearchUserCreation: &ElasticsearchUserCreation{
-			ElasticsearchRef: func(c k8s.Client, association commonv1.Association) (bool, commonv1.AssociationRef, error) {
-				return true, association.AssociationRef(), nil
-			},
 			UserSecretSuffix: "kibana-user",
 			ESUserRole: func(associated commonv1.Associated) (string, error) {
 				return "kibana_system", nil
@@ -402,25 +403,59 @@ func TestReconciler_Reconcile_NoES(t *testing.T) {
 }
 
 func TestReconciler_Reconcile_RBACNotAllowed(t *testing.T) {
-	kb := sampleAssociatedKibana()
-	require.NotEmpty(t, kb.Annotations[kb.EsAssociation().AssociationConfAnnotationName()])
-	r := testReconciler(&kb, &sampleES, &kibanaUserInESNamespace, esHTTPService())
-	// simulate rbac association disallowed
-	r.accessReviewer = denyAllAccessReviewer{}
-	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: k8s.ExtractNamespacedName(&kb)})
-	require.NoError(t, err)
-	// association should be pending
-	var updatedKibana kbv1.Kibana
-	err = r.Get(context.Background(), k8s.ExtractNamespacedName(&kb), &updatedKibana)
-	require.NoError(t, err)
-	require.Equal(t, commonv1.AssociationPending, updatedKibana.Status.AssociationStatus)
-	// association conf should be removed
-	require.Empty(t, updatedKibana.Annotations[kb.EsAssociation().AssociationConfAnnotationName()])
-	// user in es namespace should be deleted
-	var secret corev1.Secret
-	err = r.Get(context.Background(), k8s.ExtractNamespacedName(&kibanaUserInESNamespace), &secret)
-	require.Error(t, err)
-	require.True(t, apierrors.IsNotFound(err))
+	for _, tt := range []struct {
+		name             string
+		setup            func(*toolsevents.FakeRecorder) (Reconciler, types.NamespacedName)
+		wantWarningEvent bool
+		checkResult      func(*testing.T, Reconciler, kbv1.Kibana)
+	}{
+		{
+			name: "ES association denied: blocks (pending), conf cleared, user deleted",
+			setup: func(rec *toolsevents.FakeRecorder) (Reconciler, types.NamespacedName) {
+				kb := sampleAssociatedKibana()
+				require.NotEmpty(t, kb.Annotations[kb.EsAssociation().AssociationConfAnnotationName()])
+				r := testReconciler(&kb, &sampleES, &kibanaUserInESNamespace, esHTTPService())
+				r.accessReviewer = denyAllAccessReviewer{}
+				r.recorder = rec
+				return r, k8s.ExtractNamespacedName(&kb)
+			},
+			wantWarningEvent: true,
+			checkResult: func(t *testing.T, r Reconciler, kb kbv1.Kibana) {
+				t.Helper()
+				require.Equal(t, commonv1.AssociationPending, kb.Status.AssociationStatus)
+				require.Empty(t, kb.Annotations[kb.EsAssociation().AssociationConfAnnotationName()])
+				var secret corev1.Secret
+				err := r.Get(context.Background(), k8s.ExtractNamespacedName(&kibanaUserInESNamespace), &secret)
+				require.True(t, apierrors.IsNotFound(err))
+			},
+		},
+		{
+			name: "permissive reviewer (RBAC always allowed): association establishes, no warning event",
+			setup: func(rec *toolsevents.FakeRecorder) (Reconciler, types.NamespacedName) {
+				kb := sampleKibanaWithESRef()
+				r := testReconciler(&kb, &sampleES, &esHTTPPublicCertsSecret, esHTTPService())
+				r.recorder = rec
+				return r, k8s.ExtractNamespacedName(&kb)
+			},
+			wantWarningEvent: false,
+			checkResult: func(t *testing.T, _ Reconciler, kb kbv1.Kibana) {
+				t.Helper()
+				require.Equal(t, commonv1.AssociationEstablished, kb.Status.AssociationStatus)
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := toolsevents.NewFakeRecorder(10)
+			r, nsn := tt.setup(recorder)
+			_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: nsn})
+			require.NoError(t, err)
+			var updatedKibana kbv1.Kibana
+			require.NoError(t, r.Get(context.Background(), nsn, &updatedKibana))
+			gotWarning := strings.HasPrefix(fetchEvent(recorder), corev1.EventTypeWarning)
+			require.Equal(t, tt.wantWarningEvent, gotWarning)
+			tt.checkResult(t, r, updatedKibana)
+		})
+	}
 }
 
 func TestReconciler_Reconcile_NewAssociation(t *testing.T) {
@@ -869,10 +904,10 @@ func TestReconciler_Reconcile_MultiRef(t *testing.T) {
 		AssociationConfAnnotationNameBase:     commonv1.ElasticsearchConfigAnnotationNameBase,
 		AssociationResourceNameLabelName:      eslabel.ClusterNameLabelName,
 		AssociationResourceNamespaceLabelName: eslabel.ClusterNamespaceLabelName,
+		ElasticsearchRef: func(_ context.Context, c k8s.Client, association commonv1.Association) (bool, commonv1.AssociationRef, error) {
+			return true, association.AssociationRef(), nil
+		},
 		ElasticsearchUserCreation: &ElasticsearchUserCreation{
-			ElasticsearchRef: func(c k8s.Client, association commonv1.Association) (bool, commonv1.AssociationRef, error) {
-				return true, association.AssociationRef(), nil
-			},
 			UserSecretSuffix: "agent-user",
 			ESUserRole: func(associated commonv1.Associated) (string, error) {
 				return "superuser", nil
@@ -2077,6 +2112,83 @@ func TestReconciler_Unbind(t *testing.T) {
 				require.True(t, apierrors.IsNotFound(err), "cross-namespace CA copy must be deleted by Unbind")
 			},
 		},
+		{
+			name: "CA secret without AdditionalSecretLabel is deleted",
+			setup: func() (Reconciler, commonv1.Association) {
+				caSecretNoLabel := corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: agentNS,
+						Name:      "agent1-fleetserver-ca",
+						Labels:    map[string]string{"test": "fleet1", "test-ns": "fleet-ns"},
+					},
+				}
+				r := Reconciler{
+					AssociationInfo: AssociationInfo{
+						Labels:                                func(types.NamespacedName) map[string]string { return nil },
+						AssociationResourceNameLabelName:      "test",
+						AssociationResourceNamespaceLabelName: "test-ns",
+						ReferencedResourceNamer:               common_name.NewNamer("agent"),
+					},
+					Client:  k8s.NewFakeClient(&crossNSAgent, &caSecretNoLabel),
+					watches: watches.NewDynamicWatches(),
+				}
+				return r, crossNSAgent.GetAssociations()[0]
+			},
+			check: func(t *testing.T, r Reconciler) {
+				t.Helper()
+				var got corev1.Secret
+				err := r.Client.Get(context.Background(), types.NamespacedName{Namespace: agentNS, Name: "agent1-fleetserver-ca"}, &got)
+				require.True(t, apierrors.IsNotFound(err), "CA secret without AdditionalSecretLabelName must be deleted by Unbind")
+			},
+		},
+		{
+			name: "all association-labeled secrets deleted; unrelated secret survives",
+			setup: func() (Reconciler, commonv1.Association) {
+				assocLabels := map[string]string{"test": "fleet1", "test-ns": "fleet-ns"}
+				caSecretNoLabel := corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Namespace: agentNS, Name: "agent1-fleetserver-ca", Labels: assocLabels},
+				}
+				additionalCopy := corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: agentNS,
+						Name:      "fleet1-es-ca-copy",
+						Labels: map[string]string{
+							AdditionalSecretLabelName: "true",
+							"test":                    "fleet1",
+							"test-ns":                 "fleet-ns",
+						},
+					},
+				}
+				clientCertSecret := corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Namespace: agentNS, Name: "agent1-es-client-cert", Labels: assocLabels},
+				}
+				unrelatedSecret := corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Namespace: agentNS, Name: "unrelated-secret"},
+				}
+				r := Reconciler{
+					AssociationInfo: AssociationInfo{
+						Labels:                                func(types.NamespacedName) map[string]string { return nil },
+						AssociationResourceNameLabelName:      "test",
+						AssociationResourceNamespaceLabelName: "test-ns",
+						ReferencedResourceNamer:               common_name.NewNamer("agent"),
+					},
+					Client:  k8s.NewFakeClient(&crossNSAgent, &caSecretNoLabel, &additionalCopy, &clientCertSecret, &unrelatedSecret),
+					watches: watches.NewDynamicWatches(),
+				}
+				return r, crossNSAgent.GetAssociations()[0]
+			},
+			check: func(t *testing.T, r Reconciler) {
+				t.Helper()
+				for _, name := range []string{"agent1-fleetserver-ca", "fleet1-es-ca-copy", "agent1-es-client-cert"} {
+					var got corev1.Secret
+					err := r.Client.Get(context.Background(), types.NamespacedName{Namespace: agentNS, Name: name}, &got)
+					require.True(t, apierrors.IsNotFound(err), "secret %q must be deleted by Unbind", name)
+				}
+				var got corev1.Secret
+				require.NoError(t, r.Client.Get(context.Background(), types.NamespacedName{Namespace: agentNS, Name: "unrelated-secret"}, &got),
+					"unrelated secret must survive Unbind")
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			r, assoc := tt.setup()
@@ -2084,6 +2196,45 @@ func TestReconciler_Unbind(t *testing.T) {
 			tt.check(t, r)
 		})
 	}
+}
+
+func TestReconciler_ReconcileThenUnbind(t *testing.T) {
+	kb := sampleKibanaWithESRef()
+	r := testReconciler(&kb, &sampleES, &esHTTPPublicCertsSecret, esHTTPService())
+
+	// Reconcile to establish the association and create all secrets.
+	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: k8s.ExtractNamespacedName(&kb)})
+	require.NoError(t, err)
+
+	// Verify the three secrets created by the reconcile exist.
+	for _, nsn := range []types.NamespacedName{
+		k8s.ExtractNamespacedName(&kibanaUserInESNamespace),
+		k8s.ExtractNamespacedName(&kibanaUserInKibanaNamespace),
+		k8s.ExtractNamespacedName(&esCertsInKibanaNamespace),
+	} {
+		var s corev1.Secret
+		require.NoError(t, r.Get(context.Background(), nsn, &s), "secret %s must exist after reconcile", nsn)
+	}
+
+	// Unbind should remove all of them.
+	var updatedKb kbv1.Kibana
+	require.NoError(t, r.Get(context.Background(), k8s.ExtractNamespacedName(&kb), &updatedKb))
+	require.NoError(t, r.Unbind(context.Background(), updatedKb.EsAssociation()))
+
+	for _, nsn := range []types.NamespacedName{
+		k8s.ExtractNamespacedName(&kibanaUserInESNamespace),
+		k8s.ExtractNamespacedName(&kibanaUserInKibanaNamespace),
+		k8s.ExtractNamespacedName(&esCertsInKibanaNamespace),
+	} {
+		var s corev1.Secret
+		err := r.Get(context.Background(), nsn, &s)
+		require.True(t, apierrors.IsNotFound(err), "secret %s must be deleted after Unbind", nsn)
+	}
+
+	// Association conf annotation must also be cleared.
+	require.NoError(t, r.Get(context.Background(), k8s.ExtractNamespacedName(&kb), &updatedKb))
+	require.Empty(t, updatedKb.Annotations[kb.EsAssociation().AssociationConfAnnotationName()],
+		"association conf annotation must be cleared after Unbind")
 }
 
 func TestReconcileWatches_SameNamespace_WatchRegistered(t *testing.T) {


### PR DESCRIPTION
## Summary

The Agent-to-Fleet-Server association controller was not enforcing Elasticsearch RBAC for the transitive path Agent -> Fleet Server -> Elasticsearch. When a fleet-managed Agent associated with a Fleet Server that itself referenced an Elasticsearch cluster in a different namespace, the operator would copy CA and authentication certificates to the Agent's namespace without first checking whether the Agent's namespace was permitted to access that Elasticsearch. This allowed cross-namespace credential access that bypassed the RBAC boundary ECK enforces for direct associations.

The fix promotes `ElasticsearchRef` from inside `ElasticsearchUserCreation` to the top-level `AssociationInfo` struct, making it usable by association types that copy ES-sourced secrets without creating an ES user. The Agent-FleetServer controller now wires in a transitive resolver (`agentFleetServerESRef`) that follows the Agent -> Fleet Server -> Elasticsearch chain. A shared `resolveESAndCheckRBAC` helper, called at the start of `reconcileAssociation`, fetches the Elasticsearch resource and runs `CheckAndUnbind` before any secret copies or annotations are written.

A secondary fix broadens the `Unbind` path: it now deletes all secrets bearing the association's resource labels (CA copies, additional secret copies, transitive client cert secrets) regardless of whether `AdditionalSecrets` is configured, closing a gap where stale copies could persist after the association was removed.

Relates #9683

## Changes

- Promoted `ElasticsearchRef` from `ElasticsearchUserCreation` to top-level `AssociationInfo`, enabling RBAC enforcement for association types that copy ES-sourced secrets but do not create an ES user.
- Added `agentFleetServerESRef` to the Agent-FleetServer controller to resolve the transitive Elasticsearch reference through the Fleet Server, and wired it as the `ElasticsearchRef` for RBAC checks.
- Extracted `resolveESAndCheckRBAC` in the association reconciler to perform ES resolution and RBAC enforcement as the first step in `reconcileAssociation`, before any side-effecting operations.
- Broadened `Unbind` to delete all secrets carrying the association's resource labels using a label selector, replacing the `AdditionalSecrets`-gated deletion that missed CA and transitive client-cert copies.
- Added `ValidateAssociationInfo` to catch misconfigured `AssociationInfo` (e.g. `ElasticsearchUserCreation` set without `ElasticsearchRef`) at controller registration time.
- Added `TestRegisterControllers` smoke test to verify all association controller registrations succeed before the operator starts.
- Extracted shared `directElasticsearchRef` and `getElasticsearchFromKibana` helpers into `common.go`; extracted `getFleetServerESAssociation` to eliminate duplication across `additionalSecrets`, `agentFleetServerESRef`, and `fleetManagedAgentTransitiveESRef`.
- Added `NewTestAssociationReconcilerWithReviewer` to allow unit tests to inject a custom `AccessReviewer`.
- Added not-found guard in `reconcileWatches` so a missing transitive resource does not surface as an error when computing dynamic watches.
