### PR TITLE
Move GKE CI tests + DEV to europe-west1 on N2D

### DIFF
--- a/hack/deployer/README.md
+++ b/hack/deployer/README.md
@@ -18,6 +18,31 @@ Deployer is the provisioning tool that aims to be the interface to multiple Kube
     make switch-gke bootstrap-cloud
     ```
 
+  The `gke-dev` plan uses GKE Persistent Disk for `e2e-default` and does not
+  attach Local SSDs by default. To reproduce the CI storage setup, enable raw
+  NVMe Local SSD before initially creating the cluster. This single setting
+  both attaches one Local SSD to every node and provisions it as fixed-size
+  local PersistentVolumes.
+
+  Add `localNvmeSsdBlock` to the `gke` overrides in the generated
+  `hack/deployer/config/deployer-config-gke.yml` before running
+  `make bootstrap-cloud`:
+
+    ```yaml
+    overrides:
+      gke:
+        localNvmeSsdBlock: true
+    ```
+
+  This override only takes effect during cluster creation and cannot enable
+  Local SSD on an existing cluster. To opt in later, migrate or back up any
+  existing `e2e-default` data, delete the cluster, and create it again with the
+  override enabled.
+
+  The GKE `localSsdCount` setting is deprecated and retained only for
+  compatibility with existing deployer configurations. New configurations
+  should use `localNvmeSsdBlock`.
+
 * AKS
 
   * Install [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest)

--- a/hack/deployer/config/local-disks-gke/gke-nvme-format-script-patch.yaml
+++ b/hack/deployer/config/local-disks-gke/gke-nvme-format-script-patch.yaml
@@ -12,16 +12,31 @@
       exit 1
     fi
 
-    if ! blkid "${device}" >/dev/null 2>&1; then
-      echo "Formatting ${device} as ext4"
-      mkfs.ext4 -m 0 -F "${device}"
-    fi
-
     mkdir -p "${mount_point}"
     if mountpoint -q -- "${mount_point}"; then
       echo "${mount_point} already mounted"
       exit 0
     fi
+
+    if findmnt -rn --source "${device}" >/dev/null 2>&1; then
+      echo "${device} is already mounted outside ${mount_point}; refusing to format or remount it" >&2
+      exit 1
+    fi
+
+    filesystem_type=$(blkid -s TYPE -o value "${device}" 2>/dev/null || true)
+    case "${filesystem_type}" in
+      "")
+        echo "Formatting ${device} as ext4"
+        mkfs.ext4 -m 0 -F "${device}"
+        ;;
+      ext4)
+        echo "${device} already contains an ext4 filesystem"
+        ;;
+      *)
+        echo "${device} contains unsupported filesystem ${filesystem_type}; refusing to format it" >&2
+        exit 1
+        ;;
+    esac
 
     echo "Mounting ${device} at ${mount_point}"
     mount -t ext4 -o defaults,noatime,discard,nobarrier "${device}" "${mount_point}"

--- a/hack/deployer/config/local-disks-gke/gke-nvme-format-script-patch.yaml
+++ b/hack/deployer/config/local-disks-gke/gke-nvme-format-script-patch.yaml
@@ -4,8 +4,8 @@
     #!/bin/sh
     set -eu
 
-    device=/dev/disk/by-id/google-local-ssd-block0
-    mount_point=/mnt/disks/ssd0
+    device=${GKE_LOCAL_SSD_DEVICE:-/dev/disk/by-id/google-local-ssd-block0}
+    mount_point=${GKE_LOCAL_SSD_MOUNT_POINT:-/mnt/disks/ssd0}
 
     if [ ! -e "${device}" ]; then
       echo "GKE raw NVMe Local SSD not found at ${device}" >&2

--- a/hack/deployer/config/local-disks-gke/gke-nvme-format-script-patch.yaml
+++ b/hack/deployer/config/local-disks-gke/gke-nvme-format-script-patch.yaml
@@ -11,14 +11,21 @@
       echo "GKE raw NVMe Local SSD not found at ${device}" >&2
       exit 1
     fi
+    canonical_device=$(readlink -f "${device}")
 
     mkdir -p "${mount_point}"
     if mountpoint -q -- "${mount_point}"; then
-      echo "${mount_point} already mounted"
-      exit 0
+      mounted_source=$(findmnt -rn -o SOURCE --target "${mount_point}")
+      canonical_mounted_source=$(readlink -f "${mounted_source}" 2>/dev/null || true)
+      if [ "${canonical_mounted_source}" = "${canonical_device}" ]; then
+        echo "${device} already mounted at ${mount_point}"
+        exit 0
+      fi
+      echo "${mount_point} is mounted from unexpected source ${mounted_source}; expected ${device}" >&2
+      exit 1
     fi
 
-    if findmnt -rn --source "${device}" >/dev/null 2>&1; then
+    if findmnt -rn --source "${canonical_device}" >/dev/null 2>&1; then
       echo "${device} is already mounted outside ${mount_point}; refusing to format or remount it" >&2
       exit 1
     fi

--- a/hack/deployer/config/local-disks-gke/gke-nvme-format-script-patch.yaml
+++ b/hack/deployer/config/local-disks-gke/gke-nvme-format-script-patch.yaml
@@ -1,0 +1,27 @@
+- op: add
+  path: /data/gke-nvme-format.sh
+  value: |-
+    #!/bin/sh
+    set -eu
+
+    device=/dev/disk/by-id/google-local-ssd-block0
+    mount_point=/mnt/disks/ssd0
+
+    if [ ! -e "${device}" ]; then
+      echo "GKE raw NVMe Local SSD not found at ${device}" >&2
+      exit 1
+    fi
+
+    if ! blkid "${device}" >/dev/null 2>&1; then
+      echo "Formatting ${device} as ext4"
+      mkfs.ext4 -m 0 -F "${device}"
+    fi
+
+    mkdir -p "${mount_point}"
+    if mountpoint -q -- "${mount_point}"; then
+      echo "${mount_point} already mounted"
+      exit 0
+    fi
+
+    echo "Mounting ${device} at ${mount_point}"
+    mount -t ext4 -o defaults,noatime,discard,nobarrier "${device}" "${mount_point}"

--- a/hack/deployer/config/local-disks-gke/gke-nvme-init-container-patch.yaml
+++ b/hack/deployer/config/local-disks-gke/gke-nvme-init-container-patch.yaml
@@ -1,0 +1,23 @@
+- op: add
+  path: /spec/template/spec/initContainers/0
+  value:
+    name: gke-nvme-format
+    image: cgr.dev/chainguard/wolfi-base:latest
+    securityContext:
+      privileged: true
+    command:
+      - sh
+      - -c
+      - |-
+        apk update \
+          && apk add e2fsprogs mount util-linux \
+          && /bin/gke-nvme-format.sh
+    volumeMounts:
+      - mountPath: /bin/gke-nvme-format.sh
+        name: setup-disks
+        subPath: gke-nvme-format.sh
+      - mountPath: /mnt/disks
+        name: e2e-default
+        mountPropagation: Bidirectional
+      - mountPath: /dev
+        name: host-dev

--- a/hack/deployer/config/local-disks-gke/kustomization.yaml
+++ b/hack/deployer/config/local-disks-gke/kustomization.yaml
@@ -1,0 +1,15 @@
+resources:
+  - ../local-disks
+patches:
+  - target:
+      group: ""
+      version: v1
+      kind: ConfigMap
+      name: setup-disks
+    path: gke-nvme-format-script-patch.yaml
+  - target:
+      group: apps
+      version: v1
+      kind: DaemonSet
+      name: local-volume-provisioner
+    path: gke-nvme-init-container-patch.yaml

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -4,14 +4,14 @@ plans:
   clusterName: ci
   provider: gke
   kubernetesVersion: 1.34
-  machineType: n1-standard-4
+  machineType: n2d-standard-4
   serviceAccount: true
   enforceSecurityPolicies: true
-  # use kustomize in GKE to remove the NVMe provisioning already taken care of by the platform
-  diskSetup: kubectl apply -k hack/deployer/config/local-disks
+  # Format and mount the raw GKE NVMe Local SSD before provisioning fixed-size local PVs.
+  diskSetup: kubectl apply -k hack/deployer/config/local-disks-gke
   gke:
-    region: us-central1
-    localSsdCount: 1
+    region: us-east4
+    localNvmeSsdBlock: true
     nodeCountPerZone: 1
     gcpScopes: https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/trace.append
 - id: gke-autopilot-ci
@@ -25,7 +25,7 @@ plans:
   # diskSetup: kubectl apply -k hack/deployer/config/local-disks
   gke:
     autopilot: true
-    region: us-central1
+    region: us-east4
     gcpScopes: https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/trace.append
 - id: gke-dev
   operation: create

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -7,10 +7,9 @@ plans:
   machineType: n2d-standard-4
   serviceAccount: true
   enforceSecurityPolicies: true
-  # Format and mount the raw GKE NVMe Local SSD before provisioning fixed-size local PVs.
-  diskSetup: kubectl apply -k hack/deployer/config/local-disks-gke
   gke:
     region: europe-west1
+    # Attach, format, and provision the raw Local SSD as fixed-size local PVs.
     localNvmeSsdBlock: true
     nodeCountPerZone: 1
     gcpScopes: https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/trace.append
@@ -32,9 +31,11 @@ plans:
   clusterName: dev
   provider: gke
   kubernetesVersion: 1.34
-  machineType: n1-standard-8
+  machineType: n2d-standard-8
   serviceAccount: false
   enforceSecurityPolicies: true
+  # CI-equivalent Local SSD-backed PVs can be enabled before cluster creation.
+  # See hack/deployer/README.md for the localNvmeSsdBlock override.
   ## Bucket configuration, used for stateless. If provided, the bucket will be created and the credentials will be stored in the K8s clusters.
   bucket:
     # Bucket name, created in the same region as the cluster.
@@ -46,7 +47,6 @@ plans:
       namespace: "{{ .ClusterName }}-namespace"
   gke:
     region: europe-west1
-    localSsdCount: 1
     nodeCountPerZone: 1
     # Uncomment option below to enable network policy enforcement in GKE.
     # networkPolicy: true

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -10,7 +10,7 @@ plans:
   # Format and mount the raw GKE NVMe Local SSD before provisioning fixed-size local PVs.
   diskSetup: kubectl apply -k hack/deployer/config/local-disks-gke
   gke:
-    region: us-east4
+    region: europe-west1
     localNvmeSsdBlock: true
     nodeCountPerZone: 1
     gcpScopes: https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/trace.append
@@ -25,7 +25,7 @@ plans:
   # diskSetup: kubectl apply -k hack/deployer/config/local-disks
   gke:
     autopilot: true
-    region: us-east4
+    region: europe-west1
     gcpScopes: https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/trace.append
 - id: gke-dev
   operation: create

--- a/hack/deployer/runner/gke.go
+++ b/hack/deployer/runner/gke.go
@@ -57,6 +57,11 @@ type GKEDriver struct {
 }
 
 func (gdf *GKEDriverFactory) Create(plan Plan) (Driver, error) {
+	localSSDOption, err := gkeLocalSSDOption(plan.Gke)
+	if err != nil {
+		return nil, err
+	}
+
 	pvcPrefix := plan.ClusterName
 	if len(pvcPrefix) > pvcPrefixMaxLength {
 		pvcPrefix = pvcPrefix[0:pvcPrefixMaxLength]
@@ -87,7 +92,7 @@ func (gdf *GKEDriverFactory) Create(plan Plan) (Driver, error) {
 			"Region":                 plan.Gke.Region,
 			"KubernetesVersion":      plan.KubernetesVersion,
 			"MachineType":            plan.MachineType,
-			"LocalSsdCount":          plan.Gke.LocalSsdCount,
+			"LocalSSDOption":         localSSDOption,
 			"GcpScopes":              plan.Gke.GcpScopes,
 			"NodeCountPerZone":       plan.Gke.NodeCountPerZone,
 			"ClusterIPv4CIDR":        clusterIPv4CIDR,
@@ -95,6 +100,25 @@ func (gdf *GKEDriverFactory) Create(plan Plan) (Driver, error) {
 		},
 		vaultClient: c,
 	}, nil
+}
+
+func gkeLocalSSDOption(settings *GKESettings) (string, error) {
+	if settings == nil {
+		return "", fmt.Errorf("GKE settings must be configured")
+	}
+	if settings.LocalSsdCount > 0 && settings.LocalNvmeSsdBlock {
+		return "", fmt.Errorf("localSsdCount and localNvmeSsdBlock are mutually exclusive")
+	}
+	if settings.LocalNvmeSsdBlock {
+		return "--local-nvme-ssd-block count=1", nil
+	}
+	if settings.LocalSsdCount > 0 {
+		return fmt.Sprintf("--local-ssd-count %d", settings.LocalSsdCount), nil
+	}
+	if settings.LocalSsdCount < 0 {
+		return "", fmt.Errorf("local SSD count must not be negative")
+	}
+	return "", nil
 }
 
 func (d *GKEDriver) Execute() error {
@@ -327,7 +351,7 @@ func (d *GKEDriver) create() error {
 		createGKEClusterCommand = `gcloud container --quiet --project {{.GCloudProject}} clusters create {{.ClusterName}} ` +
 			`--labels "` + labels + `" --region {{.Region}} --no-enable-basic-auth --cluster-version {{.KubernetesVersion}} ` +
 			`--machine-type {{.MachineType}} --disk-type pd-ssd --disk-size 100 ` +
-			`--local-ssd-count {{.LocalSsdCount}} --scopes {{.GcpScopes}} --num-nodes {{.NodeCountPerZone}} ` +
+			`{{.LocalSSDOption}} --scopes {{.GcpScopes}} --num-nodes {{.NodeCountPerZone}} ` +
 			`--addons HorizontalPodAutoscaling,HttpLoadBalancing ` +
 			`--no-enable-autoupgrade --no-enable-autorepair --enable-ip-alias --metadata disable-legacy-endpoints=true ` +
 			`--network projects/{{.GCloudProject}}/global/networks/default ` +

--- a/hack/deployer/runner/gke.go
+++ b/hack/deployer/runner/gke.go
@@ -28,6 +28,7 @@ const (
 	GKEServiceAccountVaultFieldName = "service-account"
 	GKEProjectVaultFieldName        = "gcloud-project"
 	GoogleCloudProjectCtxKey        = "GCloudProject"
+	gkeLocalDiskSetupCommand        = "kubectl apply -k hack/deployer/config/local-disks-gke"
 	DefaultGKERunConfigTemplate     = `id: gke-dev
 overrides:
   clusterName: %s-dev-cluster
@@ -61,6 +62,7 @@ func (gdf *GKEDriverFactory) Create(plan Plan) (Driver, error) {
 	if err != nil {
 		return nil, err
 	}
+	plan = configureGKELocalSSD(plan)
 
 	pvcPrefix := plan.ClusterName
 	if len(pvcPrefix) > pvcPrefixMaxLength {
@@ -106,6 +108,9 @@ func gkeLocalSSDOption(settings *GKESettings) (string, error) {
 	if settings == nil {
 		return "", fmt.Errorf("GKE settings must be configured")
 	}
+	if settings.LocalSsdCount < 0 {
+		return "", fmt.Errorf("local SSD count must not be negative")
+	}
 	if settings.LocalSsdCount > 0 && settings.LocalNvmeSsdBlock {
 		return "", fmt.Errorf("localSsdCount and localNvmeSsdBlock are mutually exclusive")
 	}
@@ -113,12 +118,18 @@ func gkeLocalSSDOption(settings *GKESettings) (string, error) {
 		return "--local-nvme-ssd-block count=1", nil
 	}
 	if settings.LocalSsdCount > 0 {
+		// Deprecated compatibility path for existing GKE deployer overrides.
+		log.Printf("WARNING: gke.localSsdCount is deprecated; use gke.localNvmeSsdBlock instead")
 		return fmt.Sprintf("--local-ssd-count %d", settings.LocalSsdCount), nil
 	}
-	if settings.LocalSsdCount < 0 {
-		return "", fmt.Errorf("local SSD count must not be negative")
-	}
 	return "", nil
+}
+
+func configureGKELocalSSD(plan Plan) Plan {
+	if plan.Gke.LocalNvmeSsdBlock && plan.DiskSetup == "" {
+		plan.DiskSetup = gkeLocalDiskSetupCommand
+	}
+	return plan
 }
 
 func (d *GKEDriver) Execute() error {

--- a/hack/deployer/runner/gke_nvme_format_test.go
+++ b/hack/deployer/runner/gke_nvme_format_test.go
@@ -178,7 +178,7 @@ func (f *nvmeFormatterFixture) run() nvmeFormatterResult {
 	scriptPath := filepath.Join(f.t.TempDir(), "gke-nvme-format.sh")
 	writeExecutable(f.t, scriptPath, f.script)
 
-	cmd := exec.Command("sh", scriptPath)
+	cmd := exec.CommandContext(f.t.Context(), "sh", scriptPath)
 	cmd.Env = append(withoutPath(os.Environ()),
 		"PATH="+f.binDir+":"+os.Getenv("PATH"),
 		"GKE_LOCAL_SSD_DEVICE="+f.device,

--- a/hack/deployer/runner/gke_nvme_format_test.go
+++ b/hack/deployer/runner/gke_nvme_format_test.go
@@ -1,0 +1,220 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package runner
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestGKENvmeFormatScript(t *testing.T) {
+	script := loadGKENvmeFormatScript(t)
+
+	tests := []struct {
+		name           string
+		mountedSource  nvmeMountedSource
+		filesystemType string
+		wantError      bool
+		wantOutput     string
+		wantCommands   []string
+	}{
+		{
+			name:          "reuses the expected mounted device",
+			mountedSource: expectedDevice,
+			wantOutput:    "already mounted at",
+		},
+		{
+			name:          "rejects an unexpected mounted device",
+			mountedSource: unexpectedDevice,
+			wantError:     true,
+			wantOutput:    "is mounted from unexpected source",
+		},
+		{
+			name:         "formats and mounts a blank device",
+			wantOutput:   "Formatting",
+			wantCommands: []string{"mkfs.ext4", "mount"},
+		},
+		{
+			name:           "mounts an existing ext4 filesystem without formatting",
+			filesystemType: "ext4",
+			wantOutput:     "already contains an ext4 filesystem",
+			wantCommands:   []string{"mount"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture := newNVMeFormatterFixture(t, script)
+			fixture.stubMountedSource(tt.mountedSource)
+			fixture.filesystemType = tt.filesystemType
+
+			result := fixture.run()
+
+			if tt.wantError {
+				require.Error(t, result.err)
+			} else {
+				require.NoError(t, result.err, result.output)
+			}
+			require.Contains(t, result.output, tt.wantOutput)
+			require.Equal(t, tt.wantCommands, result.commands)
+		})
+	}
+}
+
+func loadGKENvmeFormatScript(t *testing.T) string {
+	t.Helper()
+
+	patchYAML, err := os.ReadFile("../config/local-disks-gke/gke-nvme-format-script-patch.yaml")
+	require.NoError(t, err)
+
+	var patches []struct {
+		Value string `yaml:"value"`
+	}
+	require.NoError(t, yaml.Unmarshal(patchYAML, &patches))
+	require.Len(t, patches, 1)
+	return patches[0].Value
+}
+
+type nvmeFormatterFixture struct {
+	t              *testing.T
+	script         string
+	device         string
+	otherDevice    string
+	mountPoint     string
+	mountedSource  string
+	filesystemType string
+	commandLog     string
+	binDir         string
+}
+
+type nvmeMountedSource int
+
+const (
+	noMountedDevice nvmeMountedSource = iota
+	expectedDevice
+	unexpectedDevice
+)
+
+func newNVMeFormatterFixture(t *testing.T, script string) *nvmeFormatterFixture {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	fixture := &nvmeFormatterFixture{
+		t:           t,
+		script:      script,
+		device:      filepath.Join(tempDir, "expected-device"),
+		otherDevice: filepath.Join(tempDir, "unexpected-device"),
+		mountPoint:  filepath.Join(tempDir, "mount"),
+		commandLog:  filepath.Join(tempDir, "commands.log"),
+		binDir:      filepath.Join(tempDir, "bin"),
+	}
+	require.NoError(t, os.WriteFile(fixture.device, nil, 0o600))
+	require.NoError(t, os.WriteFile(fixture.otherDevice, nil, 0o600))
+	require.NoError(t, os.Mkdir(fixture.binDir, 0o700))
+	fixture.installFakeCommands()
+	return fixture
+}
+
+func (f *nvmeFormatterFixture) stubMountedSource(source nvmeMountedSource) {
+	f.t.Helper()
+
+	switch source {
+	case noMountedDevice:
+		f.mountedSource = ""
+	case expectedDevice:
+		f.mountedSource = f.device
+	case unexpectedDevice:
+		f.mountedSource = f.otherDevice
+	default:
+		f.t.Fatalf("unknown mounted source %d", source)
+	}
+}
+
+func (f *nvmeFormatterFixture) installFakeCommands() {
+	f.t.Helper()
+
+	writeExecutable(f.t, filepath.Join(f.binDir, "mountpoint"), `#!/bin/sh
+[ -n "${MOUNTED_SOURCE}" ]
+`)
+	writeExecutable(f.t, filepath.Join(f.binDir, "findmnt"), `#!/bin/sh
+case "$*" in
+  *"-o SOURCE"*)
+    [ -n "${MOUNTED_SOURCE}" ] || exit 1
+    printf '%s\n' "${MOUNTED_SOURCE}"
+    exit 0
+    ;;
+esac
+exit 1
+`)
+	writeExecutable(f.t, filepath.Join(f.binDir, "readlink"), "#!/bin/sh\nprintf '%s\\n' \"$2\"\n")
+	writeExecutable(f.t, filepath.Join(f.binDir, "blkid"), `#!/bin/sh
+if [ -n "${FILESYSTEM_TYPE}" ]; then
+  printf '%s\n' "${FILESYSTEM_TYPE}"
+  exit 0
+fi
+exit 2
+`)
+	writeExecutable(f.t, filepath.Join(f.binDir, "mkfs.ext4"), "#!/bin/sh\necho mkfs.ext4 >> \"${COMMAND_LOG}\"\n")
+	writeExecutable(f.t, filepath.Join(f.binDir, "mount"), "#!/bin/sh\necho mount >> \"${COMMAND_LOG}\"\n")
+}
+
+type nvmeFormatterResult struct {
+	output   string
+	commands []string
+	err      error
+}
+
+func (f *nvmeFormatterFixture) run() nvmeFormatterResult {
+	f.t.Helper()
+
+	scriptPath := filepath.Join(f.t.TempDir(), "gke-nvme-format.sh")
+	writeExecutable(f.t, scriptPath, f.script)
+
+	cmd := exec.Command("sh", scriptPath)
+	cmd.Env = append(withoutPath(os.Environ()),
+		"PATH="+f.binDir+":"+os.Getenv("PATH"),
+		"GKE_LOCAL_SSD_DEVICE="+f.device,
+		"GKE_LOCAL_SSD_MOUNT_POINT="+f.mountPoint,
+		"MOUNTED_SOURCE="+f.mountedSource,
+		"FILESYSTEM_TYPE="+f.filesystemType,
+		"COMMAND_LOG="+f.commandLog,
+	)
+	output, commandErr := cmd.CombinedOutput()
+
+	commandLogContents, err := os.ReadFile(f.commandLog)
+	if err != nil && !os.IsNotExist(err) {
+		require.NoError(f.t, err)
+	}
+	var commands []string
+	if err == nil {
+		commands = strings.Fields(string(commandLogContents))
+	}
+	return nvmeFormatterResult{
+		output:   string(output),
+		commands: commands,
+		err:      commandErr,
+	}
+}
+
+func writeExecutable(t *testing.T, path, contents string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o700))
+}
+
+func withoutPath(environment []string) []string {
+	result := make([]string, 0, len(environment))
+	for _, value := range environment {
+		if !strings.HasPrefix(value, "PATH=") {
+			result = append(result, value)
+		}
+	}
+	return result
+}

--- a/hack/deployer/runner/gke_test.go
+++ b/hack/deployer/runner/gke_test.go
@@ -1,0 +1,92 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package runner
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestGKELocalSSDOption(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings *GKESettings
+		want     string
+		wantErr  string
+	}{
+		{
+			name:     "no local SSD",
+			settings: &GKESettings{},
+		},
+		{
+			name: "legacy local SSD",
+			settings: &GKESettings{
+				LocalSsdCount: 1,
+			},
+			want: "--local-ssd-count 1",
+		},
+		{
+			name: "raw NVMe local SSD",
+			settings: &GKESettings{
+				LocalNvmeSsdBlock: true,
+			},
+			want: "--local-nvme-ssd-block count=1",
+		},
+		{
+			name: "mutually exclusive modes",
+			settings: &GKESettings{
+				LocalSsdCount:     1,
+				LocalNvmeSsdBlock: true,
+			},
+			wantErr: "localSsdCount and localNvmeSsdBlock are mutually exclusive",
+		},
+		{
+			name: "negative count",
+			settings: &GKESettings{
+				LocalSsdCount: -1,
+			},
+			wantErr: "local SSD count must not be negative",
+		},
+		{
+			name:    "missing settings",
+			wantErr: "GKE settings must be configured",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := gkeLocalSSDOption(tt.settings)
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGKECIPlanUsesRawNVMeLocalSSD(t *testing.T) {
+	plansYAML, err := os.ReadFile("../config/plans.yml")
+	require.NoError(t, err)
+
+	var plans Plans
+	require.NoError(t, yaml.Unmarshal(plansYAML, &plans))
+
+	plan, err := choosePlan(plans.Plans, "gke-ci")
+	require.NoError(t, err)
+	require.Equal(t, "us-east4", plan.Gke.Region)
+	require.Equal(t, "n2d-standard-4", plan.MachineType)
+	require.Zero(t, plan.Gke.LocalSsdCount)
+	require.True(t, plan.Gke.LocalNvmeSsdBlock)
+	require.Equal(t, "kubectl apply -k hack/deployer/config/local-disks-gke", plan.DiskSetup)
+
+	option, err := gkeLocalSSDOption(plan.Gke)
+	require.NoError(t, err)
+	require.Equal(t, "--local-nvme-ssd-block count=1", option)
+}

--- a/hack/deployer/runner/gke_test.go
+++ b/hack/deployer/runner/gke_test.go
@@ -24,7 +24,7 @@ func TestGKELocalSSDOption(t *testing.T) {
 			settings: &GKESettings{},
 		},
 		{
-			name: "legacy local SSD",
+			name: "deprecated legacy local SSD compatibility",
 			settings: &GKESettings{
 				LocalSsdCount: 1,
 			},
@@ -49,6 +49,14 @@ func TestGKELocalSSDOption(t *testing.T) {
 			name: "negative count",
 			settings: &GKESettings{
 				LocalSsdCount: -1,
+			},
+			wantErr: "local SSD count must not be negative",
+		},
+		{
+			name: "negative count with raw NVMe local SSD",
+			settings: &GKESettings{
+				LocalSsdCount:     -1,
+				LocalNvmeSsdBlock: true,
 			},
 			wantErr: "local SSD count must not be negative",
 		},
@@ -84,9 +92,52 @@ func TestGKECIPlanUsesRawNVMeLocalSSD(t *testing.T) {
 	require.Equal(t, "n2d-standard-4", plan.MachineType)
 	require.Zero(t, plan.Gke.LocalSsdCount)
 	require.True(t, plan.Gke.LocalNvmeSsdBlock)
-	require.Equal(t, "kubectl apply -k hack/deployer/config/local-disks-gke", plan.DiskSetup)
+	require.Empty(t, plan.DiskSetup)
 
 	option, err := gkeLocalSSDOption(plan.Gke)
 	require.NoError(t, err)
 	require.Equal(t, "--local-nvme-ssd-block count=1", option)
+
+	plan = configureGKELocalSSD(plan)
+	require.Equal(t, gkeLocalDiskSetupCommand, plan.DiskSetup)
+}
+
+func TestGKEDevPlanDefaultsToPersistentDiskWithLocalSSDOptIn(t *testing.T) {
+	plansYAML, err := os.ReadFile("../config/plans.yml")
+	require.NoError(t, err)
+
+	var plans Plans
+	require.NoError(t, yaml.Unmarshal(plansYAML, &plans))
+
+	plan, err := choosePlan(plans.Plans, "gke-dev")
+	require.NoError(t, err)
+	require.Equal(t, "europe-west1", plan.Gke.Region)
+	require.Equal(t, "n2d-standard-8", plan.MachineType)
+	require.Zero(t, plan.Gke.LocalSsdCount)
+	require.False(t, plan.Gke.LocalNvmeSsdBlock)
+	require.Empty(t, plan.DiskSetup)
+
+	option, err := gkeLocalSSDOption(plan.Gke)
+	require.NoError(t, err)
+	require.Empty(t, option)
+
+	var runConfig RunConfig
+	require.NoError(t, yaml.Unmarshal([]byte(`
+id: gke-dev
+overrides:
+  gke:
+    localNvmeSsdBlock: true
+`), &runConfig))
+
+	plan, err = GetPlan(plans.Plans, runConfig, "")
+	require.NoError(t, err)
+	require.True(t, plan.Gke.LocalNvmeSsdBlock)
+	require.Empty(t, plan.DiskSetup)
+
+	option, err = gkeLocalSSDOption(plan.Gke)
+	require.NoError(t, err)
+	require.Equal(t, "--local-nvme-ssd-block count=1", option)
+
+	plan = configureGKELocalSSD(plan)
+	require.Equal(t, gkeLocalDiskSetupCommand, plan.DiskSetup)
 }

--- a/hack/deployer/runner/gke_test.go
+++ b/hack/deployer/runner/gke_test.go
@@ -80,7 +80,7 @@ func TestGKECIPlanUsesRawNVMeLocalSSD(t *testing.T) {
 
 	plan, err := choosePlan(plans.Plans, "gke-ci")
 	require.NoError(t, err)
-	require.Equal(t, "us-east4", plan.Gke.Region)
+	require.Equal(t, "europe-west1", plan.Gke.Region)
 	require.Equal(t, "n2d-standard-4", plan.MachineType)
 	require.Zero(t, plan.Gke.LocalSsdCount)
 	require.True(t, plan.Gke.LocalNvmeSsdBlock)

--- a/hack/deployer/runner/settings.go
+++ b/hack/deployer/runner/settings.go
@@ -76,16 +76,17 @@ type BucketSecretSettings struct {
 
 // GKESettings encapsulates settings specific to GKE
 type GKESettings struct {
-	GCloudProject    string `yaml:"gCloudProject"`
-	Region           string `yaml:"region"`
-	LocalSsdCount    int    `yaml:"localSsdCount"`
-	NodeCountPerZone int    `yaml:"nodeCountPerZone"`
-	GcpScopes        string `yaml:"gcpScopes"`
-	ClusterIPv4CIDR  string `yaml:"clusterIpv4Cidr"`
-	ServicesIPv4CIDR string `yaml:"servicesIpv4Cidr"`
-	Private          bool   `yaml:"private"`
-	NetworkPolicy    bool   `yaml:"networkPolicy"`
-	Autopilot        bool   `yaml:"autopilot"`
+	GCloudProject     string `yaml:"gCloudProject"`
+	Region            string `yaml:"region"`
+	LocalSsdCount     int    `yaml:"localSsdCount"`
+	LocalNvmeSsdBlock bool   `yaml:"localNvmeSsdBlock"`
+	NodeCountPerZone  int    `yaml:"nodeCountPerZone"`
+	GcpScopes         string `yaml:"gcpScopes"`
+	ClusterIPv4CIDR   string `yaml:"clusterIpv4Cidr"`
+	ServicesIPv4CIDR  string `yaml:"servicesIpv4Cidr"`
+	Private           bool   `yaml:"private"`
+	NetworkPolicy     bool   `yaml:"networkPolicy"`
+	Autopilot         bool   `yaml:"autopilot"`
 }
 
 // AKSSettings encapsulates settings specific to AKS

--- a/hack/deployer/runner/settings.go
+++ b/hack/deployer/runner/settings.go
@@ -76,9 +76,11 @@ type BucketSecretSettings struct {
 
 // GKESettings encapsulates settings specific to GKE
 type GKESettings struct {
-	GCloudProject     string `yaml:"gCloudProject"`
-	Region            string `yaml:"region"`
-	LocalSsdCount     int    `yaml:"localSsdCount"`
+	GCloudProject string `yaml:"gCloudProject"`
+	Region        string `yaml:"region"`
+	// Deprecated: use LocalNvmeSsdBlock. LocalSsdCount is retained for compatibility with existing GKE overrides.
+	LocalSsdCount int `yaml:"localSsdCount"`
+	// LocalNvmeSsdBlock attaches one raw NVMe Local SSD per node and configures it for local PersistentVolumes.
 	LocalNvmeSsdBlock bool   `yaml:"localNvmeSsdBlock"`
 	NodeCountPerZone  int    `yaml:"nodeCountPerZone"`
 	GcpScopes         string `yaml:"gcpScopes"`


### PR DESCRIPTION
Use n2d-standard-4 nodes and migrate local storage from the legacy SCSI Local SSD API to raw NVMe. Add GKE-specific formatting and mounting while preserving the existing fixed-size local PV setup.

Changing the CI and DEV setup. 
For now, still supporting backwards compatibility with the old flag/config. 

fixes #9727

Assisted-by: Cursor (GPT-5.6 Sol)
