### PR TITLE
Do not restart Pods that are being removed during a rolling upgrade

### DIFF
--- a/pkg/controller/elasticsearch/driver/stateful/esstate_test.go
+++ b/pkg/controller/elasticsearch/driver/stateful/esstate_test.go
@@ -6,6 +6,7 @@ package stateful
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -43,6 +44,7 @@ type fakeESClient struct { //nolint:maligned
 	GetClusterRoutingAllocationCallCount int
 
 	Shutdowns            map[string]esclient.NodeShutdown
+	PutShutdownCalls     []shutdownCall
 	DeleteShutdownCalled bool
 
 	health                      esclient.Health
@@ -102,7 +104,22 @@ func (f *fakeESClient) GetClusterHealthWaitForAllEvents(_ context.Context) (escl
 	return f.health, nil
 }
 
-func (f *fakeESClient) PutShutdown(_ context.Context, _ string, _ esclient.ShutdownType, _ string, _ *time.Duration) error {
+// shutdownCall is one PutShutdown call recorded by the fake.
+type shutdownCall struct {
+	NodeID string
+	Type   esclient.ShutdownType
+}
+
+func (f *fakeESClient) PutShutdown(_ context.Context, nodeID string, shutdownType esclient.ShutdownType, _ string, _ *time.Duration) error {
+	f.PutShutdownCalls = append(f.PutShutdownCalls, shutdownCall{NodeID: nodeID, Type: shutdownType})
+	// NodeShutdown.ReconcileShutdowns reads the record back right after the PUT, so one is created for the node if there
+	// is none yet; tests that need a specific status seed it in Shutdowns
+	if _, exists := f.Shutdowns[nodeID]; !exists {
+		if f.Shutdowns == nil {
+			f.Shutdowns = make(map[string]esclient.NodeShutdown)
+		}
+		f.Shutdowns[nodeID] = esclient.NodeShutdown{NodeID: nodeID, Type: strings.ToUpper(string(shutdownType)), Status: esclient.ShutdownComplete}
+	}
 	return nil
 }
 
@@ -117,8 +134,9 @@ func (f *fakeESClient) GetShutdown(_ context.Context, nodeID *string) (esclient.
 	return esclient.ShutdownResponse{Nodes: ns}, nil
 }
 
-func (f *fakeESClient) DeleteShutdown(_ context.Context, _ string) error {
+func (f *fakeESClient) DeleteShutdown(_ context.Context, nodeID string) error {
 	f.DeleteShutdownCalled = true
+	delete(f.Shutdowns, nodeID)
 	return nil
 }
 

--- a/pkg/controller/elasticsearch/driver/stateful/nodes.go
+++ b/pkg/controller/elasticsearch/driver/stateful/nodes.go
@@ -221,7 +221,7 @@ func (d *Driver) reconcileNodeSpecs(
 		return results
 	}
 
-	isNodeSpecsReconciled := d.isNodeSpecsReconciled(ctx, actualStatefulSets, d.Client, results)
+	isNodeSpecsReconciled := d.isNodeSpecsReconciled(ctx, expectedResources.StatefulSets(), actualStatefulSets, d.Client, results)
 	// as of 7.15.2 with node shutdown we do not need transient settings anymore and in fact want to remove any left-overs.
 	if esReachable && isNodeSpecsReconciled {
 		if err := d.maybeRemoveTransientSettings(ctx, esClient); err != nil {
@@ -252,7 +252,7 @@ func (d *Driver) reconcileNodeSpecs(
 	return results
 }
 
-func (d *Driver) isNodeSpecsReconciled(ctx context.Context, actualStatefulSets es_sset.StatefulSetList, client k8s.Client, result *reconciler.Results) bool {
+func (d *Driver) isNodeSpecsReconciled(ctx context.Context, expectedStatefulSets es_sset.StatefulSetList, actualStatefulSets es_sset.StatefulSetList, client k8s.Client, result *reconciler.Results) bool {
 	if isReconciled, _ := result.IsReconciled(); !isReconciled {
 		return false
 	}
@@ -261,7 +261,7 @@ func (d *Driver) isNodeSpecsReconciled(ctx context.Context, actualStatefulSets e
 	}
 
 	// all pods should have been upgraded
-	pods, err := podsToUpgrade(client, actualStatefulSets)
+	pods, err := podsToRollingUpgrade(ctx, client, expectedStatefulSets, actualStatefulSets)
 	if err != nil {
 		return false
 	}

--- a/pkg/controller/elasticsearch/driver/stateful/upgrade.go
+++ b/pkg/controller/elasticsearch/driver/stateful/upgrade.go
@@ -28,6 +28,7 @@ import (
 	es_sset "github.com/elastic/cloud-on-k8s/v3/pkg/controller/elasticsearch/sset"
 	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/k8s"
 	ulog "github.com/elastic/cloud-on-k8s/v3/pkg/utils/log"
+	"github.com/elastic/cloud-on-k8s/v3/pkg/utils/set"
 )
 
 func (d *Driver) handleUpgrades(
@@ -56,7 +57,7 @@ func (d *Driver) handleUpgrades(
 	if err != nil {
 		return results.WithError(err)
 	}
-	podsToUpgrade, err := podsToUpgrade(d.Client, statefulSets)
+	rollingUpgradeCandidates, err := podsToRollingUpgrade(ctx, d.Client, expectedResources.StatefulSets(), statefulSets)
 	if err != nil {
 		return results.WithError(err)
 	}
@@ -66,7 +67,7 @@ func (d *Driver) handleUpgrades(
 		return results.WithError(err)
 	}
 
-	isTriggeredRestart := isAnnotationTriggeredRestart(d.ES, expectedResources, podsToUpgrade)
+	isTriggeredRestart := isAnnotationTriggeredRestart(d.ES, expectedResources, rollingUpgradeCandidates)
 
 	nodeNameToID, err := esState.NodeNameToID()
 	if err != nil {
@@ -99,7 +100,7 @@ func (d *Driver) handleUpgrades(
 		esState,
 		nodeShutdown,
 		expectedMasters,
-		podsToUpgrade,
+		rollingUpgradeCandidates,
 		healthyPods,
 		currentPods,
 		isTriggeredRestart,
@@ -126,7 +127,7 @@ func (d *Driver) handleUpgrades(
 		// Some Pods have just been deleted, we don't need to try to enable shards allocation.
 		return results.WithReconciliationState(shared.DefaultRequeue.WithReason("Nodes upgrade in progress"))
 	}
-	if len(podsToUpgrade) > len(deletedPods) {
+	if len(rollingUpgradeCandidates) > len(deletedPods) {
 		// Some Pods have not been updated, ensure that we retry later
 		results.WithReconciliationState(shared.DefaultRequeue.WithReason("Nodes upgrade in progress"))
 	}
@@ -254,6 +255,34 @@ func healthyPods(
 		}
 	}
 	return healthyPods, nil
+}
+
+// podsToRollingUpgrade returns the Pods that podsToUpgrade reports, minus the ones the downscale wants to remove: Pods
+// of a StatefulSet that is not expected anymore, and Pods whose ordinal is at or above the expected number of replicas.
+// Deleting such a Pod for a rolling upgrade disrupts the remove-type shutdown that is migrating its shards away (its
+// record may even be replaced by a restart-type one): the removal has to be requested again once the Pod is back, and
+// shards with no other copy stay unavailable if it does not come back.
+func podsToRollingUpgrade(
+	ctx context.Context,
+	client k8s.Client,
+	expectedStatefulSets es_sset.StatefulSetList,
+	actualStatefulSets es_sset.StatefulSetList,
+) ([]corev1.Pod, error) {
+	toUpgrade, err := podsToUpgrade(client, actualStatefulSets)
+	if err != nil {
+		return nil, err
+	}
+	// the downscale state only matters to the budget filter, which is not applied here: this is the whole set of Pods
+	// the downscale wants to remove, not the ones it is allowed to remove now
+	downscales, _ := calculateDownscales(ctx, downscaleState{}, expectedStatefulSets, actualStatefulSets, noDownscaleFilter)
+	leaving := set.Make(leavingNodeNames(downscales)...)
+	staying := make([]corev1.Pod, 0, len(toUpgrade))
+	for _, pod := range toUpgrade {
+		if !leaving.Has(pod.Name) {
+			staying = append(staying, pod)
+		}
+	}
+	return staying, nil
 }
 
 // podsToUpgrade returns all Pods of all StatefulSets where the controller-revision-hash label compared to the sset's

--- a/pkg/controller/elasticsearch/driver/stateful/upgrade_test.go
+++ b/pkg/controller/elasticsearch/driver/stateful/upgrade_test.go
@@ -151,6 +151,199 @@ func Test_podsToUpgrade(t *testing.T) {
 	}
 }
 
+func Test_podsToRollingUpgrade(t *testing.T) {
+	type args struct {
+		pods                 []client.Object
+		statefulSets         es_sset.StatefulSetList
+		expectedStatefulSets es_sset.StatefulSetList
+	}
+	outdated := appsv1.StatefulSetStatus{CurrentRevision: "rev-a", UpdateRevision: "rev-b", UpdatedReplicas: 0, Replicas: 2}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "no StatefulSet is being removed: same as podsToUpgrade",
+			args: args{
+				statefulSets: es_sset.StatefulSetList{
+					sset.TestSset{Name: "data", Namespace: TestEsNamespace, Replicas: 2, Status: outdated}.Build(),
+				},
+				expectedStatefulSets: es_sset.StatefulSetList{
+					sset.TestSset{Name: "data", Namespace: TestEsNamespace, Replicas: 2}.Build(),
+				},
+				pods: []client.Object{
+					podWithRevision("data-0", "rev-a"),
+					podWithRevision("data-1", "rev-a"),
+				},
+			},
+			want: []string{"data-0", "data-1"},
+		},
+		{
+			name: "pods of a StatefulSet that is not expected anymore are not upgraded",
+			args: args{
+				statefulSets: es_sset.StatefulSetList{
+					sset.TestSset{Name: "data", Namespace: TestEsNamespace, Replicas: 2, Status: outdated}.Build(),
+					sset.TestSset{Name: "data-new", Namespace: TestEsNamespace, Replicas: 2, Status: outdated}.Build(),
+				},
+				expectedStatefulSets: es_sset.StatefulSetList{
+					sset.TestSset{Name: "data-new", Namespace: TestEsNamespace, Replicas: 2}.Build(),
+				},
+				pods: []client.Object{
+					podWithRevision("data-0", "rev-a"),
+					podWithRevision("data-1", "rev-a"),
+					podWithRevision("data-new-0", "rev-a"),
+					podWithRevision("data-new-1", "rev-a"),
+				},
+			},
+			want: []string{"data-new-0", "data-new-1"},
+		},
+		{
+			name: "pods whose ordinal is at or above the expected number of replicas are not upgraded",
+			args: args{
+				statefulSets: es_sset.StatefulSetList{
+					sset.TestSset{Name: "data", Namespace: TestEsNamespace, Replicas: 2, Status: outdated}.Build(),
+				},
+				expectedStatefulSets: es_sset.StatefulSetList{
+					sset.TestSset{Name: "data", Namespace: TestEsNamespace, Replicas: 1}.Build(),
+				},
+				pods: []client.Object{
+					podWithRevision("data-0", "rev-a"),
+					podWithRevision("data-1", "rev-a"),
+				},
+			},
+			want: []string{"data-0"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := k8s.NewFakeClient(tt.args.pods...)
+			got, err := podsToRollingUpgrade(context.Background(), client, tt.args.expectedStatefulSets, tt.args.statefulSets)
+			require.NoError(t, err)
+			assert.ElementsMatch(t, names(got), tt.want, tt.name)
+		})
+	}
+}
+
+// Test_Driver_handleUpgrades_leavingPodsAreNotRestarted drives handleUpgrades with a nodeSet that has been removed from the
+// spec while a rolling upgrade was still pending on it: its Pod must be left to the downscale, while the outdated Pod of a
+// nodeSet that stays is still upgraded. Each case has exactly one outdated Pod so that the outcome does not depend on the
+// order in which candidates are considered.
+func Test_Driver_handleUpgrades_leavingPodsAreNotRestarted(t *testing.T) {
+	esVersion := "8.1.0"
+	es := esv1.Elasticsearch{
+		ObjectMeta: metav1.ObjectMeta{Name: TestEsName, Namespace: TestEsNamespace},
+		Spec:       esv1.ElasticsearchSpec{Version: esVersion},
+		Status:     esv1.ElasticsearchStatus{Version: esVersion},
+	}
+	outdated := appsv1.StatefulSetStatus{CurrentRevision: "rev-a", UpdateRevision: "rev-b", UpdatedReplicas: 0, Replicas: 1}
+	upToDate := appsv1.StatefulSetStatus{CurrentRevision: "rev-b", UpdateRevision: "rev-b", UpdatedReplicas: 1, Replicas: 1}
+	statefulSet := func(name string, status appsv1.StatefulSetStatus) appsv1.StatefulSet {
+		return sset.TestSset{Name: name, Namespace: TestEsNamespace, ClusterName: TestEsName, Version: esVersion, Replicas: 1, Data: true, Status: status}.Build()
+	}
+	pod := func(ssetName, revision string) corev1.Pod {
+		return sset.TestPod{Name: ssetName + "-0", Namespace: TestEsNamespace, ClusterName: TestEsName, StatefulSetName: ssetName, Version: esVersion, Revision: revision, Data: true, Ready: true}.Build()
+	}
+	tests := []struct {
+		name              string
+		leaving           appsv1.StatefulSetStatus // status of "data", which is absent from the expected StatefulSets
+		staying           appsv1.StatefulSetStatus // status of "data-new", which is expected
+		wantShutdowns     []shutdownCall           // shutdowns requested, by node ID and type
+		wantRemainingPods []string                 // Pods that have not been deleted for an upgrade
+	}{
+		{
+			name:              "only the leaving Pod is outdated: nothing is restarted",
+			leaving:           outdated,
+			staying:           upToDate,
+			wantShutdowns:     nil,
+			wantRemainingPods: []string{"data-0", "data-new-0"},
+		},
+		{
+			name:              "only the staying Pod is outdated: it is restarted",
+			leaving:           upToDate,
+			staying:           outdated,
+			wantShutdowns:     []shutdownCall{{NodeID: "id-data-new-0", Type: esclient.Restart}},
+			wantRemainingPods: []string{"data-0"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			leavingSset, stayingSset := statefulSet("data", tt.leaving), statefulSet("data-new", tt.staying)
+			leavingPod, stayingPod := pod("data", tt.leaving.CurrentRevision), pod("data-new", tt.staying.CurrentRevision)
+			k8sClient := k8s.NewFakeClient(&es, &leavingSset, &stayingSset, &leavingPod, &stayingPod)
+			esClient := &fakeESClient{
+				version: version.MustParse(esVersion),
+				nodes:   esclient.Nodes{Nodes: map[string]esclient.Node{"id-data-0": {Name: "data-0"}, "id-data-new-0": {Name: "data-new-0"}}},
+				health:  esclient.Health{Status: esv1.ElasticsearchGreenHealth},
+			}
+			d := &Driver{BaseDriver: driver.BaseDriver{Parameters: driver.Parameters{
+				Client:         k8sClient,
+				ES:             es,
+				Expectations:   expectations.NewExpectations(k8sClient, &appsv1.StatefulSet{}),
+				ReconcileState: reconcile.MustNewState(es),
+			}}}
+			// the spec only has data-new left: data is being removed
+			expectedResources := nodespec.ResourcesList{{StatefulSet: stayingSset}}
+
+			results := d.handleUpgrades(context.Background(), esClient, NewMemoizingESState(context.Background(), esClient), expectedResources)
+
+			_, err := results.Aggregate()
+			require.NoError(t, err)
+			assert.ElementsMatch(t, tt.wantShutdowns, esClient.PutShutdownCalls)
+			var pods corev1.PodList
+			require.NoError(t, k8sClient.List(context.Background(), &pods))
+			assert.ElementsMatch(t, tt.wantRemainingPods, names(pods.Items))
+		})
+	}
+}
+
+// Test_Driver_handleUpgrades_leavingPodsSurviveFullClusterRestart covers the other deletion branch of handleUpgrades: a
+// version upgrade of a non-HA cluster restarts all outdated Pods at once, without predicates. A Pod of a nodeSet that
+// is being removed must not be part of that restart either.
+func Test_Driver_handleUpgrades_leavingPodsSurviveFullClusterRestart(t *testing.T) {
+	fromVersion, toVersion := "8.1.0", "8.2.0"
+	es := esv1.Elasticsearch{
+		ObjectMeta: metav1.ObjectMeta{Name: TestEsName, Namespace: TestEsNamespace},
+		Spec:       esv1.ElasticsearchSpec{Version: toVersion},
+		Status:     esv1.ElasticsearchStatus{Version: fromVersion},
+	}
+	outdated := appsv1.StatefulSetStatus{CurrentRevision: "rev-a", UpdateRevision: "rev-b", UpdatedReplicas: 0, Replicas: 1}
+	// a single master makes the cluster non-HA; "gone" is absent from the expected StatefulSets
+	masterSset := sset.TestSset{Name: "master", Namespace: TestEsNamespace, ClusterName: TestEsName, Version: toVersion, Replicas: 1, Master: true, Data: true, Status: outdated}.Build()
+	leavingSset := sset.TestSset{Name: "gone", Namespace: TestEsNamespace, ClusterName: TestEsName, Version: toVersion, Replicas: 1, Data: true, Status: outdated}.Build()
+	masterPod := sset.TestPod{Name: "master-0", Namespace: TestEsNamespace, ClusterName: TestEsName, StatefulSetName: "master", Version: fromVersion, Revision: "rev-a", Master: true, Data: true, Ready: true}.Build()
+	leavingPod := sset.TestPod{Name: "gone-0", Namespace: TestEsNamespace, ClusterName: TestEsName, StatefulSetName: "gone", Version: fromVersion, Revision: "rev-a", Data: true, Ready: true}.Build()
+	k8sClient := k8s.NewFakeClient(&es, &masterSset, &leavingSset, &masterPod, &leavingPod)
+	esClient := &fakeESClient{
+		version: version.MustParse(fromVersion),
+		nodes:   esclient.Nodes{Nodes: map[string]esclient.Node{"id-master-0": {Name: "master-0"}, "id-gone-0": {Name: "gone-0"}}},
+		health:  esclient.Health{Status: esv1.ElasticsearchGreenHealth},
+	}
+	d := &Driver{BaseDriver: driver.BaseDriver{Parameters: driver.Parameters{
+		Client:         k8sClient,
+		ES:             es,
+		Expectations:   expectations.NewExpectations(k8sClient, &appsv1.StatefulSet{}),
+		ReconcileState: reconcile.MustNewState(es),
+	}}}
+	expectedResources := nodespec.ResourcesList{{StatefulSet: masterSset}}
+	// make sure the fixture really selects the full-restart branch
+	currentPods, err := es_sset.StatefulSetList{masterSset, leavingSset}.GetActualPods(k8sClient)
+	require.NoError(t, err)
+	isUpgrade, err := isVersionUpgrade(es)
+	require.NoError(t, err)
+	require.True(t, isUpgrade)
+	require.True(t, isNonHACluster(currentPods, expectedResources.MasterNodesNames()))
+
+	results := d.handleUpgrades(context.Background(), esClient, NewMemoizingESState(context.Background(), esClient), expectedResources)
+
+	_, err = results.Aggregate()
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []shutdownCall{{NodeID: "id-master-0", Type: esclient.Restart}}, esClient.PutShutdownCalls)
+	var pods corev1.PodList
+	require.NoError(t, k8sClient.List(context.Background(), &pods))
+	assert.ElementsMatch(t, []string{"gone-0"}, names(pods.Items))
+}
+
 func Test_healthyPods(t *testing.T) {
 	type args struct {
 		pods         upgradeTestPods


### PR DESCRIPTION
Fixes #9732.

## Implementation

This adds `podsToRollingUpgrade`, which starts with `podsToUpgrade` and removes the Pods that `calculateDownscales` reports as leaving the cluster (via `leavingNodeNames`).

The leaving set is calculated with `noDownscaleFilter`. This is intentional: a temporary downscale constraint — the change budget or the master-removal invariants — must not make a Pod eligible for upgrade when the desired spec says that Pod will be removed later.

The filtered list is now used by:

- `handleUpgrades`
- `isNodeSpecsReconciled`

The `podsToUpgrade` function itself remains unchanged so it can continue to represent all Pods with an outstanding revision change (the `upgradeCtx.podsToUpgrade` field now carries the filtered list).

`MaybeForceUpgrade` also remains on the unfiltered list. That path only fires when every Pod of a StatefulSet is Pending, or not ready and restarting, including while Elasticsearch is unreachable; filtering it would remove a recovery mechanism without addressing the reported case, which goes through the rolling-upgrade path.

The exclusion is implemented during candidate selection rather than as an upgrade predicate. Upgrade predicates can be disabled with the `eck.k8s.elastic.co/disable-upgrade-predicates` annotation, while a Pod scheduled for removal must never be handled by the rolling-upgrade path.

## Behavior changes

- Pods scheduled for removal are no longer restarted as part of a rolling upgrade (the forced-upgrade path above is unchanged).
- Those Pods no longer appear under `status.inProgressOperations.upgrade` as rolling-upgrade candidates; they remain represented by the downscale operation.
- Pod-template changes are not applied to the Pods that a NodeSet removal or scale-down is going to delete.
- `isNodeSpecsReconciled` and the `Nodes upgrade in progress` requeue driven by the candidate count no longer wait for leaving Pods.
- Upgrade predicates that reason about the whole candidate set (last-master, data-tier ordering) no longer count leaving Pods, so they no longer hold back the Pods that are staying.
- `isAnnotationTriggeredRestart` classifies against the filtered candidate list, so a leaving Pod with a stale config hash no longer masks an annotation-triggered restart.

## Tests

The added tests cover:

- A Pod whose StatefulSet is absent from the expected StatefulSet list.
- A Pod whose ordinal is at or above the desired NodeSet count.
- A Pod that is still desired and must remain an upgrade candidate.
- `handleUpgrades` not restarting leaving Pods, including assertions on shutdown node ID and type.
- The non-HA full-cluster-restart `DeleteAll` path leaving a removed NodeSet's Pod alone, with the fixture asserting that this branch is the one taken.

The fake Elasticsearch client now records `PutShutdown` calls and, for a node with no record yet, creates a `COMPLETE` one (removed again by `DeleteShutdown`), so the tests can verify both the target node and shutdown type.

Package tests, the full unit-test tree, race-enabled tests, `go vet`, and `golangci-lint` pass at the PR commit.