### PR TITLE
fix orphaned PVCs on ES cluster deletion via StatefulSet PVC retention policy

### DIFF
--- a/pkg/controller/elasticsearch/driver/stateful/nodes.go
+++ b/pkg/controller/elasticsearch/driver/stateful/nodes.go
@@ -141,7 +141,7 @@ func (d *Driver) reconcileNodeSpecs(
 		return results.WithError(err)
 	}
 
-	if err := reconcilePVCOwnerRefs(ctx, d.K8sClient(), d.ES); err != nil {
+	if err := ReconcilePVCOwnerRefs(ctx, d.K8sClient(), d.ES); err != nil {
 		return results.WithError(err)
 	}
 

--- a/pkg/controller/elasticsearch/driver/stateful/pvc_owner.go
+++ b/pkg/controller/elasticsearch/driver/stateful/pvc_owner.go
@@ -7,8 +7,10 @@ package stateful
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -18,12 +20,11 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
 )
 
-// reconcilePVCOwnerRefs sets or removes an owner reference into each PVC for the given Elasticsearch cluster depending
-// on the VolumeClaimDeletePolicy.
-// The intent behind this approach is to allow users to specify per cluster whether they want to retain or remove
-// the related PVCs. We rely on Kubernetes garbage collection for the cleanup once a cluster has been deleted and
-// the operator separately deletes PVCs on scale down if so desired (see GarbageCollectPVCs)
-func reconcilePVCOwnerRefs(ctx context.Context, c k8s.Client, es esv1.Elasticsearch) error {
+// ReconcilePVCOwnerRefs sets or removes an ownerReference on each PVC for the given Elasticsearch cluster
+// depending on VolumeClaimDeletePolicy. It is also called during the deletion path to stamp any PVC the
+// StatefulSet controller may have recreated during the deletion window. We rely on Kubernetes GC for cleanup
+// once the cluster is deleted, and separately delete PVCs on scale-down when desired (see GarbageCollectPVCs).
+func ReconcilePVCOwnerRefs(ctx context.Context, c k8s.Client, es esv1.Elasticsearch) error {
 	var pvcs corev1.PersistentVolumeClaimList
 	ns := client.InNamespace(es.Namespace)
 	labelSelector := label.NewLabelSelectorForElasticsearch(es)
@@ -33,23 +34,48 @@ func reconcilePVCOwnerRefs(ctx context.Context, c k8s.Client, es esv1.Elasticsea
 
 	for _, pvc := range pvcs.Items {
 		hasOwner := k8s.HasOwner(&pvc, &es)
+		needsUpdate := false
+
 		switch es.Spec.VolumeClaimDeletePolicyOrDefault() {
 		case esv1.DeleteOnScaledownOnlyPolicy:
-			if !hasOwner {
-				continue
-			}
-			k8s.RemoveOwner(&pvc, &es)
-		case esv1.DeleteOnScaledownAndClusterDeletionPolicy:
 			if hasOwner {
-				continue
+				k8s.RemoveOwner(&pvc, &es)
+				needsUpdate = true
 			}
-			if err := controllerutil.SetOwnerReference(&es, &pvc, scheme.Scheme); err != nil {
-				return fmt.Errorf("while setting owner during owner ref reconciliation: %w", err)
+			// Remove any stale StatefulSet ownerRefs left over from a previous
+			// DeleteOnScaledownAndClusterDeletionPolicy.
+			if removeStatefulSetOwnerRefs(&pvc) {
+				needsUpdate = true
 			}
+		case esv1.DeleteOnScaledownAndClusterDeletionPolicy:
+			if !hasOwner {
+				if err := controllerutil.SetOwnerReference(&es, &pvc, scheme.Scheme); err != nil {
+					return fmt.Errorf("while setting owner during owner ref reconciliation: %w", err)
+				}
+				needsUpdate = true
+			}
+		}
+
+		if !needsUpdate {
+			continue
 		}
 		if err := c.Update(ctx, &pvc); err != nil {
 			return fmt.Errorf("while updating pvc during owner ref reconciliation: %w", err)
 		}
 	}
 	return nil
+}
+
+// removeStatefulSetOwnerRefs removes all ownerReferences with Kind=StatefulSet from the PVC
+// and reports whether any were removed.
+func removeStatefulSetOwnerRefs(pvc *corev1.PersistentVolumeClaim) bool {
+	refs := pvc.GetOwnerReferences()
+	filtered := slices.DeleteFunc(refs, func(ref metav1.OwnerReference) bool {
+		return ref.Kind == "StatefulSet"
+	})
+	if len(filtered) == len(refs) {
+		return false
+	}
+	pvc.SetOwnerReferences(filtered)
+	return true
 }

--- a/pkg/controller/elasticsearch/driver/stateful/pvc_owner_test.go
+++ b/pkg/controller/elasticsearch/driver/stateful/pvc_owner_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
 )
 
-func Test_reconcilePVCOwnerRefs(t *testing.T) {
+func Test_ReconcilePVCOwnerRefs(t *testing.T) {
 	type args struct {
 		c  k8s.Client
 		es esv1.Elasticsearch
@@ -55,6 +55,16 @@ func Test_reconcilePVCOwnerRefs(t *testing.T) {
 	pvcFixturePtr := func(name string, ownerRefs ...string) *corev1.PersistentVolumeClaim {
 		pvc := pvcFixture(name, ownerRefs...)
 		return &pvc
+	}
+
+	// withSSetOwnerRef appends a StatefulSet ownerRef to the given PVC.
+	withSSetOwnerRef := func(pvc corev1.PersistentVolumeClaim, ssetName string) corev1.PersistentVolumeClaim {
+		pvc.OwnerReferences = append(pvc.OwnerReferences, metav1.OwnerReference{
+			Name:       ssetName,
+			Kind:       "StatefulSet",
+			APIVersion: "apps/v1",
+		})
+		return pvc
 	}
 
 	tests := []struct {
@@ -124,15 +134,54 @@ func Test_reconcilePVCOwnerRefs(t *testing.T) {
 			wantErr:    false,
 			wantUpdate: true,
 		},
+		{
+			name: "remove stale StatefulSet ownerRef on DeleteOnScaledownOnlyPolicy",
+			args: args{
+				c: k8s.NewFakeClient(func() *corev1.PersistentVolumeClaim {
+					p := withSSetOwnerRef(pvcFixture("es-data-0"), "es-es-0")
+					return &p
+				}()),
+				es: esFixture(esv1.DeleteOnScaledownOnlyPolicy),
+			},
+			want:       []corev1.PersistentVolumeClaim{pvcFixture("es-data-0")},
+			wantErr:    false,
+			wantUpdate: true,
+		},
+		{
+			name: "remove both ES and StatefulSet ownerRefs on DeleteOnScaledownOnlyPolicy",
+			args: args{
+				c: k8s.NewFakeClient(func() *corev1.PersistentVolumeClaim {
+					p := withSSetOwnerRef(pvcFixture("es-data-0", "es"), "es-es-0")
+					return &p
+				}()),
+				es: esFixture(esv1.DeleteOnScaledownOnlyPolicy),
+			},
+			want:       []corev1.PersistentVolumeClaim{pvcFixture("es-data-0")},
+			wantErr:    false,
+			wantUpdate: true,
+		},
+		{
+			name: "keep non-StatefulSet ownerRefs when removing stale StatefulSet ownerRef",
+			args: args{
+				c: k8s.NewFakeClient(func() *corev1.PersistentVolumeClaim {
+					p := withSSetOwnerRef(pvcFixture("es-data-0", "some-other-ref"), "es-es-0")
+					return &p
+				}()),
+				es: esFixture(esv1.DeleteOnScaledownOnlyPolicy),
+			},
+			want:       []corev1.PersistentVolumeClaim{pvcFixture("es-data-0", "some-other-ref")},
+			wantErr:    false,
+			wantUpdate: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			trackedClient := trackingK8sClient{Client: tt.args.c}
-			if err := reconcilePVCOwnerRefs(context.Background(), &trackedClient, tt.args.es); (err != nil) != tt.wantErr {
+			if err := ReconcilePVCOwnerRefs(t.Context(), &trackedClient, tt.args.es); (err != nil) != tt.wantErr {
 				t.Errorf("reconcilePVCOwnerRefs() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			var pvcs corev1.PersistentVolumeClaimList
-			if err := tt.args.c.List(context.Background(), &pvcs); err != nil {
+			if err := tt.args.c.List(t.Context(), &pvcs); err != nil {
 				t.Errorf("reconcilePVCOwnerRefs(), failed to list pvcs: %v", err)
 			}
 			require.Equal(t, len(tt.want), len(pvcs.Items), "unexpected number of pvcs")

--- a/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -185,6 +185,15 @@ func (r *ReconcileElasticsearch) Reconcile(ctx context.Context, request reconcil
 		return reconcile.Result{}, nil
 	}
 
+	// Best-effort: stamp ownerRefs on PVCs while the ES CR still exists. On clusters with legacy
+	// finalizers this is guaranteed to run before GC; on clusters without finalizers it may not
+	// fire before the CR is removed, but normal reconciliation covers the steady state.
+	if es.IsMarkedForDeletion() {
+		if err := stateful.ReconcilePVCOwnerRefs(ctx, r.Client, es); err != nil {
+			return reconcile.Result{}, tracing.CaptureError(ctx, err)
+		}
+	}
+
 	// Remove any previous Finalizers
 	if err := finalizer.RemoveAll(ctx, r.Client, &es); err != nil {
 		return reconcile.Result{}, tracing.CaptureError(ctx, err)

--- a/pkg/controller/elasticsearch/nodespec/statefulset.go
+++ b/pkg/controller/elasticsearch/nodespec/statefulset.go
@@ -113,6 +113,19 @@ func BuildStatefulSet(
 	}
 	claims := preserveExistingVolumeClaimsOwnerRefs(nodeSet.VolumeClaimTemplates, existingClaims)
 
+	// When DeleteOnScaledownAndClusterDeletion is set (the default), instruct the StatefulSet
+	// controller to stamp ownerRef → StatefulSet on every PVC it manages, including any PVC it
+	// recreates during the cluster-deletion window. When the StatefulSet is subsequently
+	// garbage-collected (because the ES CR is gone), all owned PVCs cascade-delete automatically.
+	// WhenScaled is always Retain because ECK manages scale-down PVC cleanup itself via GarbageCollectPVCs.
+	var pvcWhenDeleted appsv1.PersistentVolumeClaimRetentionPolicyType
+	switch es.Spec.VolumeClaimDeletePolicyOrDefault() {
+	case esv1.DeleteOnScaledownAndClusterDeletionPolicy:
+		pvcWhenDeleted = appsv1.DeletePersistentVolumeClaimRetentionPolicyType
+	case esv1.DeleteOnScaledownOnlyPolicy:
+		pvcWhenDeleted = appsv1.RetainPersistentVolumeClaimRetentionPolicyType
+	}
+
 	sset := appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:   es.Namespace,
@@ -137,6 +150,10 @@ func BuildStatefulSet(
 			Replicas:             &nodeSet.Count,
 			VolumeClaimTemplates: claims,
 			Template:             podTemplate,
+			PersistentVolumeClaimRetentionPolicy: &appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy{
+				WhenDeleted: pvcWhenDeleted,
+				WhenScaled:  appsv1.RetainPersistentVolumeClaimRetentionPolicyType,
+			},
 		},
 	}
 

--- a/pkg/controller/elasticsearch/nodespec/statefulset_test.go
+++ b/pkg/controller/elasticsearch/nodespec/statefulset_test.go
@@ -8,11 +8,18 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	commonv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/v3/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/metadata"
 	controllerscheme "github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/scheme"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/common/version"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/settings"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/stackconfig"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
 )
 
 func Test_setVolumeClaimsControllerReference(t *testing.T) {
@@ -130,6 +137,77 @@ func Test_setVolumeClaimsControllerReference(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := preserveExistingVolumeClaimsOwnerRefs(tt.persistentVolumeClaims, tt.existingClaims)
 			require.Equal(t, tt.wantClaims, got)
+		})
+	}
+}
+
+func Test_BuildStatefulSet_PVCRetentionPolicy(t *testing.T) {
+	tests := []struct {
+		name            string
+		deletePolicy    esv1.VolumeClaimDeletePolicy
+		wantWhenDeleted appsv1.PersistentVolumeClaimRetentionPolicyType
+		wantWhenScaled  appsv1.PersistentVolumeClaimRetentionPolicyType
+	}{
+		{
+			name:            "DeleteOnScaledownAndClusterDeletion sets whenDeleted=Delete",
+			deletePolicy:    esv1.DeleteOnScaledownAndClusterDeletionPolicy,
+			wantWhenDeleted: appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
+			wantWhenScaled:  appsv1.RetainPersistentVolumeClaimRetentionPolicyType,
+		},
+		{
+			name:            "DeleteOnScaledownOnly sets whenDeleted=Retain",
+			deletePolicy:    esv1.DeleteOnScaledownOnlyPolicy,
+			wantWhenDeleted: appsv1.RetainPersistentVolumeClaimRetentionPolicyType,
+			wantWhenScaled:  appsv1.RetainPersistentVolumeClaimRetentionPolicyType,
+		},
+		{
+			name:            "empty policy (default) sets whenDeleted=Delete",
+			deletePolicy:    "",
+			wantWhenDeleted: appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
+			wantWhenScaled:  appsv1.RetainPersistentVolumeClaimRetentionPolicyType,
+		},
+	}
+
+	nodeSet := esv1.NodeSet{
+		Name:  "default",
+		Count: 1,
+		Config: &commonv1.Config{
+			Data: map[string]any{"node.roles": []string{"master", "data"}},
+		},
+		PodTemplate: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: esv1.ElasticsearchContainerName}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			esObj := newEsSampleBuilder().withVersion("8.14.0").build()
+			esObj.Spec.NodeSets = []esv1.NodeSet{nodeSet}
+			esObj.Spec.VolumeClaimDeletePolicy = tt.deletePolicy
+
+			client := k8s.NewFakeClient(&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Namespace: esObj.Namespace, Name: esv1.ScriptsConfigMap(esObj.Name)},
+			})
+
+			ver, err := version.Parse(esObj.Spec.Version)
+			require.NoError(t, err)
+			cfg, err := settings.NewMergedESConfig(
+				esObj.Name, ver, corev1.IPv4Protocol, esObj.Spec.HTTP,
+				*nodeSet.Config, nil, false, false, false, false,
+			)
+			require.NoError(t, err)
+
+			sts, err := BuildStatefulSet(
+				t.Context(), client, esObj, nodeSet, cfg,
+				nil, nil, false, stackconfig.PolicyConfig{}, metadata.Metadata{}, "", false,
+			)
+			require.NoError(t, err)
+			require.NotNil(t, sts.Spec.PersistentVolumeClaimRetentionPolicy,
+				"PersistentVolumeClaimRetentionPolicy must be set")
+			require.Equal(t, tt.wantWhenDeleted, sts.Spec.PersistentVolumeClaimRetentionPolicy.WhenDeleted)
+			require.Equal(t, tt.wantWhenScaled, sts.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

When an Elasticsearch cluster is deleted, the StatefulSet controller can recreate PVCs during the window between the ES CR receiving its `DeletionTimestamp` and the StatefulSets being garbage-collected. Because those PVCs are created after ECK's last normal reconcile, they carry no ownerReference pointing to the ES CR and are never cleaned up - they are silently orphaned.

This change closes that gap using two complementary mechanisms. First, it sets `PersistentVolumeClaimRetentionPolicy.WhenDeleted=Delete` on every ES StatefulSet so the SSet controller proactively stamps an ownerRef (SSet -> PVC) on all managed PVCs at every sync, including any it recreates during the deletion window. When the StatefulSet is subsequently garbage-collected (because the ES CR is gone), all owned PVCs cascade-delete automatically. `WhenScaled` is left as `Retain` because ECK already manages scale-down PVC cleanup via `GarbageCollectPVCs`. Second, it adds the ECK ownerRef stamping call (`ReconcilePVCOwnerRefs`) before finalizer removal in the controller's `Reconcile` loop.

Existing StatefulSets will receive a one-time "harmless" spec update on the first reconcile after upgrade (the hash covers the full spec). The SSet controller will retroactively stamp ownerRefs on all currently managed PVCs at that point.

Fixes #9020
Fixes #9601

## Changes

- Set `PersistentVolumeClaimRetentionPolicy.WhenDeleted` on ES StatefulSets based on `VolumeClaimDeletePolicy` (`Delete` for the default `DeleteOnScaledownAndClusterDeletion` policy, `Retain` for `DeleteOnScaledownOnly`); `WhenScaled` is always `Retain`.
- Exported `ReconcilePVCOwnerRefs` and moved its deletion-path call to before `finalizer.RemoveAll` so ownerRefs are stamped while legacy finalizers still protect the ES CR from GC.
- Added `Test_BuildStatefulSet_PVCRetentionPolicy` covering all three `VolumeClaimDeletePolicy` cases (DeleteOnScaledownAndClusterDeletion, DeleteOnScaledownOnly, and empty/default).
